### PR TITLE
refactor(inference): share prefix-cache preparation

### DIFF
--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -14,8 +14,8 @@ use crate::attention::gdn_fused::{
 };
 use crate::forward::cpu::{elementwise_mul, silu_inplace};
 use crate::model::qwen35::{
-    ForwardScratch, KvCache, decode_tokens, qwen35_rms_norm, resize, sample_token,
-    should_stop_token,
+    ForwardScratch, GenerationEntryContract, GenerationPlan, GenerationPreparation, KvCache,
+    decode_tokens, prepare_generation, qwen35_rms_norm, resize, sample_token, should_stop_token,
 };
 use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config};
 use crate::rope::RopeTable;
@@ -892,79 +892,23 @@ pub fn generate_f16(
     prompt: &str,
     gen_cfg: &GenerateConfig,
 ) -> Result<GenerateOutput, crate::error::InferenceError> {
-    // Initialize RNG
-    let mut rng_state = match gen_cfg.seed {
-        Some(s) => {
-            if s == 0 {
-                1
-            } else {
-                s
-            }
-        }
-        None => {
-            use std::time::SystemTime;
-            let t = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .map(|d| d.as_nanos() as u64)
-                .unwrap_or(0x12345678_9abcdef0);
-            if t == 0 { 1 } else { t }
-        }
+    let plan = match prepare_generation(
+        tokenizer,
+        prompt,
+        gen_cfg,
+        cfg.vocab_size,
+        rope.max_positions(),
+        GenerationEntryContract::StandaloneCpu,
+    )? {
+        GenerationPreparation::Ready(plan) => plan,
+        GenerationPreparation::Complete(output) => return Ok(output),
     };
-
-    // Tokenize prompt
-    let input = tokenizer.tokenize(prompt);
-    let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
-    let prompt_len = prompt_ids.len();
-
-    // #856: single shared preflight, unified with the Metal paths (which
-    // used to accept an empty prompt and return an empty Ok) — see
-    // `check_prompt_not_empty` (model::qwen35::generation).
-    crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
-
-    crate::model::qwen35::check_prompt_ids_in_vocab(&prompt_ids, cfg.vocab_size)?;
-
-    // max_new_tokens == 0 means "generate nothing": return before sampling so
-    // we never emit a token the caller did not ask for. Mirrors the guard in
-    // Qwen35Model::generate (crates/inference/src/model/qwen35/generation.rs).
-    if gen_cfg.max_new_tokens == 0 {
-        return Ok(GenerateOutput {
-            text: String::new(),
-            token_ids: vec![],
-            prompt_tokens: prompt_len,
-            generated_tokens: 0,
-            stopped: false,
-            stop_reason: Some(StopReason::Length),
-            token_logprobs: vec![],
-        });
-    }
-
-    // Reject grammar configs before allocating any state. Grammar masking
-    // (`mask_logits` + `advance`) is not wired into this generate loop; without
-    // the guard the grammar field would be silently ignored, producing
-    // unconstrained output despite a grammar being set (#397/#398).
-    crate::model::qwen35::check_grammar_not_set(gen_cfg)?;
-    // Same rationale for logprobs capture, which is also not wired into this
-    // generate loop (#585).
-    crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
-    // Same rationale for stop_strings matching and reasoning-budget forcing,
-    // neither of which is wired into this generate loop (ADR-080 C3, #783).
-    crate::model::qwen35::check_stop_strings_not_set(gen_cfg)?;
-    crate::model::qwen35::check_reasoning_budget_not_set(gen_cfg)?;
-
-    // Context preflight. The RoPE cos/sin tables are indexed unchecked in
-    // forward_step_f16 (`rope.cos_at(base + i)`), so a position at or past the
-    // table capacity is an out-of-bounds slice access — a release panic, not a
-    // clean error. Mirror Qwen35Model::generate's total-token policy
-    // (prompt_len + max_new_tokens <= max_context) so direct and HTTP generation
-    // agree on when a request is too long.
-    let max_context = rope.max_positions();
-    if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
-        return Err(crate::error::InferenceError::Inference(format!(
-            "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
-             model context window ({max_context})",
-            gen_cfg.max_new_tokens
-        )));
-    }
+    let GenerationPlan {
+        mut rng_state,
+        prompt_ids,
+        prompt_len,
+        ..
+    } = plan;
 
     // Initialize states
     let num_linear = cfg.num_linear_attention_layers();
@@ -2601,8 +2545,8 @@ mod tests {
     /// are sufficient (mirrors `generate_f16_rejects_grammar_config_before_sampling`
     /// below).
     ///
-    /// Mutation sensitivity: reverting the `check_prompt_not_empty` call at
-    /// this call site makes the function proceed past the guard with a
+    /// Mutation sensitivity: bypassing the shared preparation at this entry
+    /// point makes the function proceed past the guard with a
     /// zero-length prompt, either panicking in the prefill/decode loop
     /// (`all_ids.last()` on an empty vec) or producing a non-`Inference`
     /// error — this assert fails either way.

--- a/crates/inference/src/forward/cpu_q8.rs
+++ b/crates/inference/src/forward/cpu_q8.rs
@@ -16,14 +16,13 @@ use crate::attention::gdn_fused::{
 use crate::forward::cpu::{elementwise_mul, matmul_bt, silu_inplace};
 use crate::model::qwen35::Qwen35Model;
 use crate::model::qwen35::{
-    ForwardScratch, KvCache, decode_tokens, qwen35_rms_norm, resize, sample_token,
-    should_stop_token,
+    ForwardScratch, GenerationEntryContract, GenerationPlan, GenerationPreparation, KvCache,
+    decode_tokens, prepare_generation, qwen35_rms_norm, resize, sample_token, should_stop_token,
 };
 use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config};
 use crate::rope::RopeTable;
 use crate::stop_reason::StopReason;
 use crate::tokenizer::bpe::BpeTokenizer;
-use crate::tokenizer::common::Tokenizer;
 use crate::weights::q8_weights::{
     Q8AttentionWeights, Q8CommonLayerWeights, Q8FullAttentionLayerWeights, Q8GatedDeltaNetWeights,
     Q8ModelWeights, matmul_bt_q8,
@@ -691,77 +690,23 @@ pub fn generate_q8(
     prompt: &str,
     gen_cfg: &GenerateConfig,
 ) -> Result<GenerateOutput, crate::error::InferenceError> {
-    // Initialize RNG
-    let mut rng_state = match gen_cfg.seed {
-        Some(s) => {
-            if s == 0 {
-                1
-            } else {
-                s
-            }
-        }
-        None => {
-            use std::time::SystemTime;
-            let t = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .map(|d| d.as_nanos() as u64)
-                .unwrap_or(0x12345678_9abcdef0);
-            if t == 0 { 1 } else { t }
-        }
+    let plan = match prepare_generation(
+        tokenizer,
+        prompt,
+        gen_cfg,
+        cfg.vocab_size,
+        rope.max_positions(),
+        GenerationEntryContract::StandaloneCpu,
+    )? {
+        GenerationPreparation::Ready(plan) => plan,
+        GenerationPreparation::Complete(output) => return Ok(output),
     };
-
-    // Tokenize prompt
-    let input = tokenizer.tokenize(prompt);
-    let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
-    let prompt_len = prompt_ids.len();
-
-    // #856: single shared preflight, unified with the Metal paths (which
-    // used to accept an empty prompt and return an empty Ok) — see
-    // `check_prompt_not_empty` (model::qwen35::generation).
-    crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
-    crate::model::qwen35::check_prompt_ids_in_vocab(&prompt_ids, cfg.vocab_size)?;
-
-    // max_new_tokens == 0 is a valid request: "score this prompt, return no tokens".
-    // Guard here so the decode loop (`for _ in 1..0`) never accidentally samples one
-    // token from the prefill logits before realising the budget is exhausted.
-    if gen_cfg.max_new_tokens == 0 {
-        return Ok(GenerateOutput {
-            text: String::new(),
-            token_ids: vec![],
-            prompt_tokens: prompt_len,
-            generated_tokens: 0,
-            stopped: false,
-            stop_reason: Some(StopReason::Length),
-            token_logprobs: vec![],
-        });
-    }
-    // Reject grammar configs before allocating any state. Grammar masking
-    // (`mask_logits` + `advance`) is not wired into this generate loop; without
-    // the guard the grammar field would be silently ignored, producing
-    // unconstrained output despite a grammar being set (#397/#398).
-    crate::model::qwen35::check_grammar_not_set(gen_cfg)?;
-    // Same rationale for logprobs capture, which is also not wired into this
-    // generate loop (#585).
-    crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
-    // Same rationale for stop_strings matching and reasoning-budget forcing,
-    // neither of which is wired into this generate loop (ADR-080 C3, #783).
-    crate::model::qwen35::check_stop_strings_not_set(gen_cfg)?;
-    crate::model::qwen35::check_reasoning_budget_not_set(gen_cfg)?;
-
-    // Context preflight. The RoPE cos/sin tables are indexed unchecked in
-    // full_attention_step_q8 (`rope.cos_at(position * half + i)`), so a position
-    // at or past the table capacity is an out-of-bounds slice access — a release
-    // panic, not a clean error. Mirror Qwen35Model::generate's total-token policy
-    // (prompt_len + max_new_tokens <= max_context) so direct and HTTP generation
-    // agree on when a request is too long.
-    let max_context = rope.max_positions();
-    if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
-        return Err(crate::error::InferenceError::Inference(format!(
-            "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
-             model context window ({max_context})",
-            gen_cfg.max_new_tokens
-        )));
-    }
+    let GenerationPlan {
+        mut rng_state,
+        prompt_ids,
+        prompt_len,
+        ..
+    } = plan;
 
     // Initialize states
     let num_linear = cfg.num_linear_attention_layers();
@@ -1571,8 +1516,8 @@ mod tests {
     /// Metal paths, which used to silently accept an empty prompt and
     /// return an empty `Ok`. See docs/generation-entrypoint-matrix.md row 2.
     ///
-    /// Mutation sensitivity: reverting the `check_prompt_not_empty` call at
-    /// this call site makes the function proceed past the guard with a
+    /// Mutation sensitivity: bypassing the shared preparation at this entry
+    /// point makes the function proceed past the guard with a
     /// zero-length prompt, either panicking in the prefill/decode loop or
     /// producing a non-`Inference` error — this assert fails either way.
     #[test]
@@ -1611,8 +1556,8 @@ mod tests {
     /// larger than the supplied model config. The boundary ID `vocab_size`
     /// must be rejected before `forward_step_q8` slices the embedding table.
     ///
-    /// Mutation sensitivity: removing only the Q8 call to
-    /// `check_prompt_ids_in_vocab` lets this request reach the unchecked
+    /// Mutation sensitivity: removing the shared setup's
+    /// `check_prompt_ids_in_vocab` call lets this request reach the unchecked
     /// embedding slice and panic instead of returning `InvalidInput`.
     #[test]
     fn generate_q8_rejects_out_of_vocab_prompt_id() {

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -1925,6 +1925,95 @@ mod inner {
         }
     }
 
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum SamplingLogprobsGate {
+        NotRequired,
+        RequireAbsent,
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct SamplingRouteEnvironment {
+        compact: bool,
+        selection: bool,
+        approximate_top_p: bool,
+    }
+
+    impl SamplingRouteEnvironment {
+        fn current() -> Self {
+            Self {
+                compact: std::env::var("LATTICE_COMPACT_TOPK").is_ok(),
+                selection: std::env::var("LATTICE_COMPACT_TOPK_SELECT").is_ok(),
+                approximate_top_p: std::env::var("LATTICE_COMPACT_TOPP_APPROX").is_ok(),
+            }
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct SamplingRoutePlan {
+        use_compact: bool,
+        compact_route: GpuTopkRoute,
+        compact_topk: usize,
+    }
+
+    fn plan_sampling_route(
+        gen_cfg: &GenerateConfig,
+        history_is_empty: bool,
+        logprobs_gate: SamplingLogprobsGate,
+        environment: SamplingRouteEnvironment,
+    ) -> SamplingRoutePlan {
+        let block_route = choose_gpu_block_topk_route(
+            gen_cfg.top_k,
+            gen_cfg.top_p,
+            environment.compact,
+            environment.approximate_top_p,
+        );
+        let route = if block_route != GpuTopkRoute::CpuFallback {
+            block_route
+        } else {
+            choose_gpu_topk_route(gen_cfg.top_k, environment.compact, environment.selection)
+        };
+        let logprobs_eligible = match logprobs_gate {
+            SamplingLogprobsGate::NotRequired => true,
+            SamplingLogprobsGate::RequireAbsent => gen_cfg.logprobs.is_none(),
+        };
+        let use_compact = route != GpuTopkRoute::CpuFallback
+            && (gen_cfg.repetition_penalty == 1.0 || history_is_empty)
+            && gen_cfg.grammar.is_none()
+            && logprobs_eligible;
+
+        if use_compact {
+            SamplingRoutePlan {
+                use_compact,
+                compact_route: route,
+                compact_topk: match route {
+                    GpuTopkRoute::BlockArgmax => 1,
+                    GpuTopkRoute::BlockTopK { local_k } => local_k as usize,
+                    _ => gen_cfg.top_k,
+                },
+            }
+        } else {
+            SamplingRoutePlan {
+                use_compact,
+                compact_route: GpuTopkRoute::CpuFallback,
+                compact_topk: 0,
+            }
+        }
+    }
+
+    fn apply_sampling_route_plan(
+        plan: SamplingRoutePlan,
+        compact_route: &mut GpuTopkRoute,
+        compact_topk: &mut usize,
+        compact_result: &mut Vec<crate::sampling::Candidate>,
+    ) -> bool {
+        *compact_route = plan.compact_route;
+        *compact_topk = plan.compact_topk;
+        if !plan.use_compact {
+            compact_result.clear();
+        }
+        plan.use_compact
+    }
+
     /// Resolves a `compact_route` to `(local_k, precompiled Stage-1 pipeline
     /// slot)`, or `None` if the route isn't a block-top-k route at all
     /// (`Argmax`/`Select64`/`HierarchicalK50`/`CpuFallback`) **or** if
@@ -8823,6 +8912,26 @@ mod inner {
             Ok(GenerateAdmission::Ready(prompt_ids))
         }
 
+        fn configure_sampling_route(
+            &mut self,
+            gen_cfg: &GenerateConfig,
+            history_is_empty: bool,
+            logprobs_gate: SamplingLogprobsGate,
+        ) -> bool {
+            let plan = plan_sampling_route(
+                gen_cfg,
+                history_is_empty,
+                logprobs_gate,
+                SamplingRouteEnvironment::current(),
+            );
+            apply_sampling_route_plan(
+                plan,
+                &mut self.session.compact_route,
+                &mut self.session.compact_topk,
+                &mut self.session.compact_result,
+            )
+        }
+
         /// **Unstable**: generate text from a prompt; sampling parameters and output format may change.
         ///
         /// Generate text from a prompt.
@@ -8875,44 +8984,11 @@ mod inner {
             let mut generated_ids: Vec<u32> = Vec::with_capacity(gen_cfg.max_new_tokens);
             let mut all_ids = prompt_ids.clone();
 
-            // Issue #171: try the block-top-k route first — far fewer threadgroups
-            // than the legacy HierarchicalK50/argmax routes, which stay reachable
-            // as a fallback for k values the block kernels don't cover.
-            let block_route = choose_gpu_block_topk_route(
-                gen_cfg.top_k,
-                gen_cfg.top_p,
-                std::env::var("LATTICE_COMPACT_TOPK").is_ok(),
-                std::env::var("LATTICE_COMPACT_TOPP_APPROX").is_ok(),
+            let use_compact = self.configure_sampling_route(
+                gen_cfg,
+                all_ids.is_empty(),
+                SamplingLogprobsGate::NotRequired,
             );
-            let route = if block_route != GpuTopkRoute::CpuFallback {
-                block_route
-            } else {
-                choose_gpu_topk_route(
-                    gen_cfg.top_k,
-                    std::env::var("LATTICE_COMPACT_TOPK").is_ok(),
-                    std::env::var("LATTICE_COMPACT_TOPK_SELECT").is_ok(),
-                )
-            };
-            // Repetition penalty requires full logits — disable compact mode when active.
-            // Grammar-constrained decoding also requires full logits (CpuFallback).
-            let use_compact = route != GpuTopkRoute::CpuFallback
-                && (gen_cfg.repetition_penalty == 1.0 || all_ids.is_empty())
-                && gen_cfg.grammar.is_none();
-            if use_compact {
-                self.session.compact_route = route;
-                self.session.compact_topk = match route {
-                    GpuTopkRoute::BlockArgmax => 1,
-                    GpuTopkRoute::BlockTopK { local_k } => local_k as usize,
-                    _ => gen_cfg.top_k,
-                };
-            } else {
-                // Issue #171: clear any compact request
-                // left over from a prior compact-eligible generation on this same
-                // state so the exact full-logit path isn't starved by stale state.
-                self.session.compact_route = GpuTopkRoute::CpuFallback;
-                self.session.compact_topk = 0;
-                self.session.compact_result.clear();
-            }
 
             // Initialise grammar state for grammar-constrained decoding (ADR-046).
             let mut grammar_state = gen_cfg.grammar.as_ref().map(|g| g.initial_state());
@@ -13868,43 +13944,11 @@ mod inner {
             // default (no logprobs requested) path pays no extra cost.
             let mut token_logprobs: Vec<TokenLogprob> = Vec::new();
 
-            // Issue #171: try the block-top-k route first — far fewer threadgroups
-            // than the legacy HierarchicalK50/argmax routes, which stay reachable
-            // as a fallback for k values the block kernels don't cover.
-            let block_route = choose_gpu_block_topk_route(
-                gen_cfg.top_k,
-                gen_cfg.top_p,
-                std::env::var("LATTICE_COMPACT_TOPK").is_ok(),
-                std::env::var("LATTICE_COMPACT_TOPP_APPROX").is_ok(),
+            let use_compact = self.configure_sampling_route(
+                gen_cfg,
+                all_ids.is_empty(),
+                SamplingLogprobsGate::RequireAbsent,
             );
-            let route = if block_route != GpuTopkRoute::CpuFallback {
-                block_route
-            } else {
-                choose_gpu_topk_route(
-                    gen_cfg.top_k,
-                    std::env::var("LATTICE_COMPACT_TOPK").is_ok(),
-                    std::env::var("LATTICE_COMPACT_TOPK_SELECT").is_ok(),
-                )
-            };
-            let use_compact = route != GpuTopkRoute::CpuFallback
-                && (gen_cfg.repetition_penalty == 1.0 || all_ids.is_empty())
-                && gen_cfg.grammar.is_none()
-                && gen_cfg.logprobs.is_none();
-            if use_compact {
-                self.session.compact_route = route;
-                self.session.compact_topk = match route {
-                    GpuTopkRoute::BlockArgmax => 1,
-                    GpuTopkRoute::BlockTopK { local_k } => local_k as usize,
-                    _ => gen_cfg.top_k,
-                };
-            } else {
-                // Issue #171: clear any compact request
-                // left over from a prior compact-eligible generation on this same
-                // state so the exact full-logit path isn't starved by stale state.
-                self.session.compact_route = GpuTopkRoute::CpuFallback;
-                self.session.compact_topk = 0;
-                self.session.compact_result.clear();
-            }
 
             // Initialise grammar state for grammar-constrained decoding (ADR-046).
             let mut grammar_state = gen_cfg.grammar.as_ref().map(|g| g.initial_state());
@@ -16885,43 +16929,11 @@ mod inner {
             let mut generated_ids: Vec<u32> = Vec::with_capacity(gen_cfg.max_new_tokens);
             let mut all_ids = prompt_ids.clone();
 
-            // Issue #171: try the block-top-k route first — far fewer threadgroups
-            // than the legacy HierarchicalK50/argmax routes, which stay reachable
-            // as a fallback for k values the block kernels don't cover.
-            let block_route = choose_gpu_block_topk_route(
-                gen_cfg.top_k,
-                gen_cfg.top_p,
-                std::env::var("LATTICE_COMPACT_TOPK").is_ok(),
-                std::env::var("LATTICE_COMPACT_TOPP_APPROX").is_ok(),
+            let use_compact = self.configure_sampling_route(
+                gen_cfg,
+                all_ids.is_empty(),
+                SamplingLogprobsGate::RequireAbsent,
             );
-            let route = if block_route != GpuTopkRoute::CpuFallback {
-                block_route
-            } else {
-                choose_gpu_topk_route(
-                    gen_cfg.top_k,
-                    std::env::var("LATTICE_COMPACT_TOPK").is_ok(),
-                    std::env::var("LATTICE_COMPACT_TOPK_SELECT").is_ok(),
-                )
-            };
-            let use_compact = route != GpuTopkRoute::CpuFallback
-                && (gen_cfg.repetition_penalty == 1.0 || all_ids.is_empty())
-                && gen_cfg.grammar.is_none()
-                && gen_cfg.logprobs.is_none();
-            if use_compact {
-                self.session.compact_route = route;
-                self.session.compact_topk = match route {
-                    GpuTopkRoute::BlockArgmax => 1,
-                    GpuTopkRoute::BlockTopK { local_k } => local_k as usize,
-                    _ => gen_cfg.top_k,
-                };
-            } else {
-                // Issue #171: clear any compact request
-                // left over from a prior compact-eligible generation on this same
-                // state so the exact full-logit path isn't starved by stale state.
-                self.session.compact_route = GpuTopkRoute::CpuFallback;
-                self.session.compact_topk = 0;
-                self.session.compact_result.clear();
-            }
 
             let mut grammar_state = gen_cfg.grammar.as_ref().map(|g| g.initial_state());
 
@@ -19357,7 +19369,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         // ── Route-logic unit tests (pure Rust, no Metal device needed) ────────
 
         #[test]
-        fn test_choose_gpu_topk_route_all_cases() {
+        fn sampling_route_legacy_helper_all_cases() {
             // k=0 → always CPU
             assert_eq!(
                 choose_gpu_topk_route(0, true, true),
@@ -19418,6 +19430,267 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 choose_gpu_topk_route(1000, true, true),
                 GpuTopkRoute::CpuFallback,
                 "k=1000"
+            );
+        }
+
+        #[test]
+        fn sampling_route_block_helper_gate() {
+            assert_eq!(
+                choose_gpu_block_topk_route(8, 0.9, true, false),
+                GpuTopkRoute::CpuFallback,
+                "top_p<1.0 without the approx gate must stay exact"
+            );
+            assert_eq!(
+                choose_gpu_block_topk_route(8, 0.9, true, true),
+                GpuTopkRoute::BlockTopK { local_k: 8 },
+                "top_p<1.0 WITH the explicit approx gate may take the block route"
+            );
+            assert_eq!(
+                choose_gpu_block_topk_route(0, 1.0, true, false),
+                GpuTopkRoute::CpuFallback,
+                "top_k=0 means top-k DISABLED (full-distribution sampling), \
+                 not greedy; BlockArgmax here would collapse sampling to top-1"
+            );
+            assert_eq!(
+                choose_gpu_block_topk_route(1, 1.0, true, false),
+                GpuTopkRoute::BlockArgmax
+            );
+            for &k in &[8u32, 16, 40, 64] {
+                assert_eq!(
+                    choose_gpu_block_topk_route(k as usize, 1.0, true, false),
+                    GpuTopkRoute::BlockTopK { local_k: k },
+                    "k={k} must map to BlockTopK"
+                );
+            }
+            assert_eq!(
+                choose_gpu_block_topk_route(50, 1.0, true, false),
+                GpuTopkRoute::CpuFallback,
+                "k=50 has no precompiled Stage-1 variant; must fall back exact"
+            );
+            assert_eq!(
+                choose_gpu_block_topk_route(8, 1.0, false, false),
+                GpuTopkRoute::CpuFallback,
+                "LATTICE_COMPACT_TOPK unset must stay exact regardless of k"
+            );
+        }
+
+        fn compact_sampling_config(top_k: usize) -> GenerateConfig {
+            GenerateConfig {
+                top_k,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                ..Default::default()
+            }
+        }
+
+        fn compact_sampling_environment() -> SamplingRouteEnvironment {
+            SamplingRouteEnvironment {
+                compact: true,
+                selection: true,
+                approximate_top_p: false,
+            }
+        }
+
+        #[test]
+        fn sampling_route_plan_composes_block_first_then_legacy_fallback() {
+            for (top_k, expected_route, expected_topk) in [
+                (1, GpuTopkRoute::BlockArgmax, 1),
+                (8, GpuTopkRoute::BlockTopK { local_k: 8 }, 8),
+                (16, GpuTopkRoute::BlockTopK { local_k: 16 }, 16),
+                (40, GpuTopkRoute::BlockTopK { local_k: 40 }, 40),
+                (64, GpuTopkRoute::BlockTopK { local_k: 64 }, 64),
+            ] {
+                let plan = plan_sampling_route(
+                    &compact_sampling_config(top_k),
+                    false,
+                    SamplingLogprobsGate::NotRequired,
+                    compact_sampling_environment(),
+                );
+                assert_eq!(
+                    plan,
+                    SamplingRoutePlan {
+                        use_compact: true,
+                        compact_route: expected_route,
+                        compact_topk: expected_topk,
+                    },
+                    "top_k={top_k}"
+                );
+            }
+
+            let legacy_plan = plan_sampling_route(
+                &compact_sampling_config(50),
+                false,
+                SamplingLogprobsGate::NotRequired,
+                compact_sampling_environment(),
+            );
+            assert_eq!(
+                legacy_plan,
+                SamplingRoutePlan {
+                    use_compact: true,
+                    compact_route: GpuTopkRoute::HierarchicalK50,
+                    compact_topk: 50,
+                }
+            );
+        }
+
+        #[test]
+        fn sampling_route_plan_preserves_direct_and_streaming_logprobs_difference() {
+            let config = GenerateConfig {
+                logprobs: Some(5),
+                ..compact_sampling_config(1)
+            };
+
+            let direct = plan_sampling_route(
+                &config,
+                false,
+                SamplingLogprobsGate::NotRequired,
+                compact_sampling_environment(),
+            );
+            assert!(
+                direct.use_compact,
+                "the direct call site's historical route gate ignores logprobs"
+            );
+            assert_eq!(direct.compact_route, GpuTopkRoute::BlockArgmax);
+            assert_eq!(direct.compact_topk, 1);
+
+            let streaming = plan_sampling_route(
+                &config,
+                false,
+                SamplingLogprobsGate::RequireAbsent,
+                compact_sampling_environment(),
+            );
+            assert_eq!(
+                streaming,
+                SamplingRoutePlan {
+                    use_compact: false,
+                    compact_route: GpuTopkRoute::CpuFallback,
+                    compact_topk: 0,
+                },
+                "streaming and prefix-cache generation require full logits for logprobs"
+            );
+        }
+
+        #[test]
+        fn sampling_route_plan_preserves_grammar_and_repetition_gates() {
+            let penalized = GenerateConfig {
+                repetition_penalty: 1.1,
+                ..compact_sampling_config(8)
+            };
+            assert!(
+                !plan_sampling_route(
+                    &penalized,
+                    false,
+                    SamplingLogprobsGate::NotRequired,
+                    compact_sampling_environment(),
+                )
+                .use_compact,
+                "non-empty history with a repetition penalty requires full logits"
+            );
+            assert!(
+                plan_sampling_route(
+                    &penalized,
+                    true,
+                    SamplingLogprobsGate::NotRequired,
+                    compact_sampling_environment(),
+                )
+                .use_compact,
+                "an empty history preserves the existing repetition-penalty exception"
+            );
+
+            use crate::grammar::{GrammarEngine, GrammarSpec};
+            let grammar = GrammarEngine::new(
+                &GrammarSpec::Gbnf("root ::= \"a\"\n".to_string()),
+                vec![b"a".to_vec()],
+            )
+            .expect("trivial grammar must compile");
+            let constrained = GenerateConfig {
+                grammar: Some(std::sync::Arc::new(grammar)),
+                ..compact_sampling_config(8)
+            };
+            assert!(
+                !plan_sampling_route(
+                    &constrained,
+                    false,
+                    SamplingLogprobsGate::NotRequired,
+                    compact_sampling_environment(),
+                )
+                .use_compact,
+                "grammar-constrained decoding requires full logits"
+            );
+        }
+
+        #[test]
+        fn sampling_route_state_transition_preserves_enabled_result_and_clears_fallback() {
+            let sentinel = crate::sampling::Candidate {
+                token_id: 17,
+                logit: 3.5,
+            };
+            let mut compact_route = GpuTopkRoute::CpuFallback;
+            let mut compact_topk = 0;
+            let mut compact_result = vec![sentinel];
+
+            let enabled = plan_sampling_route(
+                &compact_sampling_config(8),
+                false,
+                SamplingLogprobsGate::NotRequired,
+                compact_sampling_environment(),
+            );
+            assert!(apply_sampling_route_plan(
+                enabled,
+                &mut compact_route,
+                &mut compact_topk,
+                &mut compact_result,
+            ));
+            assert_eq!(compact_route, GpuTopkRoute::BlockTopK { local_k: 8 });
+            assert_eq!(compact_topk, 8);
+            assert_eq!(
+                compact_result,
+                vec![sentinel],
+                "eligible routing preserves the existing compact_result until prefill replaces it"
+            );
+
+            let disabled = plan_sampling_route(
+                &compact_sampling_config(8),
+                false,
+                SamplingLogprobsGate::NotRequired,
+                SamplingRouteEnvironment {
+                    compact: false,
+                    selection: true,
+                    approximate_top_p: true,
+                },
+            );
+            assert!(!apply_sampling_route_plan(
+                disabled,
+                &mut compact_route,
+                &mut compact_topk,
+                &mut compact_result,
+            ));
+            assert_eq!(compact_route, GpuTopkRoute::CpuFallback);
+            assert_eq!(compact_topk, 0);
+            assert!(
+                compact_result.is_empty(),
+                "fallback routing must clear stale compact candidates"
+            );
+        }
+
+        #[test]
+        fn sampling_route_configurator_owns_all_three_generation_call_sites() {
+            let source = include_str!("metal_qwen35.rs");
+            let production = source
+                .split_once("    // Tests\n")
+                .expect("inner test section marker must exist")
+                .0;
+            assert_eq!(
+                production.matches("self.configure_sampling_route(").count(),
+                3,
+                "direct, streaming, and prefix-cache generation must share the configurator"
+            );
+            assert_eq!(
+                production
+                    .matches("let block_route = choose_gpu_block_topk_route(")
+                    .count(),
+                1,
+                "route chooser composition must have one production owner"
             );
         }
 
@@ -25900,52 +26173,6 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         // the lm_head two-stage block-top-k path (issue #171).
         // ===================================================================
 
-        /// Pure unit test for the route gate (no GPU). Design-spec "Routing
-        /// Rules": top_p < 1.0 must stay on the exact full-logit path
-        /// (`CpuFallback`) unless the explicit approximate gate is set, since
-        /// nucleus sampling over a truncated candidate set is not equivalent
-        /// to full-vocab nucleus sampling.
-        #[test]
-        fn choose_gpu_block_topk_route_gate() {
-            assert_eq!(
-                choose_gpu_block_topk_route(8, 0.9, true, false),
-                GpuTopkRoute::CpuFallback,
-                "top_p<1.0 without the approx gate must stay exact"
-            );
-            assert_eq!(
-                choose_gpu_block_topk_route(8, 0.9, true, true),
-                GpuTopkRoute::BlockTopK { local_k: 8 },
-                "top_p<1.0 WITH the explicit approx gate may take the block route"
-            );
-            assert_eq!(
-                choose_gpu_block_topk_route(0, 1.0, true, false),
-                GpuTopkRoute::CpuFallback,
-                "top_k=0 means top-k DISABLED (full-distribution sampling), \
-                 not greedy; BlockArgmax here would collapse sampling to top-1"
-            );
-            assert_eq!(
-                choose_gpu_block_topk_route(1, 1.0, true, false),
-                GpuTopkRoute::BlockArgmax
-            );
-            for &k in &[8u32, 16, 40, 64] {
-                assert_eq!(
-                    choose_gpu_block_topk_route(k as usize, 1.0, true, false),
-                    GpuTopkRoute::BlockTopK { local_k: k },
-                    "k={k} must map to BlockTopK"
-                );
-            }
-            assert_eq!(
-                choose_gpu_block_topk_route(50, 1.0, true, false),
-                GpuTopkRoute::CpuFallback,
-                "k=50 has no precompiled Stage-1 variant; must fall back exact"
-            );
-            assert_eq!(
-                choose_gpu_block_topk_route(8, 1.0, false, false),
-                GpuTopkRoute::CpuFallback,
-                "LATTICE_COMPACT_TOPK unset must stay exact regardless of k"
-            );
-        }
-
         /// Same construction as `tiny_metal_qwen35_fixture` but with a
         /// caller-chosen vocab size and an all-zero embedding table (only
         /// component 0 of a token's embedding is ever set below — the same
@@ -26261,7 +26488,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// setting them directly here isolates this test to the
         /// `reset_state`/route-builder clearing bug rather than also
         /// depending on route *selection*, which already has its own
-        /// coverage in `choose_gpu_block_topk_route_gate`).
+        /// coverage in `sampling_route_block_helper_gate`).
         ///
         /// MUTATION-SENSITIVE: commenting out the `reset_state` compact-state
         /// clear (the `self.session.compact_topk = 0; self.session.compact_route

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -1065,7 +1065,10 @@ mod inner {
     };
     use crate::model::qwen35::detokenize::IncrementalDetokenizer;
     use crate::model::qwen35::stop_strings::StopStringMatcher;
-    use crate::model::qwen35::{AttentionWeights, ModelWeights};
+    use crate::model::qwen35::{
+        AttentionWeights, GenerationEntryContract, GenerationPlan, GenerationPreparation,
+        ModelWeights, prepare_generation,
+    };
     use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config, TokenLogprob};
     use crate::stop_reason::StopReason;
     use crate::tokenizer::bpe::BpeTokenizer;
@@ -2497,11 +2500,6 @@ mod inner {
         /// otherwise); read via `path_proof_snapshot` and zeroed via
         /// `reset_path_proof_counters`.
         pub(crate) path_proof: PathProofCounters,
-    }
-
-    enum GenerateAdmission {
-        Zero(GenerateOutput),
-        Ready(Vec<u32>),
     }
 
     // ---------------------------------------------------------------------------
@@ -4605,9 +4603,9 @@ mod inner {
                 ));
             }
 
-            match self.preflight_generate(prompt, tokenizer, gen_cfg)? {
-                GenerateAdmission::Zero(output) => return Ok(output),
-                GenerateAdmission::Ready(_) => {}
+            match self.prepare_direct_generation(prompt, tokenizer, gen_cfg)? {
+                GenerationPreparation::Complete(output) => return Ok(output),
+                GenerationPreparation::Ready(_) => {}
             }
 
             // Unload any previously loaded adapter so the slot is free.
@@ -8878,38 +8876,20 @@ mod inner {
             }
         }
 
-        fn preflight_generate(
+        fn prepare_direct_generation(
             &self,
             prompt: &str,
             tokenizer: &BpeTokenizer,
             gen_cfg: &GenerateConfig,
-        ) -> Result<GenerateAdmission, crate::error::InferenceError> {
-            let input = tokenizer.tokenize(prompt);
-            let prompt_ids = input.input_ids[..input.real_length].to_vec();
-            let prompt_len = prompt_ids.len();
-
-            crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
-            if gen_cfg.max_new_tokens == 0 {
-                return Ok(GenerateAdmission::Zero(GenerateOutput {
-                    text: String::new(),
-                    token_ids: vec![],
-                    prompt_tokens: prompt_len,
-                    generated_tokens: 0,
-                    stopped: false,
-                    stop_reason: Some(StopReason::Length),
-                    token_logprobs: vec![],
-                }));
-            }
-            crate::model::qwen35::check_reasoning_budget_not_set(gen_cfg)?;
-            crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
-            crate::model::qwen35::check_context_budget(
-                prompt_len,
-                gen_cfg.reasoning_budget,
-                gen_cfg.max_new_tokens,
+        ) -> Result<GenerationPreparation, crate::error::InferenceError> {
+            prepare_generation(
+                tokenizer,
+                prompt,
+                gen_cfg,
+                self.engine.config.vocab_size,
                 self.max_context(),
-            )?;
-
-            Ok(GenerateAdmission::Ready(prompt_ids))
+                GenerationEntryContract::MetalDirect,
+            )
         }
 
         fn configure_sampling_route(
@@ -8951,32 +8931,18 @@ mod inner {
         ) -> Result<GenerateOutput, crate::error::InferenceError> {
             use crate::error::InferenceError;
 
-            let prompt_ids = match self.preflight_generate(prompt, tokenizer, gen_cfg)? {
-                GenerateAdmission::Zero(output) => return Ok(output),
-                GenerateAdmission::Ready(prompt_ids) => prompt_ids,
+            let plan = match self.prepare_direct_generation(prompt, tokenizer, gen_cfg)? {
+                GenerationPreparation::Complete(output) => return Ok(output),
+                GenerationPreparation::Ready(plan) => plan,
             };
-            let prompt_len = prompt_ids.len();
+            let GenerationPlan {
+                mut rng_state,
+                prompt_ids,
+                prompt_len,
+                ..
+            } = plan;
 
             let cfg = self.engine.config.clone();
-
-            // Initialize RNG
-            let mut rng_state = match gen_cfg.seed {
-                Some(s) => {
-                    if s == 0 {
-                        1
-                    } else {
-                        s
-                    }
-                }
-                None => {
-                    use std::time::SystemTime;
-                    let t = SystemTime::now()
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .map(|d| d.as_nanos() as u64)
-                        .unwrap_or(0x12345678_9abcdef0);
-                    if t == 0 { 1 } else { t }
-                }
-            };
 
             // Reset state for new generation
             self.reset_state();
@@ -13876,64 +13842,25 @@ mod inner {
         {
             use crate::error::InferenceError;
 
-            let input = tokenizer.tokenize(prompt);
-            let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
-            let prompt_len = prompt_ids.len();
-
-            // Empty prompt is rejected with a typed Err on every generation
-            // entry point as of #856 (this covers both `generate_streaming`
-            // and `generate_streaming_with_cancel`, since the former is a
-            // thin `should_cancel = || false` wrapper over this function).
-            // This used to return an empty
-            // Ok(GenerateOutput { stopped: false, stop_reason: None, .. }),
-            // diverging from the CPU streaming guard and the `generate()`
-            // guard above, which both reject via this exact same shared
-            // guard. See docs/generation-entrypoint-matrix.md row 2. Runs
-            // before `reset_state()` below, so a rejected request never
-            // mutates session/cache state.
-            crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
-
-            // max_new_tokens == 0 means "generate nothing": return before prefill/sampling
-            // so we never emit a token the caller did not ask for, and on_token is never
-            // invoked. Mirrors the CPU generate_streaming() guard (model::qwen35::generation)
-            // and the generate() guard above.
-            if gen_cfg.max_new_tokens == 0 {
-                return Ok(GenerateOutput {
-                    text: String::new(),
-                    token_ids: vec![],
-                    prompt_tokens: prompt_len,
-                    generated_tokens: 0,
-                    stopped: false,
-                    stop_reason: Some(StopReason::Length),
-                    token_logprobs: vec![],
-                });
-            }
-
-            crate::model::qwen35::check_context_budget(
-                prompt_len,
-                gen_cfg.reasoning_budget,
-                gen_cfg.max_new_tokens,
+            let plan = match prepare_generation(
+                tokenizer,
+                prompt,
+                gen_cfg,
+                self.engine.config.vocab_size,
                 self.max_context(),
-            )?;
+                GenerationEntryContract::MetalStreaming,
+            )? {
+                GenerationPreparation::Complete(output) => return Ok(output),
+                GenerationPreparation::Ready(plan) => plan,
+            };
+            let GenerationPlan {
+                mut rng_state,
+                prompt_ids,
+                prompt_len,
+                ..
+            } = plan;
 
             let cfg = self.engine.config.clone();
-            let mut rng_state = match gen_cfg.seed {
-                Some(s) => {
-                    if s == 0 {
-                        1
-                    } else {
-                        s
-                    }
-                }
-                None => {
-                    use std::time::SystemTime;
-                    let t = SystemTime::now()
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .map(|d| d.as_nanos() as u64)
-                        .unwrap_or(0x12345678_9abcdef0);
-                    if t == 0 { 1 } else { t }
-                }
-            };
 
             self.reset_state();
             let mut generated_ids: Vec<u32> = Vec::with_capacity(gen_cfg.max_new_tokens);
@@ -30068,12 +29995,12 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// token is ever pushed into the output, matching the CPU `generate()`
         /// contract (model::qwen35::generation): zero tokens, `StopReason::Length`.
         ///
-        /// Mutation sensitivity: without the guard, `generate` samples the prefill
-        /// token from `prefill_logits` and pushes it into `generated_ids` before the
-        /// (empty, since `1..0` has no elements) decode loop runs, so
-        /// `generated_tokens` would be 1 instead of 0. `eos_token_id` is pushed out
-        /// of the reachable vocab range so this holds regardless of which token
-        /// greedy sampling picks at prefill.
+        /// Mutation sensitivity: treating the shared preparation's
+        /// `GenerationPreparation::Complete` as ready would let `generate` sample
+        /// the prefill token and push it into `generated_ids` before the empty
+        /// decode loop runs, so `generated_tokens` would be 1 instead of 0.
+        /// `eos_token_id` is pushed out of the reachable vocab range so this holds
+        /// regardless of which token greedy sampling picks at prefill.
         #[test]
         fn metal_generate_zero_budget_reports_length() {
             let Some(_) = metal::Device::system_default() else {
@@ -30127,16 +30054,12 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// stop_reason: None, .. })` it used to return. See
         /// docs/generation-entrypoint-matrix.md row 2.
         ///
-        /// This is the production-seam test for the guard added to `generate`
-        /// itself; `check_prompt_not_empty_rejects_zero` /
-        /// `_allows_nonzero` (model::qwen35::generation) already cover the
-        /// pure guard logic without a GPU device.
+        /// This is the production-seam test for `generate`'s shared preparation
+        /// call; the generation-setup tests cover the pure contract without a GPU.
         ///
-        /// Mutation sensitivity: reverting the `check_prompt_not_empty` call
-        /// in `generate` lets this request proceed through prefill and
-        /// sampling instead of erroring, so `result.is_err()` fails (and the
-        /// old `Ok` shape would additionally have `stop_reason: None`, the
-        /// invariant-violating result #856 fixes).
+        /// Mutation sensitivity: bypassing `prepare_direct_generation` in
+        /// `generate` lets this request proceed through prefill and sampling
+        /// instead of erroring, so `result.is_err()` fails.
         ///
         /// Honors
         /// `LATTICE_METAL_TEST_ENFORCE` like the prefix-cache empty-prompt
@@ -30187,14 +30110,13 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// `InvalidInput` error, rather than silently ignoring the budget and
         /// generating unbudgeted output (ADR-080 C3, #783).
         ///
-        /// This is the production-seam test for the guard added to `generate`
-        /// itself, proving the call site is real — `route_predicate_tests`
-        /// and `multimodal_preflight_tests` already cover the pure guard
-        /// logic without a GPU device.
+        /// This is the production-seam test for `generate`'s
+        /// `GenerationEntryContract::MetalDirect`, proving the caller selects
+        /// the fail-closed contract.
         ///
-        /// Mutation sensitivity: removing the `check_reasoning_budget_not_set`
-        /// call from `generate` lets this request proceed through prefill and
-        /// sampling instead of erroring, so `result.is_err()` fails.
+        /// Mutation sensitivity: selecting `MetalStreaming` instead lets this
+        /// request proceed through prefill and sampling instead of erroring, so
+        /// `result.is_err()` fails.
         #[test]
         fn metal_generate_plain_rejects_reasoning_budget_config() {
             let Some(_) = metal::Device::system_default() else {
@@ -30239,9 +30161,9 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// request around the MTP/self-spec predicates alone would not have
         /// closed this, since the plain fallback path is exactly as silent.
         ///
-        /// Mutation sensitivity: removing the `check_logprobs_not_set` call
-        /// from `generate` lets this request proceed through prefill and
-        /// sampling instead of erroring, so `result.is_err()` fails.
+        /// Mutation sensitivity: selecting `MetalStreaming` instead lets this
+        /// request proceed through prefill and sampling instead of erroring, so
+        /// `result.is_err()` fails.
         #[test]
         fn metal_generate_plain_rejects_logprobs_config() {
             let Some(_) = metal::Device::system_default() else {
@@ -30286,10 +30208,9 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// call site fixed by #856), so this one test covers both. See
         /// docs/generation-entrypoint-matrix.md row 2.
         ///
-        /// Mutation sensitivity: reverting the `check_prompt_not_empty` call
-        /// in `generate_streaming_with_cancel` lets this request proceed
-        /// through prefill and sampling instead of erroring, so
-        /// `result.is_err()` fails.
+        /// Mutation sensitivity: bypassing the shared `prepare_generation`
+        /// call in `generate_streaming_with_cancel` lets this request proceed
+        /// through prefill and sampling instead of erroring.
         ///
         /// Honors
         /// `LATTICE_METAL_TEST_ENFORCE` like the prefix-cache empty-prompt
@@ -30351,11 +30272,10 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// `generate_streaming()` contract (model::qwen35::generation): zero tokens,
         /// `StopReason::Length`, and `on_token` never invoked.
         ///
-        /// Mutation sensitivity: without the guard, `generate_streaming` samples the
-        /// prefill token, pushes it into `generated_ids`, and feeds its delta to
-        /// `on_token` before the (empty, since `decode_cap(None, 0) == 0` makes
-        /// `1..0` have no elements) decode loop runs, so `generated_tokens` would be
-        /// 1 and the callback would fire at least once instead of staying silent.
+        /// Mutation sensitivity: treating the shared preparation's
+        /// `GenerationPreparation::Complete` as ready would make streaming sample
+        /// and emit the prefill token before the empty decode loop runs, so
+        /// `generated_tokens` would be 1 and the callback would fire.
         #[test]
         fn metal_generate_streaming_zero_budget_reports_length() {
             let Some(_) = metal::Device::system_default() else {

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -16631,47 +16631,33 @@ mod inner {
             F: FnMut(&str, u32) -> bool,
             C: FnMut() -> bool,
         {
-            // Config preflight checks live here, in the public wrapper, and
-            // must return BEFORE the `match` below (PR #787): the
-            // error-recovery arm of that `match` unconditionally
-            // calls `reset_state()` and removes the cache slot on ANY `Err`
-            // from `_inner`, including a not-yet-attempted preflight
-            // rejection. A caller passing an unsupported config (e.g.
-            // `logprobs` or an active `enable_mtp`) never touches cache/session
-            // state in the first place, so routing that rejection through the
-            // destructive recovery path would evict a valid pre-existing
-            // cross-turn entry the call never mutated. Returning here, before
-            // `_inner` is even called, leaves any existing entry untouched.
-            crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
-            crate::model::qwen35::check_mtp_not_requested(gen_cfg)?;
-
-            let input = tokenizer.tokenize(prompt);
-            let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
-
-            // #856: empty prompt is rejected here too, same reasoning as the
-            // two preflights above (PR #787) -- `_inner` no longer special-
-            // cases an empty prompt as an early `Ok` (it now unifies on this
-            // exact typed `Err` like every other entry point, see
-            // `check_prompt_not_empty` and docs/generation-entrypoint-matrix.md
-            // row 2), so this must reject before `_inner` is even called, or
-            // the rejection would flow through the destructive `Err`-recovery
-            // match below and evict a valid pre-existing cross-turn entry
-            // this call never touched.
-            crate::model::qwen35::check_prompt_not_empty(prompt_ids.len())?;
-
-            if gen_cfg.max_new_tokens > 0 {
-                crate::model::qwen35::check_context_budget(
-                    prompt_ids.len(),
-                    gen_cfg.reasoning_budget,
-                    gen_cfg.max_new_tokens,
-                    self.max_context(),
-                )?;
-            }
+            let generation_plan = match prepare_generation(
+                tokenizer,
+                prompt,
+                gen_cfg,
+                self.engine.config.vocab_size,
+                self.max_context(),
+                GenerationEntryContract::MetalPrefixCache,
+            )? {
+                GenerationPreparation::Complete(output) => {
+                    return Ok(CachedGenerateOutput {
+                        cache: CrossTurnCacheStats {
+                            slot_id,
+                            prompt_tokens: output.prompt_tokens,
+                            reused_tokens: 0,
+                            prefetched_tokens: 0,
+                            mode: crate::kv_cache::PrefixReuseMode::FullRefill,
+                        },
+                        output,
+                    });
+                }
+                GenerationPreparation::Ready(plan) => plan,
+            };
 
             // #835: validate the suffix a reuse plan would select for this
             // slot BEFORE calling `_inner` at all -- same reasoning as the
-            // `check_logprobs_not_set`/`check_mtp_not_requested` preflights
-            // above (PR #787): the `match` below unconditionally calls
+            // prefix contract's capability preflights above (PR #787): the
+            // `match` below unconditionally calls
             // `reset_state()` and evicts the cache slot on ANY `Err` from
             // `_inner`, so a suffix-validation-only rejection (out-of-vocab
             // token, empty suffix, or a suffix overflowing `max_cache_len`)
@@ -16680,15 +16666,13 @@ mod inner {
             // reachable), or a valid pre-existing cross-turn entry this call
             // never touched would be destroyed alongside it.
             //
-            if gen_cfg.max_new_tokens > 0 {
-                let metadata = self.cross_turn_metadata(tokenizer);
-                let plan = self.plan_cross_turn_reuse(slot_id, &metadata, &prompt_ids);
-                self.plan_prefix_request(&prompt_ids, &plan)?;
-            }
+            let metadata = self.cross_turn_metadata(tokenizer);
+            let plan = self.plan_cross_turn_reuse(slot_id, &metadata, &generation_plan.prompt_ids);
+            self.plan_prefix_request(&generation_plan.prompt_ids, &plan)?;
 
             match self.generate_streaming_with_prefix_cache_and_cancel_inner(
                 slot_id,
-                prompt_ids,
+                generation_plan,
                 tokenizer,
                 gen_cfg,
                 on_token,
@@ -16709,7 +16693,7 @@ mod inner {
         fn generate_streaming_with_prefix_cache_and_cancel_inner<F, C>(
             &mut self,
             slot_id: crate::kv_cache::CrossTurnSlotId,
-            prompt_ids: Vec<u32>,
+            generation_plan: GenerationPlan,
             tokenizer: &BpeTokenizer,
             gen_cfg: &GenerateConfig,
             mut on_token: F,
@@ -16722,77 +16706,34 @@ mod inner {
             use crate::error::InferenceError;
             use crate::kv_cache::PrefixReuseMode;
 
-            // The `logprobs` / `enable_mtp` / empty-prompt config preflight
-            // checks (PR #787, #856), and the suffix-content preflight below
-            // (#835), live in the public wrapper
-            // `generate_streaming_with_prefix_cache_and_cancel`, not here:
-            // that wrapper's error-recovery path unconditionally evicts the
-            // cache slot on any `Err` from this function, so a
-            // preflight-only rejection must never reach `_inner` in the first
-            // place, or a valid pre-existing cross-turn entry this call never
-            // touched would be destroyed alongside it. `prompt_ids` arrives
-            // already tokenized by the wrapper (which needs them to run that
-            // preflight) so this function never re-tokenizes `prompt`, and
-            // is therefore guaranteed non-empty by the time it reaches this
-            // function -- unlike `logprobs`/`enable_mtp`/suffix-content,
-            // empty-prompt has no cheap "run it again here as defense in
-            // depth" form: any duplicate check inside `_inner` would have to
-            // return `Err`, and an `Err` from `_inner` is exactly what the
-            // wrapper's blanket eviction match treats as cache-invalidating.
-            // `plan_cross_turn_reuse`/`plan_prefix_request` are still run
-            // again below, cheaply, as defense in depth (this function's own
-            // safety invariant should not depend solely on its one caller
-            // getting the guard conditions right).
-
             let cfg = self.engine.config.clone();
+            let GenerationPlan {
+                mut rng_state,
+                prompt_ids,
+                prompt_len,
+                ..
+            } = generation_plan;
 
-            let mut rng_state = match gen_cfg.seed {
-                Some(s) => {
-                    if s == 0 {
-                        1
-                    } else {
-                        s
-                    }
-                }
-                None => {
-                    use std::time::SystemTime;
-                    let t = SystemTime::now()
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .map(|d| d.as_nanos() as u64)
-                        .unwrap_or(0x12345678_9abcdef0);
-                    if t == 0 { 1 } else { t }
-                }
-            };
-
-            let prompt_len = prompt_ids.len();
+            // Shared preparation and the suffix-content preflight (#835)
+            // live in the public wrapper. A preflight-only rejection must
+            // never reach this function because the wrapper's error recovery
+            // treats every `Err` returned here as cache-invalidating.
+            // `plan_cross_turn_reuse`/`plan_prefix_request` still run again
+            // below as defense in depth before restore or reset.
             debug_assert!(
                 prompt_len > 0,
-                "the wrapper's check_prompt_not_empty (#856) must reject an \
-                 empty prompt before calling _inner"
+                "shared prefix-cache preparation must reject an empty prompt"
+            );
+            debug_assert!(
+                gen_cfg.max_new_tokens > 0,
+                "shared prefix-cache preparation must complete zero-budget requests"
+            );
+            debug_assert_eq!(
+                prompt_len,
+                prompt_ids.len(),
+                "shared preparation must report the tokenized prompt length"
             );
 
-            // Zero-budget requests return before any state mutation, leaving an
-            // existing cache entry exactly as-is.
-            if gen_cfg.max_new_tokens == 0 {
-                return Ok(CachedGenerateOutput {
-                    output: GenerateOutput {
-                        text: String::new(),
-                        token_ids: vec![],
-                        prompt_tokens: prompt_len,
-                        generated_tokens: 0,
-                        stopped: false,
-                        stop_reason: Some(StopReason::Length),
-                        token_logprobs: vec![],
-                    },
-                    cache: CrossTurnCacheStats {
-                        slot_id,
-                        prompt_tokens: prompt_len,
-                        reused_tokens: 0,
-                        prefetched_tokens: 0,
-                        mode: PrefixReuseMode::FullRefill,
-                    },
-                });
-            }
             let metadata = self.cross_turn_metadata(tokenizer);
             let plan = self.plan_cross_turn_reuse(slot_id, &metadata, &prompt_ids);
 
@@ -21822,9 +21763,8 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         // -------------------------------------------------------------------
 
         /// A drop guard that restores (or clears) an env var on scope exit,
-        /// so a panicking assertion inside a test can't leak
-        /// `LATTICE_MOE_EXPERT_CACHE_SLOTS` into whichever GPU test the
-        /// `gpu_test_lock()` mutex hands the machine to next.
+        /// so a panicking assertion inside a test cannot leak its setting
+        /// into whichever GPU test the `gpu_test_lock()` mutex runs next.
         struct EnvVarGuard {
             key: &'static str,
             prior: Option<String>,
@@ -21832,10 +21772,9 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         impl EnvVarGuard {
             fn set(key: &'static str, value: &str) -> Self {
                 let prior = std::env::var(key).ok();
-                // SAFETY: callers only mutate `LATTICE_MOE_EXPERT_CACHE_SLOTS`
-                // from inside a `gpu_test_lock()`-guarded test, which
-                // serializes every GPU test in this binary (same pattern as
-                // `with_self_spec_env` above) — no concurrent reader/writer.
+                // SAFETY: callers only mutate process environment from inside
+                // a `gpu_test_lock()`-guarded test, which serializes every GPU
+                // test in this binary (same pattern as `with_self_spec_env`).
                 unsafe {
                     std::env::set_var(key, value);
                 }
@@ -33276,6 +33215,197 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             }
         }
 
+        #[derive(Debug, Clone, PartialEq)]
+        struct WarmCrossTurnSnapshot {
+            generic: crate::kv_cache::CrossTurnPrefixEntry,
+            gdn_snapshot: crate::attention::gdn::GdnSnapshot,
+            checkpoints: Vec<(usize, crate::attention::gdn::GdnSnapshot)>,
+            kv_seq_len: usize,
+            position: usize,
+        }
+
+        fn warm_cross_turn_snapshot(state: &MetalQwen35State) -> WarmCrossTurnSnapshot {
+            let entry = state
+                .cross_turn_prefix_cache
+                .entry
+                .as_ref()
+                .expect("precondition: the cross-turn slot must be warm");
+            WarmCrossTurnSnapshot {
+                generic: entry.generic.clone(),
+                gdn_snapshot: entry.gdn_snapshot.clone(),
+                checkpoints: entry
+                    .checkpoints
+                    .iter()
+                    .map(|checkpoint| (checkpoint.len, checkpoint.snapshot.clone()))
+                    .collect(),
+                kv_seq_len: state.session.kv_cache.seq_len,
+                position: state.session.position,
+            }
+        }
+
+        fn assert_warm_cross_turn_snapshot(
+            state: &MetalQwen35State,
+            expected: &WarmCrossTurnSnapshot,
+        ) {
+            assert_eq!(
+                warm_cross_turn_snapshot(state),
+                expected.clone(),
+                "preparation-only rejection or completion must not mutate the warm slot or live state"
+            );
+        }
+
+        fn single_char_prompt(token_ids: &[u32]) -> String {
+            token_ids
+                .iter()
+                .map(|&id| {
+                    if id < 26 {
+                        (b'a' + id as u8) as char
+                    } else {
+                        (b'A' + (id - 26) as u8) as char
+                    }
+                })
+                .collect()
+        }
+
+        #[test]
+        fn cross_turn_preparation_outcomes_preserve_warm_slot() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+
+            use crate::error::InferenceError;
+            use crate::kv_cache::PrefixReuseMode;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (cfg, weights) = tiny_hybrid_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+
+            state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "ab",
+                    &tokenizer,
+                    &cross_turn_test_gen_cfg(7, 2),
+                    |_, _| true,
+                )
+                .expect("warm-up call must succeed");
+            let warm = warm_cross_turn_snapshot(&state);
+
+            let empty = state.generate_streaming_with_prefix_cache(
+                slot_id,
+                "",
+                &tokenizer,
+                &cross_turn_test_gen_cfg(8, 2),
+                |_, _| true,
+            );
+            assert!(
+                matches!(empty, Err(InferenceError::Inference(ref message)) if message == "empty prompt"),
+                "empty prompt must preserve its exact typed rejection; got {empty:?}"
+            );
+            assert_warm_cross_turn_snapshot(&state, &warm);
+
+            let zero = state
+                .generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "ab",
+                    &tokenizer,
+                    &cross_turn_test_gen_cfg(9, 0),
+                    |_, _| true,
+                )
+                .expect("zero-budget request must complete successfully");
+            assert!(zero.output.text.is_empty());
+            assert!(zero.output.token_ids.is_empty());
+            assert_eq!(zero.output.prompt_tokens, 2);
+            assert_eq!(zero.output.generated_tokens, 0);
+            assert!(!zero.output.stopped);
+            assert_eq!(zero.output.stop_reason, Some(StopReason::Length));
+            assert!(zero.output.token_logprobs.is_empty());
+            assert_eq!(zero.cache.slot_id, slot_id);
+            assert_eq!(zero.cache.prompt_tokens, 2);
+            assert_eq!(zero.cache.reused_tokens, 0);
+            assert_eq!(zero.cache.prefetched_tokens, 0);
+            assert_eq!(zero.cache.mode, PrefixReuseMode::FullRefill);
+            assert_warm_cross_turn_snapshot(&state, &warm);
+
+            let over_context_prompt = "a".repeat(31);
+            let over_context = state.generate_streaming_with_prefix_cache(
+                slot_id,
+                &over_context_prompt,
+                &tokenizer,
+                &cross_turn_test_gen_cfg(10, 2),
+                |_, _| true,
+            );
+            assert_context_budget_error(&over_context, 31, 2, 32);
+            assert_warm_cross_turn_snapshot(&state, &warm);
+
+            let logprobs_cfg = GenerateConfig {
+                max_new_tokens: 0,
+                logprobs: Some(0),
+                ..cross_turn_test_gen_cfg(11, 0)
+            };
+            let logprobs = state.generate_streaming_with_prefix_cache(
+                slot_id,
+                "",
+                &tokenizer,
+                &logprobs_cfg,
+                |_, _| true,
+            );
+            assert!(
+                matches!(logprobs, Err(InferenceError::InvalidInput(ref message))
+                    if message.starts_with("per-token logprobs are not yet supported")),
+                "logprobs must reject before empty/zero handling; got {logprobs:?}"
+            );
+            assert_warm_cross_turn_snapshot(&state, &warm);
+
+            let mtp_cfg = GenerateConfig {
+                max_new_tokens: 0,
+                enable_mtp: Some(true),
+                ..cross_turn_test_gen_cfg(12, 0)
+            };
+            let mtp = state.generate_streaming_with_prefix_cache(
+                slot_id,
+                "",
+                &tokenizer,
+                &mtp_cfg,
+                |_, _| true,
+            );
+            assert!(
+                matches!(mtp, Err(InferenceError::InvalidInput(ref message))
+                    if message.starts_with("enable_mtp (or LATTICE_MTP) is not supported")),
+                "explicit MTP must reject before empty/zero handling; got {mtp:?}"
+            );
+            assert_warm_cross_turn_snapshot(&state, &warm);
+
+            {
+                let _mtp_env = EnvVarGuard::set("LATTICE_MTP", "1");
+                let env_mtp_cfg = GenerateConfig {
+                    max_new_tokens: 0,
+                    enable_mtp: None,
+                    ..cross_turn_test_gen_cfg(13, 0)
+                };
+                let env_mtp = state.generate_streaming_with_prefix_cache(
+                    slot_id,
+                    "",
+                    &tokenizer,
+                    &env_mtp_cfg,
+                    |_, _| true,
+                );
+                assert!(
+                    matches!(env_mtp, Err(InferenceError::InvalidInput(ref message))
+                        if message.starts_with("enable_mtp (or LATTICE_MTP) is not supported")),
+                    "environment-requested MTP must reject before empty/zero handling; got {env_mtp:?}"
+                );
+                assert_warm_cross_turn_snapshot(&state, &warm);
+            }
+        }
+
         /// The correctness gate for #462: a growing multi-turn conversation run
         /// through `generate_streaming_with_prefix_cache` on one long-lived state
         /// must produce byte-identical token IDs, turn by turn, to running each
@@ -34405,6 +34535,85 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             );
         }
 
+        #[test]
+        fn cross_turn_cache_cancel_after_exact_restore_is_fail_closed() {
+            let Some(_) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (mut cfg, weights) = tiny_hybrid_fixture();
+            cfg.eos_token_id = u32::MAX;
+
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+            let mut state = MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let gen_cfg = cross_turn_test_gen_cfg(29, 2);
+
+            state
+                .generate_streaming_with_prefix_cache_and_cancel(
+                    slot_id,
+                    "ab",
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                    || false,
+                )
+                .expect("warm-up call must succeed");
+            let represented_ids = state
+                .cross_turn_prefix_cache
+                .entry
+                .as_ref()
+                .expect("warm-up call must retain a cache entry")
+                .generic
+                .token_ids
+                .clone();
+            let mut appended_prompt = single_char_prompt(&represented_ids);
+            appended_prompt.push('q');
+
+            let cancelled = state
+                .generate_streaming_with_prefix_cache_and_cancel(
+                    slot_id,
+                    &appended_prompt,
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                    || true,
+                )
+                .expect("cancellation after restore must be a successful interrupt");
+            assert_eq!(
+                cancelled.cache.mode,
+                crate::kv_cache::PrefixReuseMode::ExactAppend,
+                "the cancellation must exercise an exact-prefix restore, not a full refill"
+            );
+            assert_eq!(cancelled.output.stop_reason, Some(StopReason::Interrupt));
+            assert_eq!(cancelled.output.generated_tokens, 0);
+            assert!(
+                state.cross_turn_prefix_cache.entry.is_none(),
+                "restore consumes the warm entry before cancellation and must leave the slot fail-closed"
+            );
+
+            let mut reference =
+                MetalQwen35State::new(&weights, &cfg, 64).expect("tiny hybrid fixture");
+            let expected = reference
+                .generate_streaming(&appended_prompt, &tokenizer, &gen_cfg, |_, _| true)
+                .expect("full-refill reference must succeed");
+            let resumed = state
+                .generate_streaming_with_prefix_cache_and_cancel(
+                    slot_id,
+                    &appended_prompt,
+                    &tokenizer,
+                    &gen_cfg,
+                    |_, _| true,
+                    || false,
+                )
+                .expect("generation after a restore-time cancellation must succeed");
+            assert_eq!(
+                resumed.output.token_ids, expected.token_ids,
+                "restore-time cancellation must leave state safe for a later full refill"
+            );
+        }
+
         /// Serve-boundary correctness gate: `lattice_serve` always calls the
         /// cancel-aware prefix-cache API on the single `CrossTurnSlotId::DEFAULT`
         /// slot regardless of which logical conversation issued the request.
@@ -35429,10 +35638,10 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// reject the request before any cache/state mutation, so no cache
         /// entry is created (or consumed) for the rejected call.
         ///
-        /// Mutation sensitivity: removing the `check_logprobs_not_set` call
-        /// at the top of `generate_streaming_with_prefix_cache_and_cancel_inner`
-        /// makes this assertion fail (the call returns `Ok` with empty
-        /// `token_logprobs` instead of `Err`).
+        /// Mutation sensitivity: removing `check_logprobs_not_set` from the
+        /// outer `MetalPrefixCache` preparation contract makes this assertion
+        /// fail (the call returns `Ok` with empty `token_logprobs` instead of
+        /// `Err`).
         #[test]
         fn generate_streaming_with_prefix_cache_rejects_logprobs_request() {
             let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
@@ -35583,9 +35792,9 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// falling back to plain per-token decode with no MTP applied and
         /// no indication the request was ignored.
         ///
-        /// Mutation sensitivity: removing the `check_mtp_not_requested` call
-        /// in `generate_streaming_with_prefix_cache_and_cancel` makes this
-        /// assertion fail (the call returns `Ok` instead of `Err`).
+        /// Mutation sensitivity: removing `check_mtp_not_requested` from the
+        /// outer `MetalPrefixCache` preparation contract makes this assertion
+        /// fail (the call returns `Ok` instead of `Err`).
         #[test]
         fn generate_streaming_with_prefix_cache_rejects_active_mtp_request() {
             let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();

--- a/crates/inference/src/forward/neon_forward.rs
+++ b/crates/inference/src/forward/neon_forward.rs
@@ -23,14 +23,14 @@ use crate::forward::cpu::{elementwise_mul, silu_inplace};
 use crate::forward::neon::{matmul_q8_neon_into, pack_weights_q8};
 use crate::model::qwen35::{
     AttentionWeights, CommonLayerWeights, FeedForwardWeights, ForwardScratch,
-    FullAttentionLayerWeights, KvCache, ModelWeights, decode_tokens, qwen35_rms_norm, resize,
+    FullAttentionLayerWeights, GenerationEntryContract, GenerationPlan, GenerationPreparation,
+    KvCache, ModelWeights, decode_tokens, prepare_generation, qwen35_rms_norm, resize,
     sample_token, should_stop_token,
 };
 use crate::model::qwen35_config::{GenerateConfig, GenerateOutput, Qwen35Config};
 use crate::rope::RopeTable;
 use crate::stop_reason::StopReason;
 use crate::tokenizer::bpe::BpeTokenizer;
-use crate::tokenizer::common::Tokenizer;
 use crate::weights::ingress::{IngestedTensor, validate_ingested_tensor};
 use crate::weights::q8_weights::{validate_cfg_len, validate_gdn_shapes};
 
@@ -955,75 +955,23 @@ pub fn generate_q8_neon(
     prompt: &str,
     gen_cfg: &GenerateConfig,
 ) -> Result<GenerateOutput, crate::error::InferenceError> {
-    // Initialize RNG
-    let mut rng_state = match gen_cfg.seed {
-        Some(s) => {
-            if s == 0 {
-                1
-            } else {
-                s
-            }
-        }
-        None => {
-            use std::time::SystemTime;
-            let t = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .map(|d| d.as_nanos() as u64)
-                .unwrap_or(0x12345678_9abcdef0);
-            if t == 0 { 1 } else { t }
-        }
+    let plan = match prepare_generation(
+        tokenizer,
+        prompt,
+        gen_cfg,
+        cfg.vocab_size,
+        rope.max_positions(),
+        GenerationEntryContract::StandaloneCpu,
+    )? {
+        GenerationPreparation::Ready(plan) => plan,
+        GenerationPreparation::Complete(output) => return Ok(output),
     };
-
-    // Tokenize prompt
-    let input = tokenizer.tokenize(prompt);
-    let prompt_ids: Vec<u32> = input.input_ids[..input.real_length].to_vec();
-    let prompt_len = prompt_ids.len();
-
-    // #856: single shared preflight, unified with the Metal paths (which
-    // used to accept an empty prompt and return an empty Ok) — see
-    // `check_prompt_not_empty` (model::qwen35::generation).
-    crate::model::qwen35::check_prompt_not_empty(prompt_len)?;
-    crate::model::qwen35::check_prompt_ids_in_vocab(&prompt_ids, cfg.vocab_size)?;
-
-    // max_new_tokens == 0 means "generate nothing": return before sampling so
-    // we never emit a token the caller did not ask for. Mirrors the guard in
-    // Qwen35Model::generate (crates/inference/src/model/qwen35/generation.rs).
-    if gen_cfg.max_new_tokens == 0 {
-        return Ok(GenerateOutput {
-            text: String::new(),
-            token_ids: vec![],
-            prompt_tokens: prompt_len,
-            generated_tokens: 0,
-            stopped: false,
-            stop_reason: Some(StopReason::Length),
-            token_logprobs: vec![],
-        });
-    }
-
-    // Reject grammar configs before allocating any state. Grammar masking
-    // (`mask_logits` + `advance`) is not wired into this generate loop; without
-    // the guard the grammar field would be silently ignored, producing
-    // unconstrained output despite a grammar being set (#397/#398).
-    crate::model::qwen35::check_grammar_not_set(gen_cfg)?;
-    // Same rationale for logprobs capture, which is also not wired into this
-    // generate loop (#585).
-    crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
-    // Same rationale for stop_strings matching and reasoning-budget forcing,
-    // neither of which is wired into this generate loop (ADR-080 C3, #783).
-    crate::model::qwen35::check_stop_strings_not_set(gen_cfg)?;
-    crate::model::qwen35::check_reasoning_budget_not_set(gen_cfg)?;
-
-    // Reject requests whose total token budget exceeds the RoPE table's
-    // position capacity before allocating caches or dereferencing weights.
-    // Mirrors Qwen35Model::generate and forward::cpu_q8::generate_q8.
-    let max_context = rope.max_positions();
-    if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
-        return Err(crate::error::InferenceError::Inference(format!(
-            "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
-             model context window ({max_context})",
-            gen_cfg.max_new_tokens
-        )));
-    }
+    let GenerationPlan {
+        mut rng_state,
+        prompt_ids,
+        prompt_len,
+        required_capacity: max_seq_len,
+    } = plan;
 
     // Initialize states
     let num_linear = cfg.num_linear_attention_layers();
@@ -1033,10 +981,6 @@ pub fn generate_q8_neon(
         .collect();
     let mut kv_cache = KvCache::new(num_full);
     let mut scratch = ForwardScratch::new();
-    let max_seq_len = prompt_len
-        .saturating_add(gen_cfg.max_new_tokens)
-        .saturating_add(1);
-
     kv_cache.reserve(max_seq_len, cfg.full_kv_dim());
     scratch.ensure_capacity(cfg, max_seq_len);
 
@@ -3104,8 +3048,8 @@ mod tests {
     /// Metal paths, which used to silently accept an empty prompt and
     /// return an empty `Ok`. See docs/generation-entrypoint-matrix.md row 2.
     ///
-    /// Mutation sensitivity: reverting the `check_prompt_not_empty` call at
-    /// this call site makes the function proceed past the guard with a
+    /// Mutation sensitivity: bypassing the shared preparation at this entry
+    /// point makes the function proceed past the guard with a
     /// zero-length prompt, either panicking in the prefill/decode loop or
     /// producing a non-`Inference` error — this assert fails either way.
     #[test]
@@ -3148,8 +3092,8 @@ mod tests {
     /// must be rejected before `forward_step_q8_neon` slices the embedding
     /// table.
     ///
-    /// Mutation sensitivity: removing only the NEON call to
-    /// `check_prompt_ids_in_vocab` lets this request reach the unchecked
+    /// Mutation sensitivity: removing the shared setup's
+    /// `check_prompt_ids_in_vocab` call lets this request reach the unchecked
     /// embedding slice and panic instead of returning `InvalidInput`.
     #[test]
     fn generate_q8_neon_rejects_out_of_vocab_prompt_id() {

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -2312,12 +2312,11 @@ pub(crate) fn check_reasoning_budget_not_set(
 /// rejected here too, rather than silently falling back to plain per-token
 /// decode with no indication MTP was skipped.
 ///
-/// Sole caller: the Metal cross-turn prefix-cache path
-/// (`generate_streaming_with_prefix_cache_and_cancel`), which has no MTP
-/// draft/verify wiring at all -- gated identically to that Metal-only
-/// consumer (same gate as the `DecodePolicy`/`StepOutcome` re-export in
-/// `mod.rs`) so non-metal-gpu builds don't carry an unused function.
-#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+/// Sole production caller: the shared generation preparation contract for
+/// the Metal cross-turn prefix-cache path, which has no MTP draft/verify
+/// wiring at all. Test builds also compile the guard so that contract and
+/// ordering can be exercised without a Metal device.
+#[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
 pub(crate) fn check_mtp_not_requested(gen_cfg: &GenerateConfig) -> Result<(), InferenceError> {
     let mtp_enabled = gen_cfg
         .enable_mtp

--- a/crates/inference/src/model/qwen35/generation_setup.rs
+++ b/crates/inference/src/model/qwen35/generation_setup.rs
@@ -1,8 +1,12 @@
+#[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+use super::generation::check_context_budget;
 use super::generation::{
     check_grammar_not_set, check_logprobs_not_set, check_prompt_ids_in_vocab,
     check_prompt_not_empty, check_reasoning_budget_not_set, check_stop_strings_not_set,
 };
 use crate::error::InferenceError;
+#[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+use crate::model::qwen35_config::decode_cap;
 use crate::model::qwen35_config::{GenerateConfig, GenerateOutput};
 use crate::stop_reason::StopReason;
 use crate::tokenizer::bpe::BpeTokenizer;
@@ -11,16 +15,69 @@ use crate::tokenizer::common::Tokenizer;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum GenerationEntryContract {
     StandaloneCpu,
+    #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+    MetalDirect,
+    #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+    MetalStreaming,
 }
 
 impl GenerationEntryContract {
-    fn validate(self, gen_cfg: &GenerateConfig) -> Result<(), InferenceError> {
+    fn validate_prompt_ids(
+        self,
+        prompt_ids: &[u32],
+        vocab_size: usize,
+    ) -> Result<(), InferenceError> {
+        match self {
+            Self::StandaloneCpu => check_prompt_ids_in_vocab(prompt_ids, vocab_size),
+            #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+            Self::MetalDirect | Self::MetalStreaming => Ok(()),
+        }
+    }
+
+    fn validate_capabilities(self, gen_cfg: &GenerateConfig) -> Result<(), InferenceError> {
         match self {
             Self::StandaloneCpu => {
                 check_grammar_not_set(gen_cfg)?;
                 check_logprobs_not_set(gen_cfg)?;
                 check_stop_strings_not_set(gen_cfg)?;
                 check_reasoning_budget_not_set(gen_cfg)
+            }
+            #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+            Self::MetalDirect => {
+                check_reasoning_budget_not_set(gen_cfg)?;
+                check_logprobs_not_set(gen_cfg)
+            }
+            #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+            Self::MetalStreaming => Ok(()),
+        }
+    }
+
+    fn validate_context(
+        self,
+        prompt_len: usize,
+        gen_cfg: &GenerateConfig,
+        max_context: usize,
+    ) -> Result<usize, InferenceError> {
+        match self {
+            Self::StandaloneCpu => {
+                if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
+                    return Err(InferenceError::Inference(format!(
+                        "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
+                         model context window ({max_context})",
+                        gen_cfg.max_new_tokens
+                    )));
+                }
+                Ok(gen_cfg.max_new_tokens)
+            }
+            #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+            Self::MetalDirect | Self::MetalStreaming => {
+                check_context_budget(
+                    prompt_len,
+                    gen_cfg.reasoning_budget,
+                    gen_cfg.max_new_tokens,
+                    max_context,
+                )?;
+                Ok(decode_cap(gen_cfg.reasoning_budget, gen_cfg.max_new_tokens))
             }
         }
     }
@@ -55,7 +112,7 @@ pub(crate) fn prepare_generation(
     let prompt_len = prompt_ids.len();
 
     check_prompt_not_empty(prompt_len)?;
-    check_prompt_ids_in_vocab(&prompt_ids, vocab_size)?;
+    contract.validate_prompt_ids(&prompt_ids, vocab_size)?;
 
     if gen_cfg.max_new_tokens == 0 {
         return Ok(GenerationPreparation::Complete(GenerateOutput {
@@ -69,22 +126,15 @@ pub(crate) fn prepare_generation(
         }));
     }
 
-    contract.validate(gen_cfg)?;
-
-    if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
-        return Err(InferenceError::Inference(format!(
-            "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
-             model context window ({max_context})",
-            gen_cfg.max_new_tokens
-        )));
-    }
+    contract.validate_capabilities(gen_cfg)?;
+    let effective_capacity = contract.validate_context(prompt_len, gen_cfg, max_context)?;
 
     Ok(GenerationPreparation::Ready(GenerationPlan {
         rng_state,
         prompt_ids,
         prompt_len,
         required_capacity: prompt_len
-            .saturating_add(gen_cfg.max_new_tokens)
+            .saturating_add(effective_capacity)
             .saturating_add(1),
     }))
 }
@@ -132,6 +182,24 @@ mod tests {
             vocab_size,
             max_context,
             GenerationEntryContract::StandaloneCpu,
+        )
+    }
+
+    fn prepare_with_contract(
+        tokenizer: &BpeTokenizer,
+        prompt: &str,
+        gen_cfg: &GenerateConfig,
+        vocab_size: usize,
+        max_context: usize,
+        contract: GenerationEntryContract,
+    ) -> Result<GenerationPreparation, InferenceError> {
+        prepare_generation(
+            tokenizer,
+            prompt,
+            gen_cfg,
+            vocab_size,
+            max_context,
+            contract,
         )
     }
 
@@ -270,6 +338,132 @@ mod tests {
                 .expect_err("standalone CPU contract must reject unwired features");
             assert!(matches!(err, InferenceError::InvalidInput(_)));
         }
+    }
+
+    #[test]
+    fn metal_direct_contract_preserves_its_capability_set_and_guard_order() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let grammar = GrammarEngine::new(
+            &GrammarSpec::Gbnf("root ::= \"a\"\n".to_string()),
+            vec![b"a".to_vec()],
+        )
+        .expect("test grammar compiles");
+        let supported = GenerateConfig {
+            max_new_tokens: 1,
+            grammar: Some(Arc::new(grammar)),
+            stop_strings: vec!["stop".to_string()],
+            enable_mtp: Some(true),
+            ..Default::default()
+        };
+        let result = prepare_with_contract(
+            &tokenizer,
+            "a",
+            &supported,
+            1,
+            2,
+            GenerationEntryContract::MetalDirect,
+        )
+        .expect("Metal direct supports grammar, stop strings, and MTP routing");
+        assert!(matches!(result, GenerationPreparation::Ready(_)));
+
+        let rejected = GenerateConfig {
+            max_new_tokens: 1,
+            reasoning_budget: Some(1),
+            logprobs: Some(0),
+            ..Default::default()
+        };
+        let err = prepare_with_contract(
+            &tokenizer,
+            "a",
+            &rejected,
+            1,
+            usize::MAX,
+            GenerationEntryContract::MetalDirect,
+        )
+        .expect_err("Metal direct must reject reasoning before logprobs");
+        assert!(matches!(
+            err,
+            InferenceError::InvalidInput(ref message)
+                if message.starts_with("reasoning_budget is not yet supported")
+        ));
+    }
+
+    #[test]
+    fn metal_streaming_contract_accepts_its_wired_features() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let grammar = GrammarEngine::new(
+            &GrammarSpec::Gbnf("root ::= \"a\"\n".to_string()),
+            vec![b"a".to_vec()],
+        )
+        .expect("test grammar compiles");
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 1,
+            grammar: Some(Arc::new(grammar)),
+            logprobs: Some(0),
+            stop_strings: vec!["stop".to_string()],
+            reasoning_budget: Some(1),
+            enable_mtp: Some(true),
+            ..Default::default()
+        };
+        let result = prepare_with_contract(
+            &tokenizer,
+            "a",
+            &gen_cfg,
+            1,
+            4,
+            GenerationEntryContract::MetalStreaming,
+        )
+        .expect("Metal streaming supports the wired feature set and leaves MTP inert");
+        let GenerationPreparation::Ready(plan) = result else {
+            panic!("nonzero budget must return a ready plan");
+        };
+
+        assert_eq!(plan.required_capacity, 5);
+    }
+
+    #[test]
+    fn metal_contracts_preserve_no_prompt_id_admission() {
+        let tokenizer = tokenizer(&[("z", 2)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 1,
+            ..Default::default()
+        };
+
+        for contract in [
+            GenerationEntryContract::MetalDirect,
+            GenerationEntryContract::MetalStreaming,
+        ] {
+            let result = prepare_with_contract(&tokenizer, "z", &gen_cfg, 2, 2, contract)
+                .expect("Metal preparation must preserve its existing admission ordering");
+            assert!(matches!(result, GenerationPreparation::Ready(_)));
+        }
+    }
+
+    #[test]
+    fn metal_streaming_context_uses_reasoning_aware_decode_cap() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 1,
+            reasoning_budget: Some(1),
+            ..Default::default()
+        };
+        let err = prepare_with_contract(
+            &tokenizer,
+            "a",
+            &gen_cfg,
+            1,
+            3,
+            GenerationEntryContract::MetalStreaming,
+        )
+        .expect_err("prompt plus reasoning-aware decode cap must fit the context");
+
+        assert!(matches!(
+            err,
+            InferenceError::Inference(ref message)
+                if message
+                    == "prompt (1 tokens) plus effective decode cap (3 tokens; \
+                        max_new_tokens=1, reasoning_budget=1) exceeds model context window (3)"
+        ));
     }
 
     #[test]

--- a/crates/inference/src/model/qwen35/generation_setup.rs
+++ b/crates/inference/src/model/qwen35/generation_setup.rs
@@ -1,0 +1,292 @@
+use super::generation::{
+    check_grammar_not_set, check_logprobs_not_set, check_prompt_ids_in_vocab,
+    check_prompt_not_empty, check_reasoning_budget_not_set, check_stop_strings_not_set,
+};
+use crate::error::InferenceError;
+use crate::model::qwen35_config::{GenerateConfig, GenerateOutput};
+use crate::stop_reason::StopReason;
+use crate::tokenizer::bpe::BpeTokenizer;
+use crate::tokenizer::common::Tokenizer;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GenerationEntryContract {
+    StandaloneCpu,
+}
+
+impl GenerationEntryContract {
+    fn validate(self, gen_cfg: &GenerateConfig) -> Result<(), InferenceError> {
+        match self {
+            Self::StandaloneCpu => {
+                check_grammar_not_set(gen_cfg)?;
+                check_logprobs_not_set(gen_cfg)?;
+                check_stop_strings_not_set(gen_cfg)?;
+                check_reasoning_budget_not_set(gen_cfg)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct GenerationPlan {
+    pub(crate) rng_state: u64,
+    pub(crate) prompt_ids: Vec<u32>,
+    pub(crate) prompt_len: usize,
+    pub(crate) required_capacity: usize,
+}
+
+#[derive(Debug)]
+pub(crate) enum GenerationPreparation {
+    Ready(GenerationPlan),
+    Complete(GenerateOutput),
+}
+
+pub(crate) fn prepare_generation(
+    tokenizer: &BpeTokenizer,
+    prompt: &str,
+    gen_cfg: &GenerateConfig,
+    vocab_size: usize,
+    max_context: usize,
+    contract: GenerationEntryContract,
+) -> Result<GenerationPreparation, InferenceError> {
+    let rng_state = normalize_seed(gen_cfg.seed, system_seed);
+
+    let input = tokenizer.tokenize(prompt);
+    let prompt_ids = input.input_ids[..input.real_length].to_vec();
+    let prompt_len = prompt_ids.len();
+
+    check_prompt_not_empty(prompt_len)?;
+    check_prompt_ids_in_vocab(&prompt_ids, vocab_size)?;
+
+    if gen_cfg.max_new_tokens == 0 {
+        return Ok(GenerationPreparation::Complete(GenerateOutput {
+            text: String::new(),
+            token_ids: Vec::new(),
+            prompt_tokens: prompt_len,
+            generated_tokens: 0,
+            stopped: false,
+            stop_reason: Some(StopReason::Length),
+            token_logprobs: Vec::new(),
+        }));
+    }
+
+    contract.validate(gen_cfg)?;
+
+    if prompt_len.saturating_add(gen_cfg.max_new_tokens) > max_context {
+        return Err(InferenceError::Inference(format!(
+            "prompt ({prompt_len} tokens) plus max_new_tokens ({}) exceeds \
+             model context window ({max_context})",
+            gen_cfg.max_new_tokens
+        )));
+    }
+
+    Ok(GenerationPreparation::Ready(GenerationPlan {
+        rng_state,
+        prompt_ids,
+        prompt_len,
+        required_capacity: prompt_len
+            .saturating_add(gen_cfg.max_new_tokens)
+            .saturating_add(1),
+    }))
+}
+
+fn normalize_seed(seed: Option<u64>, fallback: impl FnOnce() -> u64) -> u64 {
+    let seed = seed.unwrap_or_else(fallback);
+    if seed == 0 { 1 } else { seed }
+}
+
+fn system_seed() -> u64 {
+    use std::time::SystemTime;
+
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos() as u64)
+        .unwrap_or(0x12345678_9abcdef0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::grammar::{GrammarEngine, GrammarSpec};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn tokenizer(entries: &[(&str, u32)]) -> BpeTokenizer {
+        let vocab = entries
+            .iter()
+            .map(|(token, id)| ((*token).to_string(), *id))
+            .collect::<HashMap<_, _>>();
+        BpeTokenizer::from_vocab_and_merges(vocab, Vec::new()).expect("test tokenizer constructs")
+    }
+
+    fn prepare(
+        tokenizer: &BpeTokenizer,
+        prompt: &str,
+        gen_cfg: &GenerateConfig,
+        vocab_size: usize,
+        max_context: usize,
+    ) -> Result<GenerationPreparation, InferenceError> {
+        prepare_generation(
+            tokenizer,
+            prompt,
+            gen_cfg,
+            vocab_size,
+            max_context,
+            GenerationEntryContract::StandaloneCpu,
+        )
+    }
+
+    #[test]
+    fn seed_normalization_preserves_nonzero_and_repairs_zero() {
+        assert_eq!(
+            normalize_seed(Some(7), || panic!("fallback must not run")),
+            7
+        );
+        assert_eq!(
+            normalize_seed(Some(0), || panic!("fallback must not run")),
+            1
+        );
+        assert_eq!(normalize_seed(None, || 0), 1);
+        assert_eq!(normalize_seed(None, || 9), 9);
+    }
+
+    #[test]
+    fn preparation_applies_seed_normalization_to_the_returned_plan() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 1,
+            seed: Some(0),
+            ..Default::default()
+        };
+        let result = prepare(&tokenizer, "a", &gen_cfg, 1, 2).expect("preparation succeeds");
+        let GenerationPreparation::Ready(plan) = result else {
+            panic!("nonzero budget must return a ready plan");
+        };
+
+        assert_eq!(plan.rng_state, 1);
+    }
+
+    #[test]
+    fn ready_plan_owns_prompt_seed_and_capacity_and_preserves_mtp_contract() {
+        let tokenizer = tokenizer(&[("a", 0), ("b", 1)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 3,
+            seed: Some(17),
+            enable_mtp: Some(true),
+            ..Default::default()
+        };
+        let result = prepare(&tokenizer, "ab", &gen_cfg, 2, 5).expect("preparation succeeds");
+        let GenerationPreparation::Ready(plan) = result else {
+            panic!("nonzero budget must return a ready plan");
+        };
+
+        assert_eq!(plan.rng_state, 17);
+        assert_eq!(plan.prompt_ids, vec![0, 1]);
+        assert_eq!(plan.prompt_len, 2);
+        assert_eq!(plan.required_capacity, 6);
+    }
+
+    #[test]
+    fn empty_prompt_precedes_zero_budget_and_capability_checks() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 0,
+            stop_strings: vec!["stop".to_string()],
+            ..Default::default()
+        };
+        let err = prepare(&tokenizer, "", &gen_cfg, 1, 0)
+            .expect_err("empty prompt must reject before every later branch");
+
+        assert!(matches!(
+            err,
+            InferenceError::Inference(ref message) if message == "empty prompt"
+        ));
+    }
+
+    #[test]
+    fn prompt_id_admission_precedes_zero_budget() {
+        let tokenizer = tokenizer(&[("z", 2)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 0,
+            ..Default::default()
+        };
+        let err = prepare(&tokenizer, "z", &gen_cfg, 2, usize::MAX)
+            .expect_err("out-of-vocabulary prompt must reject before zero-budget completion");
+
+        assert!(matches!(err, InferenceError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn zero_budget_precedes_capabilities_and_context() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 0,
+            stop_strings: vec!["stop".to_string()],
+            ..Default::default()
+        };
+        let result = prepare(&tokenizer, "a", &gen_cfg, 1, 0)
+            .expect("zero budget must complete before unsupported features and context");
+        let GenerationPreparation::Complete(output) = result else {
+            panic!("zero budget must return an early completion");
+        };
+
+        assert!(output.text.is_empty());
+        assert!(output.token_ids.is_empty());
+        assert_eq!(output.prompt_tokens, 1);
+        assert_eq!(output.generated_tokens, 0);
+        assert!(!output.stopped);
+        assert_eq!(output.stop_reason, Some(StopReason::Length));
+        assert!(output.token_logprobs.is_empty());
+    }
+
+    #[test]
+    fn standalone_cpu_contract_rejects_every_unwired_feature() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let grammar = GrammarEngine::new(
+            &GrammarSpec::Gbnf("root ::= \"a\"\n".to_string()),
+            vec![b"a".to_vec()],
+        )
+        .expect("test grammar compiles");
+        let configs = [
+            GenerateConfig {
+                grammar: Some(Arc::new(grammar)),
+                ..Default::default()
+            },
+            GenerateConfig {
+                logprobs: Some(0),
+                ..Default::default()
+            },
+            GenerateConfig {
+                stop_strings: vec!["stop".to_string()],
+                ..Default::default()
+            },
+            GenerateConfig {
+                reasoning_budget: Some(1),
+                ..Default::default()
+            },
+        ];
+
+        for gen_cfg in &configs {
+            let err = prepare(&tokenizer, "a", gen_cfg, 1, 0)
+                .expect_err("standalone CPU contract must reject unwired features");
+            assert!(matches!(err, InferenceError::InvalidInput(_)));
+        }
+    }
+
+    #[test]
+    fn context_preflight_preserves_the_standalone_cpu_error() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 2,
+            ..Default::default()
+        };
+        let err = prepare(&tokenizer, "a", &gen_cfg, 1, 2)
+            .expect_err("prompt plus decode budget must fit the context");
+
+        assert!(matches!(
+            err,
+            InferenceError::Inference(ref message)
+                if message
+                    == "prompt (1 tokens) plus max_new_tokens (2) exceeds model context window (2)"
+        ));
+    }
+}

--- a/crates/inference/src/model/qwen35/generation_setup.rs
+++ b/crates/inference/src/model/qwen35/generation_setup.rs
@@ -1,5 +1,5 @@
 #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
-use super::generation::check_context_budget;
+use super::generation::{check_context_budget, check_mtp_not_requested};
 use super::generation::{
     check_grammar_not_set, check_logprobs_not_set, check_prompt_ids_in_vocab,
     check_prompt_not_empty, check_reasoning_budget_not_set, check_stop_strings_not_set,
@@ -19,9 +19,24 @@ pub(crate) enum GenerationEntryContract {
     MetalDirect,
     #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
     MetalStreaming,
+    #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+    MetalPrefixCache,
 }
 
 impl GenerationEntryContract {
+    fn validate_before_tokenization(self, _gen_cfg: &GenerateConfig) -> Result<(), InferenceError> {
+        match self {
+            #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+            Self::MetalPrefixCache => {
+                check_logprobs_not_set(_gen_cfg)?;
+                check_mtp_not_requested(_gen_cfg)
+            }
+            Self::StandaloneCpu => Ok(()),
+            #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+            Self::MetalDirect | Self::MetalStreaming => Ok(()),
+        }
+    }
+
     fn validate_prompt_ids(
         self,
         prompt_ids: &[u32],
@@ -30,7 +45,7 @@ impl GenerationEntryContract {
         match self {
             Self::StandaloneCpu => check_prompt_ids_in_vocab(prompt_ids, vocab_size),
             #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
-            Self::MetalDirect | Self::MetalStreaming => Ok(()),
+            Self::MetalDirect | Self::MetalStreaming | Self::MetalPrefixCache => Ok(()),
         }
     }
 
@@ -49,6 +64,8 @@ impl GenerationEntryContract {
             }
             #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
             Self::MetalStreaming => Ok(()),
+            #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+            Self::MetalPrefixCache => Ok(()),
         }
     }
 
@@ -70,7 +87,7 @@ impl GenerationEntryContract {
                 Ok(gen_cfg.max_new_tokens)
             }
             #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
-            Self::MetalDirect | Self::MetalStreaming => {
+            Self::MetalDirect | Self::MetalStreaming | Self::MetalPrefixCache => {
                 check_context_budget(
                     prompt_len,
                     gen_cfg.reasoning_budget,
@@ -105,6 +122,8 @@ pub(crate) fn prepare_generation(
     max_context: usize,
     contract: GenerationEntryContract,
 ) -> Result<GenerationPreparation, InferenceError> {
+    contract.validate_before_tokenization(gen_cfg)?;
+
     let rng_state = normalize_seed(gen_cfg.seed, system_seed);
 
     let input = tokenizer.tokenize(prompt);
@@ -422,16 +441,90 @@ mod tests {
     }
 
     #[test]
+    fn metal_prefix_cache_contract_preserves_pre_token_capability_order() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let both_rejected = GenerateConfig {
+            max_new_tokens: 0,
+            logprobs: Some(0),
+            enable_mtp: Some(true),
+            ..Default::default()
+        };
+        let err = prepare_with_contract(
+            &tokenizer,
+            "",
+            &both_rejected,
+            1,
+            0,
+            GenerationEntryContract::MetalPrefixCache,
+        )
+        .expect_err("logprobs must reject before MTP, tokenization, empty, and zero");
+        assert!(matches!(
+            err,
+            InferenceError::InvalidInput(ref message)
+                if message.starts_with("per-token logprobs are not yet supported")
+        ));
+
+        let mtp_rejected = GenerateConfig {
+            max_new_tokens: 0,
+            enable_mtp: Some(true),
+            ..Default::default()
+        };
+        let err = prepare_with_contract(
+            &tokenizer,
+            "",
+            &mtp_rejected,
+            1,
+            0,
+            GenerationEntryContract::MetalPrefixCache,
+        )
+        .expect_err("MTP must reject before tokenization, empty, and zero");
+        assert!(matches!(
+            err,
+            InferenceError::InvalidInput(ref message)
+                if message.starts_with("enable_mtp (or LATTICE_MTP) is not supported")
+        ));
+    }
+
+    #[test]
+    fn metal_prefix_cache_zero_budget_completes_before_context() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 0,
+            enable_mtp: Some(false),
+            reasoning_budget: Some(9),
+            ..Default::default()
+        };
+        let result = prepare_with_contract(
+            &tokenizer,
+            "a",
+            &gen_cfg,
+            1,
+            0,
+            GenerationEntryContract::MetalPrefixCache,
+        )
+        .expect("supported zero-budget request must complete before context");
+        let GenerationPreparation::Complete(output) = result else {
+            panic!("zero budget must return a completed generation");
+        };
+
+        assert_eq!(output.prompt_tokens, 1);
+        assert_eq!(output.generated_tokens, 0);
+        assert_eq!(output.stop_reason, Some(StopReason::Length));
+    }
+
+    #[test]
     fn metal_contracts_preserve_no_prompt_id_admission() {
         let tokenizer = tokenizer(&[("z", 2)]);
         let gen_cfg = GenerateConfig {
             max_new_tokens: 1,
+            enable_mtp: Some(false),
             ..Default::default()
         };
 
         for contract in [
             GenerationEntryContract::MetalDirect,
             GenerationEntryContract::MetalStreaming,
+            GenerationEntryContract::MetalPrefixCache,
         ] {
             let result = prepare_with_contract(&tokenizer, "z", &gen_cfg, 2, 2, contract)
                 .expect("Metal preparation must preserve its existing admission ordering");
@@ -440,30 +533,30 @@ mod tests {
     }
 
     #[test]
-    fn metal_streaming_context_uses_reasoning_aware_decode_cap() {
+    fn metal_streaming_and_prefix_contracts_use_reasoning_aware_decode_cap() {
         let tokenizer = tokenizer(&[("a", 0)]);
         let gen_cfg = GenerateConfig {
             max_new_tokens: 1,
             reasoning_budget: Some(1),
+            enable_mtp: Some(false),
             ..Default::default()
         };
-        let err = prepare_with_contract(
-            &tokenizer,
-            "a",
-            &gen_cfg,
-            1,
-            3,
-            GenerationEntryContract::MetalStreaming,
-        )
-        .expect_err("prompt plus reasoning-aware decode cap must fit the context");
 
-        assert!(matches!(
-            err,
-            InferenceError::Inference(ref message)
-                if message
-                    == "prompt (1 tokens) plus effective decode cap (3 tokens; \
-                        max_new_tokens=1, reasoning_budget=1) exceeds model context window (3)"
-        ));
+        for contract in [
+            GenerationEntryContract::MetalStreaming,
+            GenerationEntryContract::MetalPrefixCache,
+        ] {
+            let err = prepare_with_contract(&tokenizer, "a", &gen_cfg, 1, 3, contract)
+                .expect_err("prompt plus reasoning-aware decode cap must fit the context");
+
+            assert!(matches!(
+                err,
+                InferenceError::Inference(ref message)
+                    if message
+                        == "prompt (1 tokens) plus effective decode cap (3 tokens; \
+                            max_new_tokens=1, reasoning_budget=1) exceeds model context window (3)"
+            ));
+        }
     }
 
     #[test]

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -83,11 +83,6 @@ pub(crate) use generation::check_context_budget;
 // uses `DecodePolicy` directly within its own module.
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 pub(crate) use generation::{DecodePolicy, StepOutcome, StopCheckOutcome};
-// Sibling guard for `enable_mtp` on the cross-turn prefix-cache path, which
-// has no MTP draft/verify wiring (PR #787). Only
-// that Metal-only path needs it, same gate as `DecodePolicy`/`StepOutcome`.
-#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
-pub(crate) use generation::check_mtp_not_requested;
 pub(crate) use norm::qwen35_rms_norm;
 pub(crate) use sampling::sample_token;
 pub(crate) use weights::{

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod detokenize;
 mod eval;
 mod forward;
 mod generation;
+mod generation_setup;
 mod loading;
 mod model;
 mod moe;
@@ -56,23 +57,22 @@ pub(crate) use generation::check_logprobs_not_set;
 // Sibling guards for `stop_strings` / `reasoning_budget` on the same unwired
 // paths (ADR-080 C3, #783).
 pub(crate) use generation::{check_reasoning_budget_not_set, check_stop_strings_not_set};
+pub(crate) use generation_setup::{
+    GenerationEntryContract, GenerationPlan, GenerationPreparation, prepare_generation,
+};
 // Shared empty-prompt preflight (#856): every CPU forward path (cpu_q8,
 // cpu_f16, neon_forward) and every Metal generation entry point
 // (forward::metal_qwen35) calls this instead of its own inline
 // `if prompt_len == 0` copy, unifying the CPU/Metal empty-prompt contract.
 pub(crate) use generation::check_prompt_not_empty;
-// Shared prompt-token admission guard for standalone CPU drivers whose
-// tokenizer and model config are supplied independently (#1083).
-pub(crate) use generation::check_prompt_ids_in_vocab;
 // Shared total-context admission bound (#922): every Metal generation entry
 // point (forward::metal_qwen35) calls this after check_prompt_not_empty to
 // mirror the CPU `generate`/`generate_streaming` total bound
 // (prompt_len + decode budget <= max_context), instead of only bounding the
 // prompt alone. Only the Metal (`mod inner`, gated identically) consumer
-// needs the re-export; the CPU forward paths (cpu_f16, cpu_q8, neon_forward)
-// already enforce this same bound with their own inline check and
-// `generation.rs` itself uses `check_context_budget` directly within its own
-// module.
+// needs the re-export; the standalone CPU paths (cpu_f16, cpu_q8,
+// neon_forward) enforce the same bound through `prepare_generation`, and
+// `generation.rs` uses `check_context_budget` directly within its own module.
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 pub(crate) use generation::check_context_budget;
 // Shared backend-neutral decode-policy struct (reasoning-budget accounting +


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- add a `MetalPrefixCache` contract to the shared generation-preparation seam
- run capability checks, seed normalization, tokenization, empty/zero handling, and context admission at the non-destructive public wrapper
- convert zero-budget completion to the exact cached-output shape once, then pass a prepared `GenerationPlan` into the inner path
- preserve suffix validation, cache restore/reset, cancellation, and suffix-prefill ordering
- add warmed-slot state/snapshot preservation and exact-restore cancellation regressions

Fixes #826.

This is stacked on #1245 (`423d7b322d0b3f9f187cc40a5b096458189c3160`), which establishes the shared Metal preparation pattern.

## Preserved behavior

- capability order remains logprobs → MTP → tokenization/empty → zero → context
- zero-budget calls return `FullRefill` with zero reused/prefetched tokens and do not mutate a warm slot
- the Metal prefix path retains its existing lack of whole-prompt OOV admission; the existing suffix preflight remains in place
- current #922 reasoning-aware context admission is preserved exactly; the older #743 sentence in #826 was already superseded on the base branch by `check_context_budget`
- cancellation after an exact-prefix restore still consumes the entry and leaves the slot fail-closed

## Mutation proof

Each mutation was applied independently and restored:

- moving prefix capability checks behind empty handling made the warmed-slot ordering assertion fail
- changing the zero-budget `reused_tokens` statistic from 0 to 1 made the exact-output assertion fail
- bypassing exact-prefix restore made the cancellation regression fail because the warm entry survived

## Validation

All Cargo runs used the repository-wide shared target. Because concurrent worktrees can alias same-package artifacts, the final suites were forced to rebuild this exact committed source and the new test names were observed directly.

- shared preparation suite: 14 passed
- exact real-Metal warmed-slot regression: passed
- exact real-Metal restore-time cancellation regression: passed
- full default `lattice-inference` library suite: 2,427 passed, 20 ignored
- strict `f16,metal-gpu` library/test Clippy with warnings denied
- repository pre-commit hook: passed (format, workspace/all-target Clippy, docs lint)
- independent review: approved with no correctness findings

Model-backed e2e parity was not run locally; the hosted parity gate remains the fail-closed proof for that artifact-dependent leg.

## bench-compare disposition

**Not owed. The default A/B cannot observe this change.** Under ADR-087 D3-A step 1, which is
file-level and mechanical: none of this pull request's seven changed paths falls inside the
reachable surface of the DEFAULT `bench-compare` A/B — the corrected surface recorded in
Amendment 1 of `docs/adr/ADR-087-bench-compare-gate-calibration-and-coverage.md`. Paths are
classified on both `filename` and `previous_filename`. Because the file-level answer is no,
step 2 is not owed.

Worth naming rather than leaving as a bare no, because this pull request sits exactly on the
distinction the corrected surface fixed: it changes `crates/inference/src/forward/cpu_f16.rs`
and `crates/inference/src/forward/cpu_q8.rs`. Those are sibling modules of the reached
directory `crates/inference/src/forward/cpu/`, not files inside it. An earlier form of the
predicate used the prefix without the trailing separator and matched them, which would have
made this pull request read as reached and owed a step-2 discharge it does not owe.

- Pull request head evaluated: `e6141e58d3c54b6b8625f4346ec967dbb5c79a42`
- Surface read from: `e842a892d950f3d3b2687eaf6cc573e0587785a7`

Void if either ref moves. A moved head means this has discharged nothing and must be re-derived.

**Historical, and not a disposition.** An earlier attempt ran the A/B against a base that was
this pull request's parent at a superseded head, and the gate refused before measuring base
because the machine was 21.4% idle against the repository's unchanged 70% floor. The floor was
not lowered and no measurements were produced. That is a record of a machine state at refs this
pull request no longer carries, and nothing in the statement above rests on it.

Residual, stated rather than implied: an unreachable change is not a safe change, it is an
unmeasured one. Nothing here claims the change is neutral, only that the default A/B could not
have told anyone either way.
