### PR TITLE
test: fail closed on an empty bench-target sweep

### DIFF
--- a/tests/test_bench_targets.py
+++ b/tests/test_bench_targets.py
@@ -73,9 +73,20 @@ class BenchTargetPolicyTests(unittest.TestCase):
         return manifest
 
     def test_workspace_bench_targets_are_executable(self) -> None:
+        manifests = sorted((ROOT / "crates").glob("*/Cargo.toml"))
+        self.assertGreater(
+            len(manifests),
+            0,
+            "bench-target sweep found zero crate manifests; this is an instrument defect, not a clean result",
+        )
+        self.assertIn(
+            ROOT / "crates" / "inference" / "Cargo.toml",
+            manifests,
+            "bench-target sweep did not reach crates/inference/Cargo.toml; check the workspace root and manifest glob",
+        )
         errors = [
             error
-            for manifest in sorted((ROOT / "crates").glob("*/Cargo.toml"))
+            for manifest in manifests
             for error in bench_target_errors(manifest)
         ]
         self.assertEqual(errors, [])


### PR DESCRIPTION
`test_workspace_bench_targets_are_executable` built its population from `(ROOT / "crates").glob("*/Cargo.toml")` and then asserted `errors == []` without asserting that the population was non-empty. A sweep that reached zero manifests produced the same result as a sweep that found no problems:

```
real workspace   manifests=5  errors=0  -> passes
empty root       manifests=0  errors=0  -> also passes
```

`ROOT` is `Path(__file__).resolve().parents[1]`, so moving this file one directory would have made the empty case live without any visible failure.

The file's four fixture tests each hand the checker a genuinely defective manifest, so the checker itself was well covered. What was not covered is that the sweep ran at all. Proving a checker works is not proving it was applied to anything.

The fix asserts the manifest count is non-zero and that `crates/inference/Cargo.toml` is among those swept. Both, rather than either: a bare count assertion still passes if the glob starts matching some other tree, while the named anchor pins that the sweep reached this workspace.

The one-level `crates/*/Cargo.toml` glob is left unchanged. Detecting a future nested layout would require defining a broader workspace policy than this test owns.

Mutation proof, executed both directions:

```
population emptied -> FAILS: "bench-target sweep found zero crate manifests;
                              this is an instrument defect, not a clean result"
restored           -> passes, manifest_count=5
```

Full Python suite: 630 passed, 3 skipped.

## bench-compare disposition

Not applicable. The change is confined to a Python policy test; no Rust source, and therefore no bench binary, is affected.
