### PR TITLE
test(scripts): cover late staged write failure

### DIFF
--- a/scripts/bench_quality_selftest.sh
+++ b/scripts/bench_quality_selftest.sh
@@ -37,6 +37,16 @@ case "${EVAL_MODE:-ok}" in
     result="$(awk -F '\t' 'NR == 1 { print $2 }' "${MKTEMP_LOG:?}")"
     [[ -f "$result" ]] && chmod 0444 "$result"
     ;;
+  sink-fail-late)
+    if [[ " $* " == *" --quarot-q4-dir "* ]]; then
+      result="$(awk -F '\t' 'NR == 1 { print $2 }' "${MKTEMP_LOG:?}")"
+      if ! grep -qF $'lattice\tq4\t16.589166\t2048' "$result"; then
+        echo "late sink-failure injection did not observe the q4 row" >&2
+        exit 98
+      fi
+      chmod 0444 "$result"
+    fi
+    ;;
 esac
 if [[ " $* " == *" --quarot-q4-dir "* ]]; then
   echo "PPL:                19.007144"
@@ -235,6 +245,12 @@ check_failure_preserves "staged output write failure preserves canonical" 1 "$RC
 chmod u+w "$CANONICAL" 2>/dev/null || true
 
 cp "$EXPECTED" "$CANONICAL"
+run_bench EVAL_MODE=sink-fail-late
+RC=$?
+check_failure_preserves "late staged output write failure preserves canonical" 1 "$RC" "failed to write lattice/q4-quarot result"
+chmod u+w "$CANONICAL" 2>/dev/null || true
+
+cp "$EXPECTED" "$CANONICAL"
 run_bench
 SUCCESS_RC=$?
 CONTENT_OK=0
@@ -301,4 +317,4 @@ fi
 
 echo ""
 echo "=== $pass passed, $fail failed ==="
-[[ "$pass" -eq 8 && "$fail" -eq 0 ]]
+[[ "$pass" -eq 9 && "$fail" -eq 0 ]]


### PR DESCRIPTION
## What

Adds one self-test case to `scripts/bench_quality_selftest.sh` covering a staged-output write failure that occurs **late** in the run, after earlier rows have already been appended to the staged file.

## Why

The existing `staged output write failure preserves canonical` case makes the staged file unwritable before the first row is appended, so it exercises the guard at the first append site only. A write that starts failing partway through the run — the realistic disk-full and permission-change shapes — reaches a different append site, and no case covered it.

## Evidence

Self-test count goes 8 -> 9; the suite is green on this branch:

```
=== 9 passed, 0 failed ===
```

The new case is mutation-sensitive rather than decoration. Removing the write check from the late append site only:

```
  PASS: staged output write failure preserves canonical
  FAIL: late staged output write failure preserves canonical
=== 8 passed, 1 failed ===
```

The new case fails by name and the pre-existing write-failure case survives, which shows the two cases guard different append sites rather than the same one twice. The source file was restored byte-exact afterwards (`git status --porcelain` empty, HEAD unchanged) and the suite re-ran green.

## Bench disposition

No files under `crates/inference/`, `crates/embed/`, or `crates/fann/` are changed by this PR — the diff is confined to `scripts/bench_quality_selftest.sh`. No A/B is owed and none is claimed.
