### PR TITLE
fix(bench): qualify quick-resolution warn band

### DIFF
--- a/scripts/lib/bench-compare-impl.sh
+++ b/scripts/lib/bench-compare-impl.sh
@@ -696,6 +696,7 @@ run_target_gate() {
     --baseline-name compare-base
     --target "$target"
     --provenance-file "$PROVENANCE_FILE"
+    --resolution "$([ -n "$QUICK_FLAGS" ] && echo quick || echo full)"
   )
 
   if [ -n "$QUICK_FLAGS" ]; then

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -1020,7 +1020,8 @@ def render_report(results: list[BenchResult], arch: str, target: str | None = No
                   informational_target: str | None = None,
                   provenance: RunProvenance | None = None,
                   resolution: str = "full") -> str:
-    assert results, "classifier requires at least one measured row"
+    if not results:
+        raise ValueError("classifier requires at least one measured row")
     if resolution not in ("quick", "full"):
         raise ValueError(f"unsupported benchmark resolution: {resolution}")
 
@@ -2589,7 +2590,7 @@ def main() -> int:
         )
         return finish("not_measurable", EXIT_NOT_MEASURABLE, reason)
 
-    fails = sum(1 for r in gating if r.verdict() == "FAIL")
+    fails = sum(1 for r in gating if r.verdict(args.resolution) == "FAIL")
     if fails:
         return finish(
             "regression",

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -109,6 +109,7 @@ PROVENANCE_FIELDS = (
 WARN_PCT = 3.0   # CI-lower above this => warning
 FAIL_PCT = 7.0   # CI-lower above this => FAIL
 CELEBRATE_PCT = -3.0  # point estimate below this AND CI-upper<0 => celebrate
+QUICK_UNATTRIBUTABLE = "UNATTRIBUTABLE (quick resolution)"
 
 EXIT_PASS = 0
 EXIT_REGRESSION = 1
@@ -330,10 +331,12 @@ class BenchResult:
     def is_informational(self, target: str | None, informational_target: str | None) -> bool:
         return target is not None and target == informational_target
 
-    def verdict(self) -> str:
+    def verdict(self, resolution: str = "full") -> str:
         if self.ci_low_pct > FAIL_PCT:
             return "FAIL"
         if self.ci_low_pct > WARN_PCT:
+            if resolution == "quick":
+                return QUICK_UNATTRIBUTABLE
             return "WARN"
         if self.point_pct < CELEBRATE_PCT and self.ci_high_pct < 0:
             return "WIN"
@@ -1015,7 +1018,12 @@ def render_run_provenance(
 
 def render_report(results: list[BenchResult], arch: str, target: str | None = None,
                   informational_target: str | None = None,
-                  provenance: RunProvenance | None = None) -> str:
+                  provenance: RunProvenance | None = None,
+                  resolution: str = "full") -> str:
+    assert results, "classifier requires at least one measured row"
+    if resolution not in ("quick", "full"):
+        raise ValueError(f"unsupported benchmark resolution: {resolution}")
+
     gated = [
         r for r in results
         if not r.is_informational(target, informational_target)
@@ -1025,13 +1033,19 @@ def render_report(results: list[BenchResult], arch: str, target: str | None = No
         if r.is_informational(target, informational_target)
     ]
 
-    fails = [r for r in gated if r.verdict() == "FAIL"]
-    warns = [r for r in gated if r.verdict() == "WARN"]
-    wins = [r for r in gated if r.verdict() == "WIN"]
+    fails = [r for r in gated if r.verdict(resolution) == "FAIL"]
+    warns = [r for r in gated if r.verdict(resolution) == "WARN"]
+    unattributable = [
+        r for r in gated if r.verdict(resolution) == QUICK_UNATTRIBUTABLE
+    ]
+    wins = [r for r in gated if r.verdict(resolution) == "WIN"]
 
-    info_fails = [r for r in info if r.verdict() == "FAIL"]
-    info_warns = [r for r in info if r.verdict() == "WARN"]
-    info_wins = [r for r in info if r.verdict() == "WIN"]
+    info_fails = [r for r in info if r.verdict(resolution) == "FAIL"]
+    info_warns = [r for r in info if r.verdict(resolution) == "WARN"]
+    info_unattributable = [
+        r for r in info if r.verdict(resolution) == QUICK_UNATTRIBUTABLE
+    ]
+    info_wins = [r for r in info if r.verdict(resolution) == "WIN"]
 
     lines = [f"### `{arch}` — perf regression report\n"]
     if fails:
@@ -1044,25 +1058,39 @@ def render_report(results: list[BenchResult], arch: str, target: str | None = No
             f"**⚠ {len(warns)} WARN** (regression {WARN_PCT}-{FAIL_PCT}% by the same "
             "two-sided-95%-CI lower bound)"
         )
+    if unattributable:
+        lines.append(
+            f"**◻ {len(unattributable)} UNATTRIBUTABLE** (quick-resolution "
+            f"{WARN_PCT}-{FAIL_PCT}% warn band is narrower than the harness's "
+            "measured arm-order bias)"
+        )
     if wins:
         lines.append(f"**🚀 {len(wins)} confirmed improvement**")
-    if not (fails or warns or wins):
+    if not (fails or warns or unattributable or wins):
         lines.append(f"✅ All {len(gated)} gated benches within noise band (±{WARN_PCT}%)")
     lines.append("")
     lines.extend(render_run_provenance(provenance, results))
 
-    if fails or warns or wins:
+    if fails or warns or unattributable or wins:
         lines.append(
             "| Bench | Δ point | 95% CI | new ns | base ns | base n/mode | "
             "head n/mode | verdict |"
         )
         lines.append("|---|---:|---|---:|---:|---|---|---|")
-        for r in sorted(fails + warns + wins, key=lambda r: -r.ci_low_pct):
-            icon = {"FAIL": "❌", "WARN": "⚠", "WIN": "🚀"}[r.verdict()]
+        for r in sorted(
+            fails + warns + unattributable + wins, key=lambda r: -r.ci_low_pct
+        ):
+            verdict = r.verdict(resolution)
+            icon = {
+                "FAIL": "❌",
+                "WARN": "⚠",
+                QUICK_UNATTRIBUTABLE: "◻",
+                "WIN": "🚀",
+            }[verdict]
             lines.append(
                 f"| `{r.name}` | {r.point_pct:+.2f}% | [{r.ci_low_pct:+.2f}%, {r.ci_high_pct:+.2f}%] "
                 f"| {r.new_ns:.1f} | {r.old_ns:.1f} | {sample_cell(r, 'base')} "
-                f"| {sample_cell(r, 'head')} | {icon} {r.verdict()} |"
+                f"| {sample_cell(r, 'head')} | {icon} {verdict} |"
             )
         lines.append("")
 
@@ -1072,18 +1100,27 @@ def render_report(results: list[BenchResult], arch: str, target: str | None = No
             f"lattice-embed SIMD micro-benches, tracked in #714; not gated here, "
             f"re-run `--full` for a gated verdict)"
         )
-        if info_fails or info_warns or info_wins:
+        if info_fails or info_warns or info_unattributable or info_wins:
             lines.append(
                 "| Bench | Δ point | 95% CI | new ns | base ns | base n/mode | "
                 "head n/mode | (would-be verdict) |"
             )
             lines.append("|---|---:|---|---:|---:|---|---|---|")
-            for r in sorted(info_fails + info_warns + info_wins, key=lambda r: -r.ci_low_pct):
-                icon = {"FAIL": "❌", "WARN": "⚠", "WIN": "🚀"}[r.verdict()]
+            for r in sorted(
+                info_fails + info_warns + info_unattributable + info_wins,
+                key=lambda r: -r.ci_low_pct,
+            ):
+                verdict = r.verdict(resolution)
+                icon = {
+                    "FAIL": "❌",
+                    "WARN": "⚠",
+                    QUICK_UNATTRIBUTABLE: "◻",
+                    "WIN": "🚀",
+                }[verdict]
                 lines.append(
                     f"| `{r.name}` | {r.point_pct:+.2f}% | [{r.ci_low_pct:+.2f}%, {r.ci_high_pct:+.2f}%] "
                     f"| {r.new_ns:.1f} | {r.old_ns:.1f} | {sample_cell(r, 'base')} "
-                    f"| {sample_cell(r, 'head')} | {icon} {r.verdict()} (informational) |"
+                    f"| {sample_cell(r, 'head')} | {icon} {verdict} (informational) |"
                 )
         lines.append("")
 
@@ -1099,10 +1136,18 @@ def render_report(results: list[BenchResult], arch: str, target: str | None = No
             f"| {sample_cell(r, 'head')} |"
         )
     lines.append("\n</details>\n")
-    lines.append(
-        f"_Rule: CI-lower of change ≤{WARN_PCT}% passes silently; "
-        f"({WARN_PCT}%, {FAIL_PCT}%] warns; >{FAIL_PCT}% fails._"
-    )
+    if resolution == "quick":
+        lines.append(
+            f"_Rule: CI-lower of change ≤{WARN_PCT}% passes silently; "
+            f"({WARN_PCT}%, {FAIL_PCT}%] is unattributable at quick resolution "
+            "because measured arm-order bias is wider than this band; "
+            f">{FAIL_PCT}% fails._"
+        )
+    else:
+        lines.append(
+            f"_Rule: CI-lower of change ≤{WARN_PCT}% passes silently; "
+            f"({WARN_PCT}%, {FAIL_PCT}%] warns; >{FAIL_PCT}% fails._"
+        )
     if informational_target is not None:
         lines.append(
             f"_Target `{informational_target}` classified informational-only in quick mode "
@@ -2137,6 +2182,9 @@ def main() -> int:
     ap.add_argument("--informational-target",
                     help="Classify this exact target as informational-only. Must equal --target; "
                          "omit for gating/full-mode runs.")
+    ap.add_argument("--resolution", choices=("quick", "full"), default="full",
+                    help="Measurement resolution used for verdict classification "
+                         "(default: full).")
     ap.add_argument("--require-measurements", action="store_true",
                     help="Fail (exit 2) instead of passing when the run produced no gating "
                          "comparison to judge or a selected-base benchmark has no head "
@@ -2489,7 +2537,13 @@ def main() -> int:
             )
 
     report = render_report(
-        results, args.arch, args.target, args.informational_target, provenance)
+        results,
+        args.arch,
+        args.target,
+        args.informational_target,
+        provenance,
+        args.resolution,
+    )
     print(report)
     if args.out:
         args.out.write_text(report)

--- a/tests/test_perf_bench_gate_resolution.py
+++ b/tests/test_perf_bench_gate_resolution.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GATE_PATH = ROOT / "scripts" / "perf-bench-gate.py"
+SPEC = importlib.util.spec_from_file_location("perf_bench_gate", GATE_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+GATE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = GATE
+SPEC.loader.exec_module(GATE)
+
+
+def result(ci_low_pct: float) -> object:
+    return GATE.BenchResult(
+        name="layer_norm/896",
+        point=ci_low_pct / 100.0 + 0.005,
+        ci_low=ci_low_pct / 100.0,
+        ci_high=ci_low_pct / 100.0 + 0.01,
+        new_ns=104.0,
+        old_ns=100.0,
+    )
+
+
+class PerfBenchGateResolutionTests(unittest.TestCase):
+    def test_quick_warn_band_is_unattributable_but_reported(self) -> None:
+        report = GATE.render_report(
+            [result(4.0)], "test-arch", resolution="quick"
+        )
+
+        self.assertIn("1 UNATTRIBUTABLE", report)
+        self.assertIn("layer_norm/896", report)
+        self.assertIn("+4.00%", report)
+        self.assertIn("UNATTRIBUTABLE (quick resolution)", report)
+        self.assertNotIn("1 WARN", report)
+
+    def test_full_warn_band_remains_warn(self) -> None:
+        report = GATE.render_report(
+            [result(4.0)], "test-arch", resolution="full"
+        )
+
+        self.assertIn("1 WARN", report)
+        self.assertIn("layer_norm/896", report)
+        self.assertNotIn("UNATTRIBUTABLE", report)
+
+    def test_above_fail_threshold_fails_at_both_resolutions(self) -> None:
+        for resolution in ("quick", "full"):
+            with self.subTest(resolution=resolution):
+                report = GATE.render_report(
+                    [result(8.0)], "test-arch", resolution=resolution
+                )
+                self.assertIn("1 FAIL", report)
+                self.assertIn("❌ FAIL", report)
+                self.assertNotIn("UNATTRIBUTABLE", report)
+
+    def test_clean_row_passes_at_both_resolutions_and_empty_refuses(self) -> None:
+        for resolution in ("quick", "full"):
+            with self.subTest(resolution=resolution):
+                report = GATE.render_report(
+                    [result(2.0)], "test-arch", resolution=resolution
+                )
+                self.assertIn("All 1 gated benches within noise band", report)
+                self.assertNotIn("WARN", report)
+                self.assertNotIn("FAIL", report)
+        with self.assertRaisesRegex(AssertionError, "at least one measured row"):
+            GATE.render_report([], "test-arch", resolution="quick")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_perf_bench_gate_resolution.py
+++ b/tests/test_perf_bench_gate_resolution.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -59,7 +60,7 @@ class PerfBenchGateResolutionTests(unittest.TestCase):
                 self.assertIn("❌ FAIL", report)
                 self.assertNotIn("UNATTRIBUTABLE", report)
 
-    def test_clean_row_passes_at_both_resolutions_and_empty_refuses(self) -> None:
+    def test_clean_row_passes_at_both_resolutions(self) -> None:
         for resolution in ("quick", "full"):
             with self.subTest(resolution=resolution):
                 report = GATE.render_report(
@@ -68,8 +69,31 @@ class PerfBenchGateResolutionTests(unittest.TestCase):
                 self.assertIn("All 1 gated benches within noise band", report)
                 self.assertNotIn("WARN", report)
                 self.assertNotIn("FAIL", report)
-        with self.assertRaisesRegex(AssertionError, "at least one measured row"):
-            GATE.render_report([], "test-arch", resolution="quick")
+
+    def test_empty_results_refuse_with_and_without_optimization(self) -> None:
+        program = f"""
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location("perf_bench_gate", {str(GATE_PATH)!r})
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+module.render_report([], "test-arch", resolution="quick")
+"""
+        for flags in ([], ["-O"]):
+            with self.subTest(optimized=bool(flags)):
+                completed = subprocess.run(
+                    [sys.executable, *flags, "-c", program],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                self.assertNotEqual(completed.returncode, 0)
+                self.assertIn(
+                    "ValueError: classifier requires at least one measured row",
+                    completed.stderr,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- classify quick-resolution results in the 3.0–7.0% warn band as UNATTRIBUTABLE instead of WARN, because at that resolution the band is narrower than the run-to-run variance measured on byte-identical source
- preserve raw measurements while changing only the quick-resolution verdict label; full-resolution WARN behavior and the greater-than-7% FAIL threshold remain unchanged
- make empty report classification fail closed under optimized Python
- defensively pass the selected resolution through exit-code classification so it does not depend on the current ordering of verdict rules

The evidence for the relabel is a base-versus-base control on byte-identical source (`base_sha == head_sha`): 134 positive and 127 negative across 264 groups at a median of +0.01%, with per-group spread of 1.90pp standard deviation over a -6.07% to +9.55% range. Each quick-resolution run carries a coherent offset shared across its groups whose sign differs between runs, and Criterion computes its intervals within a single run, so a quick-resolution interval is narrower than the run-to-run spread it would need to bound in order for a warn-band row to mean anything. Applying the current thresholds to that control yields 10 would-be WARN rows on source that cannot differ.

**Correction to an earlier revision of this description.** An earlier revision justified the relabel by measurement arm order, stating that the arm measured second is the slower one whichever tree occupies it, and cited a count of warn rows by sign. Both are withdrawn. The count was true by construction, since the gate defines WARN as a confidence-interval lower bound above the warn threshold. The mechanism is refuted by the control above, which is two-sided, and by a forward run in the same session that landed negative at its gated median while the branch under test occupied the head arm. The relabel itself is unaffected: it turns on the band sitting inside the null spread, not on what produces the spread.

## Verification

- python3 -m unittest discover -s tests -p test_*.py -v — 635 passed, 3 skipped
- python3 tests/test_perf_bench_gate_resolution.py -v — 5 passed
- mutation control with the empty-input guard restored to a bare assert — the normal subprocess raised AssertionError and the optimized subprocess returned successfully, causing the new test to fail
- mutation control with the ValueError guard restored — both normal and optimized subprocesses refused empty input; 5 tests passed
- python3 -m py_compile scripts/perf-bench-gate.py tests/test_perf_bench_gate_resolution.py
- bash -n scripts/lib/bench-compare-impl.sh scripts/bench-compare.sh
- python3 scripts/perf-bench-gate.py --selftest
- git diff --check

## Bench-Compare Disposition

Not applicable. The diff touches only files under scripts/ and tests/; it does not touch crates/inference/, crates/embed/, or crates/fann/.

This change modifies the regression gate itself, so running that gate to certify its own change would measure the instrument with the instrument. The classifier tests, optimized-interpreter subprocess control, mutation proof, and gate self-test provide the relevant verification.

## Known limitation this change does not address

The relabel narrows what a quick-resolution warn row is allowed to claim, but it leaves the threshold values themselves unjustified. On the byte-identical control above, applying the gate's own rule produces 3 would-be FAIL rows, so the null distribution reaches past the >7% FAIL line on source that cannot differ. Those rows all fall on `lattice-embed:simd`, which quick mode reports informationally rather than gating, and the 17 gated groups stayed inside the 3% band with a maximum excursion of +2.38%. A clean gated verdict therefore currently rests on which groups sit in the gated set rather than on the numeric threshold. Two consequences follow, and they belong with the gate rather than with this PR: a threshold that carries its own justification would be cut from the null's upper quantile on the gated set with a stated false-positive rate, and any change to gated-set membership is a change to the instrument that needs the null re-run and the threshold re-derived before the new member gates anything.
