### PR TITLE
fix(ci): validate filter execution structure

### DIFF
--- a/.github/workflows/app-binaries.yml
+++ b/.github/workflows/app-binaries.yml
@@ -100,7 +100,24 @@ jobs:
             echo "→ manual dispatch: app-binary and Swift builds REQUIRED"
             exit 0
           fi
-          CHANGED=$(./scripts/ci-changed-files.sh)
+          TRUSTED_DETECTOR=$(mktemp)
+          CHANGED_FILE=$(mktemp)
+          trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT
+          if git show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
+            :
+          else
+            DETECTOR_STATUS=$?
+            echo "::error::unable to load change detector from base revision (status $DETECTOR_STATUS)" >&2
+            exit "$DETECTOR_STATUS"
+          fi
+          if sh "$TRUSTED_DETECTOR" > "$CHANGED_FILE"; then
+            :
+          else
+            DETECTOR_STATUS=$?
+            echo "::error::change detector failed with status $DETECTOR_STATUS" >&2
+            exit "$DETECTOR_STATUS"
+          fi
+          CHANGED=$(<"$CHANGED_FILE")
           echo "Changed files:"
           echo "$CHANGED"
           # here-string, not `echo | grep -q`: -q exits at first match, echo gets
@@ -113,7 +130,7 @@ jobs:
             echo "bins=false" >> "$GITHUB_OUTPUT"
             echo "→ no app-binary change: build skipped, gate passes"
           fi
-          if grep -E '^apps/macos/|^\.github/workflows/(app-binaries|release-binaries)\.yml$|^tests/test_macos_app_release\.py$' <<<"$CHANGED" >/dev/null; then
+          if grep -E '^apps/macos/|^scripts/ci-changed-files\.sh$|^\.github/workflows/(app-binaries|release-binaries)\.yml$|^tests/test_macos_app_release\.py$' <<<"$CHANGED" >/dev/null; then
             echo "swift=true" >> "$GITHUB_OUTPUT"
             echo "→ macOS app surface changed: Swift release build REQUIRED"
           else

--- a/.github/workflows/app-binaries.yml
+++ b/.github/workflows/app-binaries.yml
@@ -92,6 +92,10 @@ jobs:
           CI_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
         run: |
           set -euo pipefail
+          # Manual dispatch and the all-zero base sentinel skip detector
+          # extraction because neither provides a usable comparison base.
+          # Both conservatively require all downstream app-binary and Swift
+          # work before the contract check runs.
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             echo "bins=true" >> "$GITHUB_OUTPUT"
             echo "swift=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/app-binaries.yml
+++ b/.github/workflows/app-binaries.yml
@@ -90,6 +90,7 @@ jobs:
         env:
           CI_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
           CI_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV PATH=/usr/bin:/bin /bin/bash --noprofile --norc -e -u -o pipefail {0}
         run: |
           set -euo pipefail
           # Manual dispatch and the all-zero base sentinel skip detector
@@ -115,14 +116,14 @@ jobs:
           TRUSTED_DETECTOR=$(mktemp)
           CHANGED_FILE=$(mktemp)
           trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT
-          if git --no-replace-objects show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
+          if /usr/bin/env -i PATH=/usr/bin:/bin /usr/bin/git --no-replace-objects show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
             :
           else
             DETECTOR_STATUS=$?
             echo "::error::unable to load change detector from base revision (status $DETECTOR_STATUS)" >&2
             exit "$DETECTOR_STATUS"
           fi
-          if sh "$TRUSTED_DETECTOR" > "$CHANGED_FILE"; then
+          if /usr/bin/env -i PATH=/usr/bin:/bin GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" CI_BASE_SHA="$CI_BASE_SHA" CI_HEAD_SHA="$CI_HEAD_SHA" /bin/sh "$TRUSTED_DETECTOR" > "$CHANGED_FILE"; then
             :
           else
             DETECTOR_STATUS=$?
@@ -212,7 +213,15 @@ jobs:
             echo "::error::change-detection did not succeed — failing closed."
             exit 1
           fi
-          if [ "$BINS" != "true" ] && [ "$SWIFT" != "true" ]; then
+          if [ "$BINS" != "true" ] && [ "$BINS" != "false" ]; then
+            echo "::error::bins selector output is missing or invalid (value=$BINS)."
+            exit 1
+          fi
+          if [ "$SWIFT" != "true" ] && [ "$SWIFT" != "false" ]; then
+            echo "::error::swift selector output is missing or invalid (value=$SWIFT)."
+            exit 1
+          fi
+          if [ "$BINS" = "false" ] && [ "$SWIFT" = "false" ]; then
             echo "No app-binary or Swift change — builds not required. PASS."
             exit 0
           fi

--- a/.github/workflows/app-binaries.yml
+++ b/.github/workflows/app-binaries.yml
@@ -100,6 +100,16 @@ jobs:
             echo "→ manual dispatch: app-binary and Swift builds REQUIRED"
             exit 0
           fi
+          if [[ ! "$CI_BASE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::base revision must be a nonempty 40-character hexadecimal commit ID" >&2
+            exit 2
+          fi
+          if [ "$CI_BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "bins=true" >> "$GITHUB_OUTPUT"
+            echo "swift=true" >> "$GITHUB_OUTPUT"
+            echo "→ all-zero base revision: app-binary and Swift builds REQUIRED"
+            exit 0
+          fi
           TRUSTED_DETECTOR=$(mktemp)
           CHANGED_FILE=$(mktemp)
           trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT

--- a/.github/workflows/app-binaries.yml
+++ b/.github/workflows/app-binaries.yml
@@ -86,8 +86,6 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - name: Verify macOS app release contract
-        run: python3 tests/test_macos_app_release.py -v
       - id: filter
         env:
           CI_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
@@ -113,7 +111,7 @@ jobs:
           TRUSTED_DETECTOR=$(mktemp)
           CHANGED_FILE=$(mktemp)
           trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT
-          if git show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
+          if git --no-replace-objects show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
             :
           else
             DETECTOR_STATUS=$?
@@ -147,6 +145,8 @@ jobs:
             echo "swift=false" >> "$GITHUB_OUTPUT"
             echo "→ no macOS app change: Swift release build skipped"
           fi
+      - name: Verify macOS app release contract
+        run: python3 tests/test_macos_app_release.py -v
 
   # Deferred while a PR is a draft, matching the macOS legs of `ci` and
   # `feature-matrix` and every macOS job in `e2e-parity`. A draft

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -74,6 +74,15 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ] || [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
+            if [[ ! "$CI_BASE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "::error::base revision must be a nonempty 40-character hexadecimal commit ID" >&2
+              exit 2
+            fi
+            if [ "$CI_BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+              echo "deps=true" >> "$GITHUB_OUTPUT"
+              echo "→ all-zero base revision: audit REQUIRED"
+              exit 0
+            fi
             TRUSTED_DETECTOR=$(mktemp)
             CHANGED_FILE=$(mktemp)
             trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -86,7 +86,7 @@ jobs:
             TRUSTED_DETECTOR=$(mktemp)
             CHANGED_FILE=$(mktemp)
             trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT
-            if git show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
+            if git --no-replace-objects show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
               :
             else
               DETECTOR_STATUS=$?

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -74,7 +74,24 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$GITHUB_EVENT_NAME" = "pull_request" ] || [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
-            CHANGED=$(./scripts/ci-changed-files.sh)
+            TRUSTED_DETECTOR=$(mktemp)
+            CHANGED_FILE=$(mktemp)
+            trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT
+            if git show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
+              :
+            else
+              DETECTOR_STATUS=$?
+              echo "::error::unable to load change detector from base revision (status $DETECTOR_STATUS)" >&2
+              exit "$DETECTOR_STATUS"
+            fi
+            if sh "$TRUSTED_DETECTOR" > "$CHANGED_FILE"; then
+              :
+            else
+              DETECTOR_STATUS=$?
+              echo "::error::change detector failed with status $DETECTOR_STATUS" >&2
+              exit "$DETECTOR_STATUS"
+            fi
+            CHANGED=$(<"$CHANGED_FILE")
             echo "Changed files:"
             echo "$CHANGED"
             # Two single greps against a here-string, not a `grep | grep -q`

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -71,56 +71,56 @@ jobs:
         env:
           CI_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
           CI_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV PATH=/usr/bin:/bin /bin/bash --noprofile --norc -e -u -o pipefail {0}
         run: |
           set -euo pipefail
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] || [ "$GITHUB_EVENT_NAME" = "merge_group" ]; then
-            if [[ ! "$CI_BASE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
-              echo "::error::base revision must be a nonempty 40-character hexadecimal commit ID" >&2
-              exit 2
-            fi
-            if [ "$CI_BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
-              echo "deps=true" >> "$GITHUB_OUTPUT"
-              echo "→ all-zero base revision: audit REQUIRED"
-              exit 0
-            fi
-            TRUSTED_DETECTOR=$(mktemp)
-            CHANGED_FILE=$(mktemp)
-            trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT
-            if git --no-replace-objects show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
-              :
-            else
-              DETECTOR_STATUS=$?
-              echo "::error::unable to load change detector from base revision (status $DETECTOR_STATUS)" >&2
-              exit "$DETECTOR_STATUS"
-            fi
-            if sh "$TRUSTED_DETECTOR" > "$CHANGED_FILE"; then
-              :
-            else
-              DETECTOR_STATUS=$?
-              echo "::error::change detector failed with status $DETECTOR_STATUS" >&2
-              exit "$DETECTOR_STATUS"
-            fi
-            CHANGED=$(<"$CHANGED_FILE")
-            echo "Changed files:"
-            echo "$CHANGED"
-            # Two single greps against a here-string, not a `grep | grep -q`
-            # pipe: a downstream `-q` can close its end of a pipe early and
-            # SIGPIPE the upstream producer, which under `pipefail` reports
-            # as the pipeline's exit code instead of the match result
-            # (fail-open on a large diff) — see the matching comment in
-            # ci.yml's `changes` job.
-            MATCH=$(grep -E '(^Cargo\.lock$|^Cargo\.toml$|^crates/.*/Cargo\.toml$|^npm/lattice-embed-native/Cargo\.toml$|^\.cargo/audit\.toml$|^scripts/ci-changed-files\.sh$|^\.github/workflows/cargo-audit\.yml$)' <<<"$CHANGED" || true)
-            if grep -q . <<<"$MATCH"; then
-              echo "deps=true" >> "$GITHUB_OUTPUT"
-              echo "→ dependency-relevant change: audit REQUIRED"
-            else
-              echo "deps=false" >> "$GITHUB_OUTPUT"
-              echo "→ no dependency-relevant change: audit work skipped"
-            fi
-          else
-            # schedule / workflow_dispatch: no event diff to gate on, always audit.
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ] || [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
             echo "deps=true" >> "$GITHUB_OUTPUT"
-            echo "→ non-diff trigger (${{ github.event_name }}): audit REQUIRED"
+            echo "→ non-diff trigger ($GITHUB_EVENT_NAME): audit REQUIRED"
+            exit 0
+          fi
+          if [[ ! "$CI_BASE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::base revision must be a nonempty 40-character hexadecimal commit ID" >&2
+            exit 2
+          fi
+          if [ "$CI_BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "deps=true" >> "$GITHUB_OUTPUT"
+            echo "→ all-zero base revision: audit REQUIRED"
+            exit 0
+          fi
+          TRUSTED_DETECTOR=$(mktemp)
+          CHANGED_FILE=$(mktemp)
+          trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT
+          if /usr/bin/env -i PATH=/usr/bin:/bin /usr/bin/git --no-replace-objects show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
+            :
+          else
+            DETECTOR_STATUS=$?
+            echo "::error::unable to load change detector from base revision (status $DETECTOR_STATUS)" >&2
+            exit "$DETECTOR_STATUS"
+          fi
+          if /usr/bin/env -i PATH=/usr/bin:/bin GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" CI_BASE_SHA="$CI_BASE_SHA" CI_HEAD_SHA="$CI_HEAD_SHA" /bin/sh "$TRUSTED_DETECTOR" > "$CHANGED_FILE"; then
+            :
+          else
+            DETECTOR_STATUS=$?
+            echo "::error::change detector failed with status $DETECTOR_STATUS" >&2
+            exit "$DETECTOR_STATUS"
+          fi
+          CHANGED=$(<"$CHANGED_FILE")
+          echo "Changed files:"
+          echo "$CHANGED"
+          # Two single greps against a here-string, not a `grep | grep -q`
+          # pipe: a downstream `-q` can close its end of a pipe early and
+          # SIGPIPE the upstream producer, which under `pipefail` reports
+          # as the pipeline's exit code instead of the match result
+          # (fail-open on a large diff) — see the matching comment in
+          # ci.yml's `changes` job.
+          MATCH=$(grep -E '(^Cargo\.lock$|^Cargo\.toml$|^crates/.*/Cargo\.toml$|^npm/lattice-embed-native/Cargo\.toml$|^\.cargo/audit\.toml$|^scripts/ci-changed-files\.sh$|^\.github/workflows/cargo-audit\.yml$)' <<<"$CHANGED" || true)
+          if grep -q . <<<"$MATCH"; then
+            echo "deps=true" >> "$GITHUB_OUTPUT"
+            echo "→ dependency-relevant change: audit REQUIRED"
+          else
+            echo "deps=false" >> "$GITHUB_OUTPUT"
+            echo "→ no dependency-relevant change: audit work skipped"
           fi
 
   audit:
@@ -198,7 +198,11 @@ jobs:
             echo "::error::change-detection did not succeed, failing closed."
             exit 1
           fi
-          if [ "$DEPS" != "true" ]; then
+          if [ "$DEPS" != "true" ] && [ "$DEPS" != "false" ]; then
+            echo "::error::deps selector output is missing or invalid (value=$DEPS)."
+            exit 1
+          fi
+          if [ "$DEPS" = "false" ]; then
             echo "No dependency-relevant change, audit jobs not required. PASS."
             exit 0
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           TRUSTED_DETECTOR=$(mktemp)
           CHANGED_FILE=$(mktemp)
           trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT
-          if git show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
+          if git --no-replace-objects show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
             :
           else
             DETECTOR_STATUS=$?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,15 @@ jobs:
           CI_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
         run: |
           set -euo pipefail
+          if [[ ! "$CI_BASE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::base revision must be a nonempty 40-character hexadecimal commit ID" >&2
+            exit 2
+          fi
+          if [ "$CI_BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "→ all-zero base revision: full matrix REQUIRED"
+            exit 0
+          fi
           TRUSTED_DETECTOR=$(mktemp)
           CHANGED_FILE=$(mktemp)
           trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,24 @@ jobs:
           CI_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
         run: |
           set -euo pipefail
-          CHANGED=$(./scripts/ci-changed-files.sh)
+          TRUSTED_DETECTOR=$(mktemp)
+          CHANGED_FILE=$(mktemp)
+          trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT
+          if git show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
+            :
+          else
+            DETECTOR_STATUS=$?
+            echo "::error::unable to load change detector from base revision (status $DETECTOR_STATUS)" >&2
+            exit "$DETECTOR_STATUS"
+          fi
+          if sh "$TRUSTED_DETECTOR" > "$CHANGED_FILE"; then
+            :
+          else
+            DETECTOR_STATUS=$?
+            echo "::error::change detector failed with status $DETECTOR_STATUS" >&2
+            exit "$DETECTOR_STATUS"
+          fi
+          CHANGED=$(<"$CHANGED_FILE")
           echo "Changed files:"
           echo "$CHANGED"
           # Non-Rust set: **/*.md, docs/**, LICENSE*, .gitignore, and the
@@ -102,13 +119,16 @@ jobs:
           # apps/macos and a Rust path still leaves the Rust file in NON_DOCS
           # below, so code=true and the full matrix runs.
           #
-          # Two single greps against here-strings, not a `grep | grep -q` pipe:
+          # Keep the detector's self-relevance explicit instead of relying on
+          # its membership in the generic non-docs bucket below.
+          DETECTOR_CHANGED=$(grep -E '^scripts/ci-changed-files\.sh$' <<<"$CHANGED" || true)
+          NON_DOCS=$(grep -vE '(\.md$|^docs/|^LICENSE|^\.gitignore$|^apps/macos/|^scripts/ci-changed-files\.sh$)' <<<"$CHANGED" || true)
+          # Single greps against here-strings, not a `grep | grep -q` pipe:
           # a downstream `-q` can close its end of a pipe early and SIGPIPE the
           # upstream producer, and under `pipefail` that reports as the
           # pipeline's exit code instead of the match result (fail-open on a
           # large diff).
-          NON_DOCS=$(grep -vE '(\.md$|^docs/|^LICENSE|^\.gitignore$|^apps/macos/)' <<<"$CHANGED" || true)
-          if grep -q . <<<"$NON_DOCS"; then
+          if [ -n "$DETECTOR_CHANGED" ] || grep -q . <<<"$NON_DOCS"; then
             echo "code=true" >> "$GITHUB_OUTPUT"
             echo "→ non-docs files changed: full matrix REQUIRED"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -675,9 +675,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
       - uses: raven-actions/actionlint@3d39aea434753780c3b3d4a1a31c854b4dbf49d7 # v2.2.0
         with:
           version: '1.7.12'
+      - name: Install workflow parser
+        run: python3 -m pip install "PyYAML==6.0.3"
       - name: merge-queue config tests
         run: python3 tests/test_ci_changed_files.py -v
       - name: post-merge benchmark progression tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
         env:
           CI_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
           CI_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV PATH=/usr/bin:/bin /bin/bash --noprofile --norc -e -u -o pipefail {0}
         run: |
           set -euo pipefail
           if [[ ! "$CI_BASE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
@@ -97,14 +98,14 @@ jobs:
           TRUSTED_DETECTOR=$(mktemp)
           CHANGED_FILE=$(mktemp)
           trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT
-          if git --no-replace-objects show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
+          if /usr/bin/env -i PATH=/usr/bin:/bin /usr/bin/git --no-replace-objects show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
             :
           else
             DETECTOR_STATUS=$?
             echo "::error::unable to load change detector from base revision (status $DETECTOR_STATUS)" >&2
             exit "$DETECTOR_STATUS"
           fi
-          if sh "$TRUSTED_DETECTOR" > "$CHANGED_FILE"; then
+          if /usr/bin/env -i PATH=/usr/bin:/bin GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" CI_BASE_SHA="$CI_BASE_SHA" CI_HEAD_SHA="$CI_HEAD_SHA" /bin/sh "$TRUSTED_DETECTOR" > "$CHANGED_FILE"; then
             :
           else
             DETECTOR_STATUS=$?
@@ -830,7 +831,11 @@ jobs:
             echo "::error::decode-harness-unit-tests did not succeed (result=$DECODE_HARNESS_RESULT)."
             exit 1
           fi
-          if [ "$CODE" != "true" ]; then
+          if [ "$CODE" != "true" ] && [ "$CODE" != "false" ]; then
+            echo "::error::code selector output is missing or invalid (value=$CODE)."
+            exit 1
+          fi
+          if [ "$CODE" = "false" ]; then
             echo "Docs-only change, heavy compile jobs not required. PASS."
             exit 0
           fi

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -86,6 +86,16 @@ jobs:
             echo "→ $GITHUB_EVENT_NAME trigger: full parity suite REQUIRED"
             exit 0
           fi
+          if [[ ! "$CI_BASE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::base revision must be a nonempty 40-character hexadecimal commit ID" >&2
+            exit 2
+          fi
+          if [ "$CI_BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            echo "engine=true" >> "$GITHUB_OUTPUT"
+            echo "tune=true" >> "$GITHUB_OUTPUT"
+            echo "→ all-zero base revision: full parity suite REQUIRED"
+            exit 0
+          fi
           TRUSTED_DETECTOR=$(mktemp)
           CHANGED_FILE=$(mktemp)
           trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -86,7 +86,24 @@ jobs:
             echo "→ $GITHUB_EVENT_NAME trigger: full parity suite REQUIRED"
             exit 0
           fi
-          CHANGED=$(./scripts/ci-changed-files.sh)
+          TRUSTED_DETECTOR=$(mktemp)
+          CHANGED_FILE=$(mktemp)
+          trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT
+          if git show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
+            :
+          else
+            DETECTOR_STATUS=$?
+            echo "::error::unable to load change detector from base revision (status $DETECTOR_STATUS)" >&2
+            exit "$DETECTOR_STATUS"
+          fi
+          if sh "$TRUSTED_DETECTOR" > "$CHANGED_FILE"; then
+            :
+          else
+            DETECTOR_STATUS=$?
+            echo "::error::change detector failed with status $DETECTOR_STATUS" >&2
+            exit "$DETECTOR_STATUS"
+          fi
+          CHANGED=$(<"$CHANGED_FILE")
           echo "Changed files:"
           echo "$CHANGED"
           # Markdown is stripped BEFORE classification, and the reason is that
@@ -140,7 +157,7 @@ jobs:
             echo "engine=false" >> "$GITHUB_OUTPUT"
             echo "→ no engine change: parity not required"
           fi
-          if grep -E '^crates/tune/(src|tests)/|^crates/tune/Cargo\.toml$|^Cargo\.lock$|^\.github/workflows/e2e-parity\.yml$|^\.github/actions/provision-qwen35-0-8b/' <<<"$CHANGED" >/dev/null; then
+          if grep -E '^crates/tune/(src|tests)/|^crates/tune/Cargo\.toml$|^Cargo\.lock$|^scripts/ci-changed-files\.sh$|^\.github/workflows/e2e-parity\.yml$|^\.github/actions/provision-qwen35-0-8b/' <<<"$CHANGED" >/dev/null; then
             echo "tune=true" >> "$GITHUB_OUTPUT"
             echo "→ tune training surface changed: layer-23 golden REQUIRED"
           else

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -99,7 +99,7 @@ jobs:
           TRUSTED_DETECTOR=$(mktemp)
           CHANGED_FILE=$(mktemp)
           trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT
-          if git show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
+          if git --no-replace-objects show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
             :
           else
             DETECTOR_STATUS=$?

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -78,6 +78,7 @@ jobs:
         env:
           CI_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
           CI_HEAD_SHA: ${{ github.event.merge_group.head_sha || github.sha }}
+        shell: /usr/bin/env -u BASH_ENV -u ENV PATH=/usr/bin:/bin /bin/bash --noprofile --norc -e -u -o pipefail {0}
         run: |
           set -euo pipefail
           if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
@@ -99,14 +100,14 @@ jobs:
           TRUSTED_DETECTOR=$(mktemp)
           CHANGED_FILE=$(mktemp)
           trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT
-          if git --no-replace-objects show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
+          if /usr/bin/env -i PATH=/usr/bin:/bin /usr/bin/git --no-replace-objects show "${CI_BASE_SHA}:scripts/ci-changed-files.sh" > "$TRUSTED_DETECTOR"; then
             :
           else
             DETECTOR_STATUS=$?
             echo "::error::unable to load change detector from base revision (status $DETECTOR_STATUS)" >&2
             exit "$DETECTOR_STATUS"
           fi
-          if sh "$TRUSTED_DETECTOR" > "$CHANGED_FILE"; then
+          if /usr/bin/env -i PATH=/usr/bin:/bin GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" CI_BASE_SHA="$CI_BASE_SHA" CI_HEAD_SHA="$CI_HEAD_SHA" /bin/sh "$TRUSTED_DETECTOR" > "$CHANGED_FILE"; then
             :
           else
             DETECTOR_STATUS=$?
@@ -1246,6 +1247,14 @@ jobs:
             echo "::error::change-detection did not succeed — failing closed."
             exit 1
           fi
+          if [ "$ENGINE" != "true" ] && [ "$ENGINE" != "false" ]; then
+            echo "::error::engine selector output is missing or invalid (value=$ENGINE)."
+            exit 1
+          fi
+          if [ "$TUNE" != "true" ] && [ "$TUNE" != "false" ]; then
+            echo "::error::tune selector output is missing or invalid (value=$TUNE)."
+            exit 1
+          fi
           # Drafts skip the resource-intensive parity jobs to keep hosted runner
           # capacity available to PRs that are ready to merge. Those skips reach
           # the arm checks below as result=skipped, which is correctly not "success",
@@ -1260,7 +1269,7 @@ jobs:
             echo "::error::Tune training surface changed and the layer-23 golden bridge did not succeed (result=$LAYER23_RESULT)."
             exit 1
           fi
-          if [ "$ENGINE" != "true" ]; then
+          if [ "$ENGINE" = "false" ]; then
             echo "No engine change — parity not required. PASS."
             exit 0
           fi

--- a/scripts/ci-changed-files.sh
+++ b/scripts/ci-changed-files.sh
@@ -44,6 +44,12 @@ else
         exit 1
     fi
 
+    resolved_base=$(git rev-parse "${base_sha}^{commit}")
+    if [ "$resolved_base" = "$actual_head" ]; then
+        echo "event base $base_sha and event head $head_sha resolve to the same commit; refusing degenerate range" >&2
+        exit 1
+    fi
+
     if ! git merge-base --is-ancestor "$base_sha" "$head_sha"; then
         echo "event base $base_sha is not an ancestor of event head $head_sha" >&2
         exit 1

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -25,67 +25,132 @@ _E2E_PARITY_WORKFLOW = _ROOT / ".github/workflows/e2e-parity.yml"
 _CI_WORKFLOW = _ROOT / ".github/workflows/ci.yml"
 _CARGO_AUDIT_WORKFLOW = _ROOT / ".github/workflows/cargo-audit.yml"
 _APP_BINARIES_WORKFLOW = _ROOT / ".github/workflows/app-binaries.yml"
+_DETECTOR_EVENTS = ("pull_request", "merge_group")
+_FILTER_SHELL_COMMAND = (
+    "/usr/bin/env",
+    "-u",
+    "BASH_ENV",
+    "-u",
+    "ENV",
+    "PATH=/usr/bin:/bin",
+    "/bin/bash",
+    "--noprofile",
+    "--norc",
+    "-e",
+    "-u",
+    "-o",
+    "pipefail",
+)
+_TRUSTED_FILTER_SHELL = " ".join((*_FILTER_SHELL_COMMAND, "{0}"))
 _DETECTOR_LOAD = re.compile(
-    r'^[ \t]*if git(?: --no-replace-objects)? show '
+    r"^if /usr/bin/env -i PATH=/usr/bin:/bin /usr/bin/git "
+    r"--no-replace-objects(?: -c core\.quotePath=false)? show "
     r'"\$\{CI_BASE_SHA\}:scripts/ci-changed-files\.sh" '
     r'> "\$TRUSTED_DETECTOR"; then$',
     re.MULTILINE,
 )
-_SAFE_FILTER_PROLOGUE_PRIMITIVES = (
-    ("strict shell options", re.compile(r"set -euo pipefail")),
+_TRUSTED_DETECTOR_EXECUTION = (
+    "/usr/bin/env -i PATH=/usr/bin:/bin "
+    'GITHUB_EVENT_NAME="$GITHUB_EVENT_NAME" '
+    'CI_BASE_SHA="$CI_BASE_SHA" CI_HEAD_SHA="$CI_HEAD_SHA" '
+    '/bin/sh "$TRUSTED_DETECTOR"'
+)
+_BASE_FORMAT_BLOCK = (
+    'if [[ ! "$CI_BASE_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then',
+    'echo "::error::base revision must be a nonempty '
+    '40-character hexadecimal commit ID" >&2',
+    "exit 2",
+    "fi",
+)
+_TEMPORARY_FILE_BLOCK = (
+    "TRUSTED_DETECTOR=$(mktemp)",
+    "CHANGED_FILE=$(mktemp)",
+    '''trap 'rm -f "$TRUSTED_DETECTOR" "$CHANGED_FILE"' EXIT''',
+)
+_EXPECTED_FILTER_PROLOGUES = {
+    ".github/workflows/ci.yml": (
+        "set -euo pipefail",
+        *_BASE_FORMAT_BLOCK,
+        f'if [ "$CI_BASE_SHA" = "{_ZERO_SHA}" ]; then',
+        'echo "code=true" >> "$GITHUB_OUTPUT"',
+        'echo "→ all-zero base revision: full matrix REQUIRED"',
+        "exit 0",
+        "fi",
+        *_TEMPORARY_FILE_BLOCK,
+    ),
+    ".github/workflows/cargo-audit.yml": (
+        "set -euo pipefail",
+        'if [ "$GITHUB_EVENT_NAME" = "schedule" ] || '
+        '[ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then',
+        'echo "deps=true" >> "$GITHUB_OUTPUT"',
+        'echo "→ non-diff trigger ($GITHUB_EVENT_NAME): audit REQUIRED"',
+        "exit 0",
+        "fi",
+        *_BASE_FORMAT_BLOCK,
+        f'if [ "$CI_BASE_SHA" = "{_ZERO_SHA}" ]; then',
+        'echo "deps=true" >> "$GITHUB_OUTPUT"',
+        'echo "→ all-zero base revision: audit REQUIRED"',
+        "exit 0",
+        "fi",
+        *_TEMPORARY_FILE_BLOCK,
+    ),
+    ".github/workflows/app-binaries.yml": (
+        "set -euo pipefail",
+        'if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then',
+        'echo "bins=true" >> "$GITHUB_OUTPUT"',
+        'echo "swift=true" >> "$GITHUB_OUTPUT"',
+        'echo "→ manual dispatch: app-binary and Swift builds REQUIRED"',
+        "exit 0",
+        "fi",
+        *_BASE_FORMAT_BLOCK,
+        f'if [ "$CI_BASE_SHA" = "{_ZERO_SHA}" ]; then',
+        'echo "bins=true" >> "$GITHUB_OUTPUT"',
+        'echo "swift=true" >> "$GITHUB_OUTPUT"',
+        'echo "→ all-zero base revision: app-binary and Swift builds REQUIRED"',
+        "exit 0",
+        "fi",
+        *_TEMPORARY_FILE_BLOCK,
+    ),
+    ".github/workflows/e2e-parity.yml": (
+        "set -euo pipefail",
+        'if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] || '
+        '[ "$GITHUB_EVENT_NAME" = "schedule" ]; then',
+        'echo "engine=true" >> "$GITHUB_OUTPUT"',
+        'echo "tune=true" >> "$GITHUB_OUTPUT"',
+        'echo "→ $GITHUB_EVENT_NAME trigger: full parity suite REQUIRED"',
+        "exit 0",
+        "fi",
+        *_BASE_FORMAT_BLOCK,
+        f'if [ "$CI_BASE_SHA" = "{_ZERO_SHA}" ]; then',
+        'echo "engine=true" >> "$GITHUB_OUTPUT"',
+        'echo "tune=true" >> "$GITHUB_OUTPUT"',
+        'echo "→ all-zero base revision: full parity suite REQUIRED"',
+        "exit 0",
+        "fi",
+        *_TEMPORARY_FILE_BLOCK,
+    ),
+}
+_EXPECTED_WORKFLOW_ENV_KEYS = {
+    ".github/workflows/ci.yml": ("CARGO_TERM_COLOR", "LATTICE_REQUIRE_FIXTURES"),
+    ".github/workflows/cargo-audit.yml": ("CARGO_TERM_COLOR",),
+    ".github/workflows/app-binaries.yml": (
+        "CARGO_TERM_COLOR",
+        "CARGO_INCREMENTAL",
+    ),
+    ".github/workflows/e2e-parity.yml": (
+        "CARGO_TERM_COLOR",
+        "CARGO_INCREMENTAL",
+    ),
+}
+_EXPECTED_FILTER_ENVIRONMENT = (
     (
-        "event policy condition",
-        re.compile(
-            r'if \[ "\$GITHUB_EVENT_NAME" = "(?:pull_request|workflow_dispatch)" \]'
-            r'(?: \|\| \[ "\$GITHUB_EVENT_NAME" = "(?:merge_group|schedule)" \])?; then'
-        ),
+        "CI_BASE_SHA",
+        "${{ github.event.pull_request.base.sha || "
+        "github.event.merge_group.base_sha || github.event.before }}",
     ),
     (
-        "base format condition",
-        re.compile(
-            r'if \[\[ ! "\$CI_BASE_SHA" =~ \^\[0-9a-fA-F\]\{40\}\$ \]\]; then'
-        ),
-    ),
-    (
-        "all-zero base condition",
-        re.compile(r'if \[ "\$CI_BASE_SHA" = "0{40}" \]; then'),
-    ),
-    (
-        "selector output",
-        re.compile(
-            r'echo "(?:code|deps|bins|swift|engine|tune)=true" '
-            r'>> "\$GITHUB_OUTPUT"'
-        ),
-    ),
-    (
-        "base validation diagnostic",
-        re.compile(
-            r'echo "::error::base revision must be a nonempty '
-            r'40-character hexadecimal commit ID" >&2'
-        ),
-    ),
-    (
-        "selection diagnostic",
-        re.compile(
-            r'echo "→ (?:'
-            r'all-zero base revision: '
-            r'(?:full matrix|audit|app-binary and Swift builds|full parity suite) '
-            r'REQUIRED'
-            r'|manual dispatch: app-binary and Swift builds REQUIRED'
-            r'|\$GITHUB_EVENT_NAME trigger: full parity suite REQUIRED)"'
-        ),
-    ),
-    ("early exit", re.compile(r"exit [02]")),
-    ("conditional terminator", re.compile(r"fi")),
-    (
-        "temporary-file allocation",
-        re.compile(r"(?:TRUSTED_DETECTOR|CHANGED_FILE)=\$\(mktemp\)"),
-    ),
-    (
-        "temporary-file cleanup",
-        re.compile(
-            r'''trap 'rm -f "\$TRUSTED_DETECTOR" "\$CHANGED_FILE"' EXIT'''
-        ),
+        "CI_HEAD_SHA",
+        "${{ github.event.merge_group.head_sha || github.sha }}",
     ),
 )
 
@@ -137,38 +202,265 @@ def _workflow_step_by_id(job: str, step_id: str) -> str:
     return job[start:end]
 
 
-def _workflow_run_script(workflow: Path, job_id: str, step_id: str) -> str:
-    contents = workflow.read_text(encoding="utf-8")
+def _workflow_run_script_from_contents(
+    contents: str,
+    job_id: str,
+    step_id: str,
+) -> str:
     step = _workflow_step_by_id(_workflow_job(contents, job_id), step_id)
     marker = "        run: |\n"
     if marker not in step:
         raise AssertionError(f"workflow step id {step_id!r} has no run script")
-    return textwrap.dedent(step.split(marker, maxsplit=1)[1])
+    run_lines = []
+    for line in step.split(marker, maxsplit=1)[1].splitlines(keepends=True):
+        if line.strip() and not line.startswith("          "):
+            break
+        run_lines.append(line)
+    return textwrap.dedent("".join(run_lines))
 
 
-def _assert_safe_filter_prologue(script: str, workflow: str) -> set[str]:
-    """Reject every undeclared executable statement before detector loading."""
+def _workflow_run_script(workflow: Path, job_id: str, step_id: str) -> str:
+    contents = workflow.read_text(encoding="utf-8")
+    return _workflow_run_script_from_contents(contents, job_id, step_id)
+
+
+def _workflow_contract_key(workflow: str) -> str:
+    matches = tuple(
+        path
+        for path in _REQUIRED_WORKFLOWS
+        if workflow == path or workflow == Path(path).name
+    )
+    if len(matches) != 1:
+        raise AssertionError(f"no unique filter contract for {workflow!r}")
+    return matches[0]
+
+
+def _yaml_direct_mapping(
+    contents: str,
+    indentation: int,
+    key: str,
+) -> tuple[tuple[str, str], ...]:
+    prefix = " " * indentation
+    header = re.search(
+        rf"^{re.escape(prefix)}{re.escape(key)}:\s*$",
+        contents,
+        re.MULTILINE,
+    )
+    if header is None:
+        return ()
+    entries = []
+    for raw_line in contents[header.end() :].splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        line_indentation = len(raw_line) - len(raw_line.lstrip(" "))
+        if line_indentation <= indentation:
+            break
+        if line_indentation != indentation + 2:
+            continue
+        entry_prefix = " " * (indentation + 2)
+        entry = re.fullmatch(
+            rf"{re.escape(entry_prefix)}([A-Za-z_][A-Za-z0-9_]*):\s*(.*)",
+            raw_line,
+        )
+        if entry is None:
+            raise AssertionError(f"{key} contains a non-scalar mapping entry")
+        entries.append((entry.group(1), entry.group(2)))
+    return tuple(entries)
+
+
+def _yaml_direct_keys(contents: str, indentation: int) -> tuple[str, ...]:
+    prefix = " " * indentation
+    keys = []
+    for raw_line in contents.splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        line_indentation = len(raw_line) - len(raw_line.lstrip(" "))
+        if line_indentation != indentation:
+            continue
+        match = re.match(
+            rf"{re.escape(prefix)}([^ \t:#][^:\n]*):",
+            raw_line,
+        )
+        if match is not None:
+            keys.append(match.group(1).strip("'\""))
+    return tuple(keys)
+
+
+def _assert_filter_execution_envelope(contents: str, workflow: str) -> None:
+    contract_key = _workflow_contract_key(workflow)
+    workflow_keys = _yaml_direct_keys(contents, 0)
+    if "defaults" in workflow_keys:
+        raise AssertionError(f"{workflow} has workflow defaults reaching filter step")
+    if "<<" in workflow_keys:
+        raise AssertionError(f"{workflow} has an unknown workflow execution merge")
+
+    job = _workflow_job(contents, "changes")
+    job_keys = _yaml_direct_keys(job, 4)
+    if "defaults" in job_keys:
+        raise AssertionError(f"{workflow} has job defaults reaching filter step")
+    if "<<" in job_keys:
+        raise AssertionError(f"{workflow} has an unknown job execution merge")
+    if _yaml_direct_mapping(job, 4, "env"):
+        raise AssertionError(f"{workflow} has job environment reaching filter step")
+
+    workflow_environment = _yaml_direct_mapping(contents, 0, "env")
+    workflow_environment_keys = tuple(key for key, _ in workflow_environment)
+    if workflow_environment_keys != _EXPECTED_WORKFLOW_ENV_KEYS[contract_key]:
+        raise AssertionError(
+            f"{workflow} workflow environment keys must be exactly "
+            f"{_EXPECTED_WORKFLOW_ENV_KEYS[contract_key]!r}, found "
+            f"{workflow_environment_keys!r}"
+        )
+
+    step = _workflow_step_by_id(job, "filter")
+    metadata_keys = ("id", *_yaml_direct_keys(step, 8))
+    expected_metadata_keys = ("id", "env", "shell", "run")
+    if metadata_keys != expected_metadata_keys:
+        raise AssertionError(
+            f"{workflow} filter step metadata keys must be exactly "
+            f"{expected_metadata_keys!r}, found {metadata_keys!r}"
+        )
+
+    step_environment = _yaml_direct_mapping(step, 8, "env")
+    if step_environment != _EXPECTED_FILTER_ENVIRONMENT:
+        raise AssertionError(
+            f"{workflow} filter environment must be exactly "
+            f"{_EXPECTED_FILTER_ENVIRONMENT!r}, found {step_environment!r}"
+        )
+
+    shell_lines = re.findall(r"^        shell:\s*(.*)$", step, re.MULTILINE)
+    if shell_lines != [_TRUSTED_FILTER_SHELL]:
+        raise AssertionError(
+            f"{workflow} filter shell command must be {_TRUSTED_FILTER_SHELL!r}"
+        )
+
+
+def _assert_safe_filter_prologue(script: str, workflow: str) -> tuple[str, ...]:
+    """Require the declared ordered grammar before a top-level detector load."""
     detector_load = _DETECTOR_LOAD.search(script)
     if detector_load is None:
-        raise AssertionError(f"{workflow} does not load the base detector")
+        raise AssertionError(
+            f"{workflow} does not load the base detector with the trusted "
+            "/usr/bin/env and /usr/bin/git form; use the declared load shape"
+        )
     prefix = script[: detector_load.start()]
-    used_primitives = set()
-    for line_number, raw_line in enumerate(prefix.splitlines(), start=1):
+    statements = []
+    conditional_depth = 0
+    for raw_line in prefix.splitlines():
         statement = raw_line.strip()
         if not statement or statement.startswith("#"):
             continue
-        matches = tuple(
-            name
-            for name, pattern in _SAFE_FILTER_PROLOGUE_PRIMITIVES
-            if pattern.fullmatch(statement) is not None
+        statements.append(statement)
+        if statement.startswith("if ") and statement.endswith("; then"):
+            conditional_depth += 1
+        elif statement == "fi":
+            if conditional_depth == 0:
+                raise AssertionError(
+                    f"{workflow} has an unbalanced conditional terminator "
+                    "before detector loading"
+                )
+            conditional_depth -= 1
+
+    if conditional_depth != 0:
+        raise AssertionError(
+            f"{workflow} must load the base detector at top level; "
+            f"conditional nesting depth is {conditional_depth}"
         )
-        if len(matches) != 1:
-            raise AssertionError(
-                f"{workflow} has an undeclared statement before detector "
-                f"loading on line {line_number}: {statement!r}"
-            )
-        used_primitives.add(matches[0])
-    return used_primitives
+
+    contract_key = _workflow_contract_key(workflow)
+    expected = _EXPECTED_FILTER_PROLOGUES[contract_key]
+    actual = tuple(statements)
+    if actual != expected:
+        mismatch = next(
+            (
+                index
+                for index in range(max(len(actual), len(expected)))
+                if index >= len(actual)
+                or index >= len(expected)
+                or actual[index] != expected[index]
+            ),
+            0,
+        )
+        found = "<missing>" if mismatch >= len(actual) else repr(actual[mismatch])
+        required = (
+            "<end>" if mismatch >= len(expected) else repr(expected[mismatch])
+        )
+        raise AssertionError(
+            f"{workflow} violates the ordered grammar before detector loading "
+            f"at statement {mismatch + 1}: expected {required}, found {found}"
+        )
+
+    detector_line = detector_load.group(0)
+    if detector_line.startswith((" ", "\t")):
+        raise AssertionError(
+            f"{workflow} must load the base detector at top level without "
+            "indentation"
+        )
+    return actual
+
+
+def _assert_trusted_detector_execution(script: str, workflow: str) -> None:
+    trusted_execution = (
+        f'if {_TRUSTED_DETECTOR_EXECUTION} > "$CHANGED_FILE"; then'
+    )
+    if script.splitlines().count(trusted_execution) != 1:
+        raise AssertionError(
+            f"{workflow} must execute the trusted detector once with a clean "
+            "environment and absolute shell"
+        )
+
+
+def _assert_safe_filter_workflow(contents: str, workflow: str) -> None:
+    _assert_filter_execution_envelope(contents, workflow)
+    script = _workflow_run_script_from_contents(contents, "changes", "filter")
+    _assert_safe_filter_prologue(script, workflow)
+    _assert_trusted_detector_execution(script, workflow)
+
+
+def _run_required_gate(
+    workflow: Path,
+    gate_id: str,
+    selector_values: dict[str, str],
+) -> subprocess.CompletedProcess[str]:
+    contents = workflow.read_text(encoding="utf-8")
+    step = _workflow_step(_workflow_job(contents, gate_id), "Resolve gate")
+    marker = "        run: |\n"
+    if marker not in step:
+        raise AssertionError(f"workflow gate {gate_id!r} has no run script")
+    script = textwrap.dedent(step.split(marker, maxsplit=1)[1])
+
+    def expression_value(match: re.Match[str]) -> str:
+        expression = match.group(1).strip()
+        selector_prefix = "needs.changes.outputs."
+        if expression == "needs.changes.result":
+            return "success"
+        if expression.startswith(selector_prefix):
+            return selector_values.get(expression.removeprefix(selector_prefix), "")
+        if expression.startswith("needs.") and expression.endswith(".result"):
+            return "success"
+        if expression == "github.event.pull_request.draft":
+            return "false"
+        if expression == "github.event_name":
+            return "pull_request"
+        raise AssertionError(f"unhandled gate expression: {expression}")
+
+    script = re.sub(r"\$\{\{\s*([^}]+?)\s*\}\}", expression_value, script)
+    return subprocess.run(
+        [
+            "/bin/bash",
+            "--noprofile",
+            "--norc",
+            "-e",
+            "-u",
+            "-o",
+            "pipefail",
+            "-c",
+            script,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
 
 
 def _require_tests_collected(test_suite: unittest.TestSuite) -> None:
@@ -458,7 +750,8 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
         base_sha: str,
         head_sha: str,
         *,
-        event: str = "pull_request",
+        event: str,
+        environment: dict[str, str] | None = None,
     ) -> tuple[subprocess.CompletedProcess[str], str]:
         output = self.repo / "github-output"
         output.unlink(missing_ok=True)
@@ -469,16 +762,15 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
             CI_BASE_SHA=base_sha,
             CI_HEAD_SHA=head_sha,
         )
+        if environment is not None:
+            env.update(environment)
+        filter_script = self.repo / "filter-step.sh"
+        filter_script.write_text(
+            _workflow_run_script(workflow, "changes", "filter"),
+            encoding="utf-8",
+        )
         result = subprocess.run(
-            [
-                "bash",
-                "--noprofile",
-                "--norc",
-                "-o",
-                "pipefail",
-                "-c",
-                _workflow_run_script(workflow, "changes", "filter"),
-            ],
+            [*_FILTER_SHELL_COMMAND, str(filter_script)],
             cwd=self.repo,
             env=env,
             check=False,
@@ -502,11 +794,18 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
             "#!/bin/sh\nexit 0\n",
         )
 
-        result, output = self._run_filter(workflow, base, head)
+        for event in _DETECTOR_EVENTS:
+            with self.subTest(workflow=workflow.name, event=event):
+                result, output = self._run_filter(
+                    workflow,
+                    base,
+                    head,
+                    event=event,
+                )
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        for expected_output in expected_outputs:
-            self.assertIn(expected_output, output)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                for expected_output in expected_outputs:
+                    self.assertIn(expected_output, output)
 
     def _assert_detector_failure_is_observed(self, workflow: Path) -> None:
         base = self._commit(
@@ -515,11 +814,21 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
         )
         head = self._commit("README.md", "change\n")
 
-        result, output = self._run_filter(workflow, base, head)
+        for event in _DETECTOR_EVENTS:
+            with self.subTest(workflow=workflow.name, event=event):
+                result, output = self._run_filter(
+                    workflow,
+                    base,
+                    head,
+                    event=event,
+                )
 
-        self.assertEqual(result.returncode, 23)
-        self.assertEqual(output, "")
-        self.assertIn("change detector failed with status 23", result.stderr)
+                self.assertEqual(result.returncode, 23)
+                self.assertEqual(output, "")
+                self.assertIn(
+                    "change detector failed with status 23",
+                    result.stderr,
+                )
 
     def _assert_replacement_ref_is_ignored(
         self,
@@ -537,17 +846,35 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
         )
         self._git("replace", base, replacement)
 
-        result, output = self._run_filter(workflow, base, replacement)
+        for event in _DETECTOR_EVENTS:
+            with self.subTest(workflow=workflow.name, event=event):
+                result, output = self._run_filter(
+                    workflow,
+                    base,
+                    replacement,
+                    event=event,
+                )
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        for expected_output in expected_outputs:
-            self.assertIn(expected_output, output)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                for expected_output in expected_outputs:
+                    self.assertIn(expected_output, output)
 
     def _ci_filter_with_added_prologue(self, statement: str) -> str:
         script = _workflow_run_script(_CI_WORKFLOW, "changes", "filter")
         marker = "TRUSTED_DETECTOR=$(mktemp)"
         self.assertIn(marker, script)
         return script.replace(marker, f"{statement}\n{marker}", 1)
+
+    def _ci_workflow_with_filter_step(self, step: str) -> str:
+        contents = _CI_WORKFLOW.read_text(encoding="utf-8")
+        job = _workflow_job(contents, "changes")
+        current = _workflow_step_by_id(job, "filter")
+        mutated_job = job.replace(current, step, 1)
+        return contents.replace(job, mutated_job, 1)
+
+    def _ci_filter_step(self) -> str:
+        contents = _CI_WORKFLOW.read_text(encoding="utf-8")
+        return _workflow_step_by_id(_workflow_job(contents, "changes"), "filter")
 
     def test_ci_runs_the_base_detector_and_classifies_its_change(self) -> None:
         self._assert_base_detector_wins(_CI_WORKFLOW, ("code=true",))
@@ -612,6 +939,58 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
             ("engine=true", "tune=true"),
         )
 
+    def test_filter_shell_removes_startup_and_path_overrides(self) -> None:
+        base = self._commit(
+            "scripts/ci-changed-files.sh",
+            _SCRIPT.read_text(encoding="utf-8"),
+        )
+        head = self._commit(
+            "scripts/ci-changed-files.sh",
+            "#!/bin/sh\nexit 0\n",
+        )
+        startup = self.repo / "bash-env"
+        startup.write_text(
+            'echo "startup-file-ran=true" >> "$GITHUB_OUTPUT"\n',
+            encoding="utf-8",
+        )
+        shadow_bin = self.repo / "shadow-bin"
+        shadow_bin.mkdir()
+        shadow_git = shadow_bin / "git"
+        shadow_git.write_text(
+            "#!/bin/sh\n"
+            'echo "shadow-path-ran=true" >> "$GITHUB_OUTPUT"\n'
+            'exec /usr/bin/git "$@"\n',
+            encoding="utf-8",
+        )
+        shadow_git.chmod(0o755)
+        environment = {
+            "BASH_ENV": str(startup),
+            "PATH": f"{shadow_bin}:/usr/bin:/bin",
+        }
+        cases = (
+            (_CI_WORKFLOW, ("code=true",)),
+            (_CARGO_AUDIT_WORKFLOW, ("deps=true",)),
+            (_APP_BINARIES_WORKFLOW, ("bins=true", "swift=true")),
+            (_E2E_PARITY_WORKFLOW, ("engine=true", "tune=true")),
+        )
+
+        for workflow, expected_outputs in cases:
+            for event in _DETECTOR_EVENTS:
+                with self.subTest(workflow=workflow.name, event=event):
+                    result, output = self._run_filter(
+                        workflow,
+                        base,
+                        head,
+                        event=event,
+                        environment=environment,
+                    )
+
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertNotIn("startup-file-ran=true", output)
+                    self.assertNotIn("shadow-path-ran=true", output)
+                    for expected_output in expected_outputs:
+                        self.assertIn(expected_output, output)
+
     def test_change_jobs_start_filter_immediately_after_checkout(self) -> None:
         for relative_path in _REQUIRED_WORKFLOWS:
             with self.subTest(workflow=relative_path):
@@ -630,25 +1009,212 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
                 )
                 self.assertEqual(step_entries[1], "      - id: filter")
 
-    def test_change_filter_prologues_allow_only_declared_operations(
+    def test_change_filter_prologues_match_declared_ordered_grammar(
         self,
     ) -> None:
-        used_primitives = set()
+        self.assertEqual(
+            set(_EXPECTED_FILTER_PROLOGUES),
+            set(_REQUIRED_WORKFLOWS),
+        )
         for relative_path in _REQUIRED_WORKFLOWS:
             with self.subTest(workflow=relative_path):
-                script = _workflow_run_script(
-                    _ROOT / relative_path,
-                    "changes",
-                    "filter",
-                )
-                used_primitives.update(
-                    _assert_safe_filter_prologue(script, relative_path)
+                contents = (_ROOT / relative_path).read_text(encoding="utf-8")
+                _assert_safe_filter_workflow(
+                    contents,
+                    relative_path,
                 )
 
-        self.assertEqual(
-            used_primitives,
-            {name for name, _ in _SAFE_FILTER_PROLOGUE_PRIMITIVES},
+    def test_detector_reader_event_matrix_is_complete(self) -> None:
+        self.assertEqual(_DETECTOR_EVENTS, ("pull_request", "merge_group"))
+
+    def test_filter_prologue_rejects_balanced_event_condition_around_detector(
+        self,
+    ) -> None:
+        step = self._ci_filter_step()
+        marker = "          TRUSTED_DETECTOR=$(mktemp)\n"
+        self.assertIn(marker, step)
+        step = step.replace(
+            marker,
+            "          if [ \"$GITHUB_EVENT_NAME\" = \"pull_request\" ]; then\n"
+            f"{marker}",
+            1,
         )
+        step = f"{step}          fi\n"
+        workflow = self._ci_workflow_with_filter_step(step)
+
+        with self.assertRaisesRegex(AssertionError, "top level"):
+            _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
+
+    def test_filter_step_rejects_event_dependent_condition(self) -> None:
+        step = self._ci_filter_step().replace(
+            "      - id: filter\n",
+            "      - id: filter\n"
+            "        if: github.event_name == 'pull_request'\n",
+            1,
+        )
+        workflow = self._ci_workflow_with_filter_step(step)
+
+        with self.assertRaisesRegex(AssertionError, "step metadata"):
+            _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
+
+    def test_filter_step_rejects_bash_env_override(self) -> None:
+        step = self._ci_filter_step().replace(
+            "        env:\n",
+            "        env:\n          BASH_ENV: /tmp/filter-startup\n",
+            1,
+        )
+        workflow = self._ci_workflow_with_filter_step(step)
+
+        with self.assertRaisesRegex(AssertionError, "environment"):
+            _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
+
+    def test_filter_step_rejects_path_override(self) -> None:
+        step = self._ci_filter_step().replace(
+            "        env:\n",
+            "        env:\n          PATH: /tmp/filter-bin\n",
+            1,
+        )
+        workflow = self._ci_workflow_with_filter_step(step)
+
+        with self.assertRaisesRegex(AssertionError, "environment"):
+            _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
+
+    def test_filter_step_rejects_unapproved_execution_metadata(self) -> None:
+        step = self._ci_filter_step()
+        mutations = {
+            "continue on error": step.replace(
+                "      - id: filter\n",
+                "      - id: filter\n        continue-on-error: true\n",
+                1,
+            ),
+            "working directory": step.replace(
+                "      - id: filter\n",
+                "      - id: filter\n        working-directory: /tmp\n",
+                1,
+            ),
+            "alternate shell": step.replace(
+                f"        shell: {_TRUSTED_FILTER_SHELL}\n",
+                "        shell: bash\n",
+                1,
+            ),
+            "mapping merge": step.replace(
+                "      - id: filter\n",
+                "      - id: filter\n        <<: *filter-options\n",
+                1,
+            ),
+        }
+
+        for name, mutated_step in mutations.items():
+            with self.subTest(metadata=name):
+                workflow = self._ci_workflow_with_filter_step(mutated_step)
+                with self.assertRaisesRegex(
+                    AssertionError,
+                    "step metadata|shell command",
+                ):
+                    _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
+
+    def test_filter_step_rejects_inherited_execution_overrides(self) -> None:
+        contents = _CI_WORKFLOW.read_text(encoding="utf-8")
+        job = _workflow_job(contents, "changes")
+        mutations = {
+            "workflow defaults": contents.replace(
+                "name: CI\n",
+                "name: CI\n\ndefaults:\n  run:\n    shell: bash\n",
+                1,
+            ),
+            "job defaults": contents.replace(
+                job,
+                job.replace(
+                    "  changes:\n",
+                    "  changes:\n    defaults:\n      run:\n        shell: bash\n",
+                    1,
+                ),
+                1,
+            ),
+            "job environment": contents.replace(
+                job,
+                job.replace(
+                    "    runs-on: ubuntu-latest\n",
+                    "    runs-on: ubuntu-latest\n"
+                    "    env:\n"
+                    "      PATH: /tmp/filter-bin\n",
+                    1,
+                ),
+                1,
+            ),
+            "workflow environment": contents.replace(
+                "env:\n",
+                "env:\n  BASH_ENV: /tmp/filter-startup\n",
+                1,
+            ),
+            "workflow merge": contents.replace(
+                "name: CI\n",
+                "name: CI\n<<: *workflow-options\n",
+                1,
+            ),
+            "job merge": contents.replace(
+                job,
+                job.replace(
+                    "  changes:\n",
+                    "  changes:\n    <<: *job-options\n",
+                    1,
+                ),
+                1,
+            ),
+        }
+
+        for name, workflow in mutations.items():
+            with self.subTest(scope=name), self.assertRaisesRegex(
+                AssertionError,
+                "defaults|environment|merge",
+            ):
+                _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
+
+    def test_filter_steps_declare_the_sanitized_absolute_shell(self) -> None:
+        for relative_path in _REQUIRED_WORKFLOWS:
+            with self.subTest(workflow=relative_path):
+                contents = (_ROOT / relative_path).read_text(encoding="utf-8")
+                step = _workflow_step_by_id(
+                    _workflow_job(contents, "changes"),
+                    "filter",
+                )
+                self.assertIn(
+                    f"        shell: {_TRUSTED_FILTER_SHELL}\n",
+                    step,
+                )
+
+    def test_filter_workflow_rejects_unsanitized_detector_commands(self) -> None:
+        contents = _CI_WORKFLOW.read_text(encoding="utf-8")
+        trusted_load = (
+            "/usr/bin/env -i PATH=/usr/bin:/bin /usr/bin/git "
+            "--no-replace-objects show"
+        )
+        trusted_execution = _TRUSTED_DETECTOR_EXECUTION
+        mutations = {
+            "relative load command": (
+                contents.replace(
+                    trusted_load,
+                    "git --no-replace-objects show",
+                    1,
+                ),
+                "trusted /usr/bin/env and /usr/bin/git form",
+            ),
+            "inherited execution environment": (
+                contents.replace(
+                    trusted_execution,
+                    'sh "$TRUSTED_DETECTOR"',
+                    1,
+                ),
+                "clean environment and absolute shell",
+            ),
+        }
+
+        for name, (workflow, expected_error) in mutations.items():
+            with self.subTest(command=name), self.assertRaisesRegex(
+                AssertionError,
+                expected_error,
+            ):
+                _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
 
     def test_filter_prologue_rejects_command_substitution(self) -> None:
         script = self._ci_filter_with_added_prologue(
@@ -669,8 +1235,8 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
     def test_filter_prologue_rejects_indirection_in_detector_load(self) -> None:
         script = _workflow_run_script(_CI_WORKFLOW, "changes", "filter")
         script, replacements = re.subn(
-            r"if git(?: --no-replace-objects)? show ",
-            'if git "$(scripts/preload-detector)" show ',
+            r"/usr/bin/git --no-replace-objects show ",
+            '/usr/bin/git "$(scripts/preload-detector)" show ',
             script,
             count=1,
         )
@@ -678,6 +1244,80 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
 
         with self.assertRaisesRegex(AssertionError, "base detector"):
             _assert_safe_filter_prologue(script, _CI_WORKFLOW.name)
+
+    def test_filter_prologue_accepts_core_quote_path_git_option(self) -> None:
+        script = _workflow_run_script(_CI_WORKFLOW, "changes", "filter")
+        script, replacements = re.subn(
+            r"/usr/bin/git --no-replace-objects show ",
+            "/usr/bin/git --no-replace-objects "
+            "-c core.quotePath=false show ",
+            script,
+            count=1,
+        )
+        self.assertEqual(replacements, 1)
+
+        _assert_safe_filter_prologue(script, _CI_WORKFLOW.name)
+
+    def test_filter_prologue_rejects_unapproved_git_option_with_guidance(
+        self,
+    ) -> None:
+        script = _workflow_run_script(_CI_WORKFLOW, "changes", "filter")
+        script, replacements = re.subn(
+            r"/usr/bin/git --no-replace-objects show ",
+            "/usr/bin/git --no-replace-objects -C . show ",
+            script,
+            count=1,
+        )
+        self.assertEqual(replacements, 1)
+
+        with self.assertRaisesRegex(AssertionError, "use the declared load shape"):
+            _assert_safe_filter_prologue(script, _CI_WORKFLOW.name)
+
+    def test_filter_prologue_rejects_unbalanced_conditionals(self) -> None:
+        mutations = {
+            "unexpected terminator": self._ci_filter_with_added_prologue("fi"),
+            "unterminated condition": self._ci_filter_with_added_prologue(
+                "if true; then"
+            ),
+        }
+
+        for name, script in mutations.items():
+            expected = "unbalanced" if name == "unexpected terminator" else "top level"
+            with self.subTest(structure=name), self.assertRaisesRegex(
+                AssertionError,
+                expected,
+            ):
+                _assert_safe_filter_prologue(script, _CI_WORKFLOW.name)
+
+    def test_filter_prologue_rejects_shell_boundary_forms(self) -> None:
+        mutations = {
+            "semicolon list": "set -euo pipefail; printf unexpected",
+            "and list": "set -euo pipefail && printf unexpected",
+            "or list": "set -euo pipefail || printf unexpected",
+            "pipeline": "set -euo pipefail | printf unexpected",
+            "line continuation": "set -euo pipefail \\\nprintf unexpected",
+            "trailing comment": "set -euo pipefail # comment",
+            "carriage return": "set -euo pipefail\rprintf unexpected",
+            "vertical tab": "set -euo pipefail\vprintf unexpected",
+            "environment assignment": "MODE=changed printf unexpected",
+            "command builtin": "command printf unexpected",
+            "brace group": "{ printf unexpected; }",
+            "subshell": "(printf unexpected)",
+            "coprocess": "coproc printf unexpected",
+            "redirection only": '> "$GITHUB_OUTPUT"',
+            "for compound": "for x in one; do printf unexpected; done",
+            "comment continuation": "# comment \\\nprintf unexpected",
+            "unicode lookalike": "ｓｅｔ -euo pipefail",
+        }
+
+        for name, statement in mutations.items():
+            with self.subTest(form=name):
+                script = self._ci_filter_with_added_prologue(statement)
+                with self.assertRaisesRegex(
+                    AssertionError,
+                    "before detector loading",
+                ):
+                    _assert_safe_filter_prologue(script, _CI_WORKFLOW.name)
 
     def test_app_binaries_full_selection_exceptions_are_exactly_enumerated(
         self,
@@ -734,15 +1374,21 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
             _APP_BINARIES_WORKFLOW,
             _E2E_PARITY_WORKFLOW,
         ):
-            with self.subTest(workflow=workflow.name):
-                result, output = self._run_filter(workflow, "f" * 40, head)
+            for event in _DETECTOR_EVENTS:
+                with self.subTest(workflow=workflow.name, event=event):
+                    result, output = self._run_filter(
+                        workflow,
+                        "f" * 40,
+                        head,
+                        event=event,
+                    )
 
-                self.assertNotEqual(result.returncode, 0)
-                self.assertEqual(output, "")
-                self.assertIn(
-                    "unable to load change detector from base revision",
-                    result.stderr,
-                )
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertEqual(output, "")
+                    self.assertIn(
+                        "unable to load change detector from base revision",
+                        result.stderr,
+                    )
 
     def test_invalid_base_never_executes_checkout_detector(self) -> None:
         head = self._commit(
@@ -758,18 +1404,28 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
             _APP_BINARIES_WORKFLOW,
             _E2E_PARITY_WORKFLOW,
         ):
-            for base_sha in ("", "a" * 39, "g" * 40):
-                with self.subTest(workflow=workflow.name, base_sha=base_sha):
-                    result, output = self._run_filter(workflow, base_sha, head)
+            for event in _DETECTOR_EVENTS:
+                for base_sha in ("", "a" * 39, "g" * 40):
+                    with self.subTest(
+                        workflow=workflow.name,
+                        event=event,
+                        base_sha=base_sha,
+                    ):
+                        result, output = self._run_filter(
+                            workflow,
+                            base_sha,
+                            head,
+                            event=event,
+                        )
 
-                    self.assertEqual(result.returncode, 2)
-                    self.assertEqual(output, "")
-                    self.assertNotIn("attacker-selected=true", output)
-                    self.assertIn(
-                        "base revision must be a nonempty 40-character "
-                        "hexadecimal commit ID",
-                        result.stderr,
-                    )
+                        self.assertEqual(result.returncode, 2)
+                        self.assertEqual(output, "")
+                        self.assertNotIn("attacker-selected=true", output)
+                        self.assertIn(
+                            "base revision must be a nonempty 40-character "
+                            "hexadecimal commit ID",
+                            result.stderr,
+                        )
 
     def test_all_zero_base_selects_every_downstream_job(self) -> None:
         head = self._commit(
@@ -806,6 +1462,79 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
                 self.assertNotIn("attacker-selected=true", output)
                 for expected_output in expected_outputs:
                     self.assertIn(expected_output, output)
+
+
+class RequiredGateSelectorTests(unittest.TestCase):
+    _CASES = (
+        (_CI_WORKFLOW, "ci-gate", ("code",)),
+        (_CARGO_AUDIT_WORKFLOW, "cargo-audit-gate", ("deps",)),
+        (
+            _APP_BINARIES_WORKFLOW,
+            "app-binaries-gate",
+            ("bins", "swift"),
+        ),
+        (_E2E_PARITY_WORKFLOW, "parity-gate", ("engine", "tune")),
+    )
+
+    def test_required_gates_reject_missing_selector_outputs(self) -> None:
+        for workflow, gate_id, selectors in self._CASES:
+            for missing in selectors:
+                values = {selector: "false" for selector in selectors}
+                values[missing] = ""
+                with self.subTest(
+                    workflow=workflow.name,
+                    selector=missing,
+                ):
+                    result = _run_required_gate(workflow, gate_id, values)
+
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(
+                        "selector output",
+                        f"{result.stdout}\n{result.stderr}",
+                    )
+
+    def test_required_gates_reject_non_boolean_selector_outputs(self) -> None:
+        for workflow, gate_id, selectors in self._CASES:
+            for invalid in selectors:
+                values = {selector: "false" for selector in selectors}
+                values[invalid] = "unknown"
+                with self.subTest(
+                    workflow=workflow.name,
+                    selector=invalid,
+                ):
+                    result = _run_required_gate(workflow, gate_id, values)
+
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(
+                        "selector output",
+                        f"{result.stdout}\n{result.stderr}",
+                    )
+
+    def test_required_gates_accept_explicit_negative_selector_outputs(
+        self,
+    ) -> None:
+        for workflow, gate_id, selectors in self._CASES:
+            with self.subTest(workflow=workflow.name):
+                result = _run_required_gate(
+                    workflow,
+                    gate_id,
+                    {selector: "false" for selector in selectors},
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_required_gates_accept_explicit_positive_selector_outputs(
+        self,
+    ) -> None:
+        for workflow, gate_id, selectors in self._CASES:
+            with self.subTest(workflow=workflow.name):
+                result = _run_required_gate(
+                    workflow,
+                    gate_id,
+                    {selector: "true" for selector in selectors},
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
 
 
 class TestRunnerContractTests(unittest.TestCase):

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -369,11 +369,14 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
         workflow: Path,
         base_sha: str,
         head_sha: str,
+        *,
+        event: str = "pull_request",
     ) -> tuple[subprocess.CompletedProcess[str], str]:
         output = self.repo / "github-output"
+        output.unlink(missing_ok=True)
         env = os.environ.copy()
         env.update(
-            GITHUB_EVENT_NAME="pull_request",
+            GITHUB_EVENT_NAME=event,
             GITHUB_OUTPUT=str(output),
             CI_BASE_SHA=base_sha,
             CI_HEAD_SHA=head_sha,
@@ -465,6 +468,69 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
 
     def test_e2e_parity_observes_detector_failure_status(self) -> None:
         self._assert_detector_failure_is_observed(_E2E_PARITY_WORKFLOW)
+
+    def test_invalid_base_never_executes_checkout_detector(self) -> None:
+        head = self._commit(
+            "scripts/ci-changed-files.sh",
+            "#!/bin/sh\n"
+            "echo 'attacker-selected=true' >> \"$GITHUB_OUTPUT\"\n"
+            "echo README.md\n",
+        )
+
+        for workflow in (
+            _CI_WORKFLOW,
+            _CARGO_AUDIT_WORKFLOW,
+            _APP_BINARIES_WORKFLOW,
+            _E2E_PARITY_WORKFLOW,
+        ):
+            for base_sha in ("", "a" * 39, "g" * 40):
+                with self.subTest(workflow=workflow.name, base_sha=base_sha):
+                    result, output = self._run_filter(workflow, base_sha, head)
+
+                    self.assertEqual(result.returncode, 2)
+                    self.assertEqual(output, "")
+                    self.assertNotIn("attacker-selected=true", output)
+                    self.assertIn(
+                        "base revision must be a nonempty 40-character "
+                        "hexadecimal commit ID",
+                        result.stderr,
+                    )
+
+    def test_all_zero_base_selects_every_downstream_job(self) -> None:
+        head = self._commit(
+            "scripts/ci-changed-files.sh",
+            "#!/bin/sh\n"
+            "echo 'attacker-selected=true' >> \"$GITHUB_OUTPUT\"\n"
+            "exit 29\n",
+        )
+        cases = (
+            (_CI_WORKFLOW, "push", ("code=true",)),
+            (_CARGO_AUDIT_WORKFLOW, "pull_request", ("deps=true",)),
+            (
+                _APP_BINARIES_WORKFLOW,
+                "push",
+                ("bins=true", "swift=true"),
+            ),
+            (
+                _E2E_PARITY_WORKFLOW,
+                "push",
+                ("engine=true", "tune=true"),
+            ),
+        )
+
+        for workflow, event, expected_outputs in cases:
+            with self.subTest(workflow=workflow.name, event=event):
+                result, output = self._run_filter(
+                    workflow,
+                    _ZERO_SHA,
+                    head,
+                    event=event,
+                )
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertNotIn("attacker-selected=true", output)
+                for expected_output in expected_outputs:
+                    self.assertIn(expected_output, output)
 
 
 class TestRunnerContractTests(unittest.TestCase):

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -10,6 +10,8 @@ import textwrap
 import unittest
 from pathlib import Path
 
+import yaml
+
 
 _SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "ci-changed-files.sh"
 _ROOT = _SCRIPT.parent.parent
@@ -153,6 +155,142 @@ _EXPECTED_FILTER_ENVIRONMENT = (
         "${{ github.event.merge_group.head_sha || github.sha }}",
     ),
 )
+_CHECKOUT_ACTION = (
+    "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+)
+_EXPECTED_CHANGE_JOB_KEYS = frozenset(("name", "runs-on", "outputs", "steps"))
+_EXPECTED_CHANGE_JOB_NAMES = {
+    ".github/workflows/ci.yml": "detect-code-changes",
+    ".github/workflows/cargo-audit.yml": "detect-dependency-changes",
+    ".github/workflows/app-binaries.yml": "detect-app-bin-changes",
+    ".github/workflows/e2e-parity.yml": "detect-engine-changes",
+}
+_EXPECTED_CHANGE_JOB_OUTPUTS = {
+    ".github/workflows/ci.yml": {
+        "code": "${{ steps.filter.outputs.code }}",
+        "oslist": "${{ steps.oslist.outputs.oslist }}",
+        "featureoslist": "${{ steps.oslist.outputs.featureoslist }}",
+    },
+    ".github/workflows/cargo-audit.yml": {
+        "deps": "${{ steps.filter.outputs.deps }}",
+    },
+    ".github/workflows/app-binaries.yml": {
+        "bins": "${{ steps.filter.outputs.bins }}",
+        "swift": "${{ steps.filter.outputs.swift }}",
+    },
+    ".github/workflows/e2e-parity.yml": {
+        "engine": "${{ steps.filter.outputs.engine }}",
+        "tune": "${{ steps.filter.outputs.tune }}",
+    },
+}
+_EXPECTED_SELECTOR_OUTPUTS = {
+    ".github/workflows/ci.yml": ("code",),
+    ".github/workflows/cargo-audit.yml": ("deps",),
+    ".github/workflows/app-binaries.yml": ("bins", "swift"),
+    ".github/workflows/e2e-parity.yml": ("engine", "tune"),
+}
+
+
+class _WorkflowLoader(yaml.SafeLoader):
+    pass
+
+
+_WorkflowLoader.yaml_implicit_resolvers = {
+    initial: [
+        resolver
+        for resolver in resolvers
+        if resolver[0] != "tag:yaml.org,2002:bool"
+    ]
+    for initial, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+_WorkflowLoader.add_implicit_resolver(
+    "tag:yaml.org,2002:bool",
+    re.compile(r"^(?:true|True|TRUE|false|False|FALSE)$"),
+    list("tTfF"),
+)
+
+
+def _construct_unique_mapping(
+    loader: _WorkflowLoader,
+    node: yaml.nodes.MappingNode,
+    deep: bool = False,
+) -> dict[object, object]:
+    loader.flatten_mapping(node)
+    mapping: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in mapping
+        except TypeError as error:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                "found an unhashable key",
+                key_node.start_mark,
+            ) from error
+        if duplicate:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_WorkflowLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_unique_mapping,
+)
+
+
+def _require_mapping(value: object, location: str) -> dict[str, object]:
+    if not isinstance(value, dict) or not all(
+        isinstance(key, str) for key in value
+    ):
+        raise AssertionError(f"{location} must be a string-keyed mapping")
+    return value
+
+
+def _parse_workflow(contents: str, workflow: str) -> dict[str, object]:
+    try:
+        document = yaml.load(contents, Loader=_WorkflowLoader)
+    except yaml.YAMLError as error:
+        raise AssertionError(f"{workflow} is not valid workflow YAML: {error}") from error
+    return _require_mapping(document, f"{workflow} document")
+
+
+def _parsed_workflow_job(
+    document: dict[str, object],
+    job_id: str,
+    workflow: str,
+) -> dict[str, object]:
+    jobs = _require_mapping(document.get("jobs"), f"{workflow} jobs")
+    if job_id not in jobs:
+        raise AssertionError(f"workflow job {job_id!r} is missing")
+    return _require_mapping(jobs[job_id], f"{workflow} job {job_id!r}")
+
+
+def _parsed_workflow_step_by_id(
+    job: dict[str, object],
+    step_id: str,
+    workflow: str,
+) -> tuple[int, dict[str, object]]:
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        raise AssertionError(f"{workflow} job steps must be a sequence")
+    matches = []
+    for index, value in enumerate(steps):
+        step = _require_mapping(value, f"{workflow} step {index + 1}")
+        if step.get("id") == step_id:
+            matches.append((index, step))
+    if len(matches) != 1:
+        raise AssertionError(
+            f"workflow step id {step_id!r} must appear exactly once, "
+            f"found {len(matches)}"
+        )
+    return matches[0]
 
 
 def _workflow_job(contents: str, job_id: str) -> str:
@@ -206,22 +344,25 @@ def _workflow_run_script_from_contents(
     contents: str,
     job_id: str,
     step_id: str,
+    workflow: str = "workflow",
 ) -> str:
-    step = _workflow_step_by_id(_workflow_job(contents, job_id), step_id)
-    marker = "        run: |\n"
-    if marker not in step:
+    document = _parse_workflow(contents, workflow)
+    job = _parsed_workflow_job(document, job_id, workflow)
+    _, step = _parsed_workflow_step_by_id(job, step_id, workflow)
+    script = step.get("run")
+    if not isinstance(script, str):
         raise AssertionError(f"workflow step id {step_id!r} has no run script")
-    run_lines = []
-    for line in step.split(marker, maxsplit=1)[1].splitlines(keepends=True):
-        if line.strip() and not line.startswith("          "):
-            break
-        run_lines.append(line)
-    return textwrap.dedent("".join(run_lines))
+    return script
 
 
 def _workflow_run_script(workflow: Path, job_id: str, step_id: str) -> str:
     contents = workflow.read_text(encoding="utf-8")
-    return _workflow_run_script_from_contents(contents, job_id, step_id)
+    return _workflow_run_script_from_contents(
+        contents,
+        job_id,
+        step_id,
+        workflow.name,
+    )
 
 
 def _workflow_contract_key(workflow: str) -> str:
@@ -235,104 +376,99 @@ def _workflow_contract_key(workflow: str) -> str:
     return matches[0]
 
 
-def _yaml_direct_mapping(
-    contents: str,
-    indentation: int,
-    key: str,
-) -> tuple[tuple[str, str], ...]:
-    prefix = " " * indentation
-    header = re.search(
-        rf"^{re.escape(prefix)}{re.escape(key)}:\s*$",
-        contents,
-        re.MULTILINE,
-    )
-    if header is None:
-        return ()
-    entries = []
-    for raw_line in contents[header.end() :].splitlines():
-        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
-            continue
-        line_indentation = len(raw_line) - len(raw_line.lstrip(" "))
-        if line_indentation <= indentation:
-            break
-        if line_indentation != indentation + 2:
-            continue
-        entry_prefix = " " * (indentation + 2)
-        entry = re.fullmatch(
-            rf"{re.escape(entry_prefix)}([A-Za-z_][A-Za-z0-9_]*):\s*(.*)",
-            raw_line,
-        )
-        if entry is None:
-            raise AssertionError(f"{key} contains a non-scalar mapping entry")
-        entries.append((entry.group(1), entry.group(2)))
-    return tuple(entries)
-
-
-def _yaml_direct_keys(contents: str, indentation: int) -> tuple[str, ...]:
-    prefix = " " * indentation
-    keys = []
-    for raw_line in contents.splitlines():
-        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
-            continue
-        line_indentation = len(raw_line) - len(raw_line.lstrip(" "))
-        if line_indentation != indentation:
-            continue
-        match = re.match(
-            rf"{re.escape(prefix)}([^ \t:#][^:\n]*):",
-            raw_line,
-        )
-        if match is not None:
-            keys.append(match.group(1).strip("'\""))
-    return tuple(keys)
-
-
-def _assert_filter_execution_envelope(contents: str, workflow: str) -> None:
+def _assert_filter_execution_envelope(contents: str, workflow: str) -> str:
     contract_key = _workflow_contract_key(workflow)
-    workflow_keys = _yaml_direct_keys(contents, 0)
-    if "defaults" in workflow_keys:
+    document = _parse_workflow(contents, workflow)
+    if "defaults" in document:
         raise AssertionError(f"{workflow} has workflow defaults reaching filter step")
-    if "<<" in workflow_keys:
-        raise AssertionError(f"{workflow} has an unknown workflow execution merge")
 
-    job = _workflow_job(contents, "changes")
-    job_keys = _yaml_direct_keys(job, 4)
-    if "defaults" in job_keys:
-        raise AssertionError(f"{workflow} has job defaults reaching filter step")
-    if "<<" in job_keys:
-        raise AssertionError(f"{workflow} has an unknown job execution merge")
-    if _yaml_direct_mapping(job, 4, "env"):
-        raise AssertionError(f"{workflow} has job environment reaching filter step")
-
-    workflow_environment = _yaml_direct_mapping(contents, 0, "env")
-    workflow_environment_keys = tuple(key for key, _ in workflow_environment)
-    if workflow_environment_keys != _EXPECTED_WORKFLOW_ENV_KEYS[contract_key]:
+    workflow_environment = _require_mapping(
+        document.get("env"),
+        f"{workflow} workflow environment",
+    )
+    workflow_environment_keys = frozenset(workflow_environment)
+    expected_workflow_environment_keys = frozenset(
+        _EXPECTED_WORKFLOW_ENV_KEYS[contract_key]
+    )
+    if workflow_environment_keys != expected_workflow_environment_keys:
         raise AssertionError(
             f"{workflow} workflow environment keys must be exactly "
             f"{_EXPECTED_WORKFLOW_ENV_KEYS[contract_key]!r}, found "
-            f"{workflow_environment_keys!r}"
+            f"{tuple(workflow_environment)!r}"
         )
 
-    step = _workflow_step_by_id(job, "filter")
-    metadata_keys = ("id", *_yaml_direct_keys(step, 8))
-    expected_metadata_keys = ("id", "env", "shell", "run")
+    job = _parsed_workflow_job(document, "changes", workflow)
+    job_keys = frozenset(job)
+    if job_keys != _EXPECTED_CHANGE_JOB_KEYS:
+        raise AssertionError(
+            f"{workflow} changes job schema must contain exactly "
+            f"{tuple(sorted(_EXPECTED_CHANGE_JOB_KEYS))!r}, found "
+            f"{tuple(sorted(job_keys))!r}"
+        )
+    if job.get("name") != _EXPECTED_CHANGE_JOB_NAMES[contract_key]:
+        raise AssertionError(
+            f"{workflow} changes job name must be "
+            f"{_EXPECTED_CHANGE_JOB_NAMES[contract_key]!r}"
+        )
+    if job.get("runs-on") != "ubuntu-latest":
+        raise AssertionError(
+            f"{workflow} changes job runs-on must be 'ubuntu-latest'"
+        )
+
+    outputs = _require_mapping(job.get("outputs"), f"{workflow} changes outputs")
+    expected_outputs = _EXPECTED_CHANGE_JOB_OUTPUTS[contract_key]
+    if outputs != expected_outputs:
+        raise AssertionError(
+            f"{workflow} changes job output mappings must be exactly "
+            f"{expected_outputs!r}, found {outputs!r}"
+        )
+
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        raise AssertionError(f"{workflow} changes job steps must be a sequence")
+    filter_index, step = _parsed_workflow_step_by_id(job, "filter", workflow)
+    if filter_index != 1:
+        raise AssertionError(
+            f"{workflow} filter step must immediately follow checkout"
+        )
+    checkout = _require_mapping(steps[0], f"{workflow} checkout step")
+    expected_checkout = {
+        "uses": _CHECKOUT_ACTION,
+        "with": {"fetch-depth": 0},
+    }
+    if checkout != expected_checkout:
+        raise AssertionError(
+            f"{workflow} changes job must start with the canonical checkout step"
+        )
+
+    metadata_keys = frozenset(step)
+    expected_metadata_keys = frozenset(("id", "env", "shell", "run"))
     if metadata_keys != expected_metadata_keys:
         raise AssertionError(
             f"{workflow} filter step metadata keys must be exactly "
-            f"{expected_metadata_keys!r}, found {metadata_keys!r}"
+            f"{tuple(sorted(expected_metadata_keys))!r}, found "
+            f"{tuple(sorted(metadata_keys))!r}"
         )
 
-    step_environment = _yaml_direct_mapping(step, 8, "env")
-    if step_environment != _EXPECTED_FILTER_ENVIRONMENT:
+    step_environment = _require_mapping(
+        step.get("env"),
+        f"{workflow} filter environment",
+    )
+    expected_filter_environment = dict(_EXPECTED_FILTER_ENVIRONMENT)
+    if step_environment != expected_filter_environment:
         raise AssertionError(
             f"{workflow} filter environment must be exactly "
-            f"{_EXPECTED_FILTER_ENVIRONMENT!r}, found {step_environment!r}"
+            f"{expected_filter_environment!r}, found {step_environment!r}"
         )
 
-    shell_lines = re.findall(r"^        shell:\s*(.*)$", step, re.MULTILINE)
-    if shell_lines != [_TRUSTED_FILTER_SHELL]:
+    if step.get("shell") != _TRUSTED_FILTER_SHELL:
         raise AssertionError(
             f"{workflow} filter shell command must be {_TRUSTED_FILTER_SHELL!r}"
         )
+    script = step.get("run")
+    if not isinstance(script, str):
+        raise AssertionError(f"{workflow} filter step must have a run script")
+    return script
 
 
 def _assert_safe_filter_prologue(script: str, workflow: str) -> tuple[str, ...]:
@@ -400,19 +536,107 @@ def _assert_safe_filter_prologue(script: str, workflow: str) -> tuple[str, ...]:
 
 
 def _assert_trusted_detector_execution(script: str, workflow: str) -> None:
+    detector_loads = tuple(_DETECTOR_LOAD.finditer(script))
+    if len(detector_loads) != 1:
+        raise AssertionError(
+            f"{workflow} must load the trusted detector exactly once"
+        )
     trusted_execution = (
         f'if {_TRUSTED_DETECTOR_EXECUTION} > "$CHANGED_FILE"; then'
     )
-    if script.splitlines().count(trusted_execution) != 1:
+    lines = script.splitlines()
+    if lines.count(trusted_execution) != 1:
         raise AssertionError(
             f"{workflow} must execute the trusted detector once with a clean "
             "environment and absolute shell"
         )
 
+    detector_load = detector_loads[0].group(0)
+    expected = (
+        detector_load,
+        "  :",
+        "else",
+        "  DETECTOR_STATUS=$?",
+        '  echo "::error::unable to load change detector from base revision '
+        '(status $DETECTOR_STATUS)" >&2',
+        '  exit "$DETECTOR_STATUS"',
+        "fi",
+        trusted_execution,
+        "  :",
+        "else",
+        "  DETECTOR_STATUS=$?",
+        '  echo "::error::change detector failed with status '
+        '$DETECTOR_STATUS" >&2',
+        '  exit "$DETECTOR_STATUS"',
+        "fi",
+        'CHANGED=$(<"$CHANGED_FILE")',
+    )
+    start = lines.index(detector_load)
+    actual = tuple(lines[start : start + len(expected)])
+    if actual != expected:
+        mismatch = next(
+            (
+                index
+                for index in range(max(len(actual), len(expected)))
+                if index >= len(actual)
+                or index >= len(expected)
+                or actual[index] != expected[index]
+            ),
+            0,
+        )
+        found = "<missing>" if mismatch >= len(actual) else repr(actual[mismatch])
+        required = (
+            "<end>" if mismatch >= len(expected) else repr(expected[mismatch])
+        )
+        raise AssertionError(
+            f"{workflow} violates ordered detector execution at line "
+            f"{mismatch + 1}: expected {required}, found {found}"
+        )
+
+    contract_key = _workflow_contract_key(workflow)
+    classification_lines = lines[start + len(expected) :]
+    if any(
+        line.lstrip().startswith("#") and line.rstrip().endswith("\\")
+        for line in classification_lines
+    ):
+        raise AssertionError(
+            f"{workflow} violates ordered selector classification with a "
+            "continued comment"
+        )
+    classification = tuple(
+        line.strip()
+        for line in classification_lines
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+    selector_writes = tuple(
+        f'echo "{selector}={value}" >> "$GITHUB_OUTPUT"'
+        for selector in _EXPECTED_SELECTOR_OUTPUTS[contract_key]
+        for value in ("true", "false")
+    )
+    for statement in classification:
+        if re.search(
+            r"(?:^|[\s;&|()])(?:exit|return|exec)(?=$|[\s;&|()])",
+            statement,
+        ):
+            raise AssertionError(
+                f"{workflow} violates ordered selector classification with "
+                f"an early terminating statement: {statement!r}"
+            )
+        if "GITHUB_OUTPUT" in statement and statement not in selector_writes:
+            raise AssertionError(
+                f"{workflow} violates ordered selector classification with "
+                f"an unrecognized output statement: {statement!r}"
+            )
+    for write in selector_writes:
+        if classification.count(write) != 1:
+            raise AssertionError(
+                f"{workflow} selector classification must write {write!r} "
+                "exactly once after trusted detector execution"
+            )
+
 
 def _assert_safe_filter_workflow(contents: str, workflow: str) -> None:
-    _assert_filter_execution_envelope(contents, workflow)
-    script = _workflow_run_script_from_contents(contents, "changes", "filter")
+    script = _assert_filter_execution_envelope(contents, workflow)
     _assert_safe_filter_prologue(script, workflow)
     _assert_trusted_detector_execution(script, workflow)
 
@@ -475,11 +699,16 @@ class _FailOnEmptyTestProgram(unittest.TestProgram):
 
 
 def _engine_change_pattern(contents: str) -> re.Pattern[str]:
-    changes = _workflow_job(contents, "changes")
+    script = _workflow_run_script_from_contents(
+        contents,
+        "changes",
+        "filter",
+        _E2E_PARITY_WORKFLOW.name,
+    )
     match = re.search(
         r"""if\ grep\ -E\ '([^']+)'\ <<<"\$CHANGED"\ >/dev/null;\ then
             \s+echo\ "engine=true" """,
-        changes,
+        script,
         re.VERBOSE,
     )
     if match is None:
@@ -995,19 +1224,25 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
         for relative_path in _REQUIRED_WORKFLOWS:
             with self.subTest(workflow=relative_path):
                 contents = (_ROOT / relative_path).read_text(encoding="utf-8")
-                job = _workflow_job(contents, "changes")
-                step_entries = re.findall(
-                    r"^      -(?: .*)?$",
-                    job,
-                    re.MULTILINE,
+                document = _parse_workflow(contents, relative_path)
+                job = _parsed_workflow_job(document, "changes", relative_path)
+                steps = job.get("steps")
+                self.assertIsInstance(steps, list)
+                assert isinstance(steps, list)
+                self.assertGreaterEqual(len(steps), 2)
+                checkout = _require_mapping(
+                    steps[0],
+                    f"{relative_path} checkout step",
                 )
-
-                self.assertGreaterEqual(len(step_entries), 2)
                 self.assertRegex(
-                    step_entries[0],
-                    r"^      - uses: actions/checkout@[0-9a-f]{40}(?: # .*)?$",
+                    str(checkout.get("uses")),
+                    r"^actions/checkout@[0-9a-f]{40}$",
                 )
-                self.assertEqual(step_entries[1], "      - id: filter")
+                filter_step = _require_mapping(
+                    steps[1],
+                    f"{relative_path} filter step",
+                )
+                self.assertEqual(filter_step.get("id"), "filter")
 
     def test_change_filter_prologues_match_declared_ordered_grammar(
         self,
@@ -1024,6 +1259,168 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
                     relative_path,
                 )
 
+    def test_filter_execution_rejects_selector_or_exit_before_trusted_execution(
+        self,
+    ) -> None:
+        contents = _CI_WORKFLOW.read_text(encoding="utf-8")
+        _assert_safe_filter_workflow(contents, _CI_WORKFLOW.name)
+        trusted_execution = (
+            f"          if {_TRUSTED_DETECTOR_EXECUTION} "
+            '> "$CHANGED_FILE"; then\n'
+        )
+        self.assertIn(trusted_execution, contents)
+        mutations = {
+            "selector write": '          echo "code=false" >> "$GITHUB_OUTPUT"\n',
+            "exit": "          exit 0\n",
+        }
+
+        for name, statement in mutations.items():
+            workflow = contents.replace(
+                trusted_execution,
+                f"{statement}{trusted_execution}",
+                1,
+            )
+            with self.subTest(mutation=name), self.assertRaisesRegex(
+                AssertionError,
+                "ordered detector execution",
+            ):
+                _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
+
+    def test_filter_execution_rejects_preclassification_output_or_exit(
+        self,
+    ) -> None:
+        contents = _CI_WORKFLOW.read_text(encoding="utf-8")
+        _assert_safe_filter_workflow(contents, _CI_WORKFLOW.name)
+        changed = '          CHANGED=$(<"$CHANGED_FILE")\n'
+        self.assertIn(changed, contents)
+        mutations = {
+            "selector output": (
+                '          printf \'code=false\\n\' >> "$GITHUB_OUTPUT"\n'
+            ),
+            "exit": "          exit 0\n",
+        }
+
+        for name, statement in mutations.items():
+            workflow = contents.replace(
+                changed,
+                f"{changed}{statement}",
+                1,
+            )
+            with self.subTest(mutation=name), self.assertRaisesRegex(
+                AssertionError,
+                "ordered selector classification",
+            ):
+                _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
+
+    def test_changes_job_rejects_selector_output_literal(self) -> None:
+        contents = _CI_WORKFLOW.read_text(encoding="utf-8")
+        _assert_safe_filter_workflow(contents, _CI_WORKFLOW.name)
+        expected = "      code: ${{ steps.filter.outputs.code }}\n"
+        self.assertIn(expected, contents)
+        workflow = contents.replace(expected, '      code: "false"\n', 1)
+
+        with self.assertRaisesRegex(AssertionError, "output"):
+            _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
+
+    def test_changes_job_rejects_container(self) -> None:
+        contents = _CI_WORKFLOW.read_text(encoding="utf-8")
+        _assert_safe_filter_workflow(contents, _CI_WORKFLOW.name)
+        expected = "    runs-on: ubuntu-latest\n"
+        self.assertIn(expected, contents)
+        workflow = contents.replace(
+            expected,
+            f"{expected}    container: ubuntu:24.04\n",
+            1,
+        )
+
+        with self.assertRaisesRegex(AssertionError, "changes job schema"):
+            _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
+
+    def test_changes_job_rejects_unapproved_execution_schema(self) -> None:
+        contents = _CI_WORKFLOW.read_text(encoding="utf-8")
+        _assert_safe_filter_workflow(contents, _CI_WORKFLOW.name)
+        runner = "    runs-on: ubuntu-latest\n"
+        self.assertIn(runner, contents)
+        mutations = {
+            "runner": contents.replace(
+                runner,
+                "    runs-on: macos-latest\n",
+                1,
+            ),
+            "services": contents.replace(
+                runner,
+                f"{runner}    services: {{}}\n",
+                1,
+            ),
+            "defaults": contents.replace(
+                runner,
+                f"{runner}    defaults: {{run: {{shell: bash}}}}\n",
+                1,
+            ),
+            "condition": contents.replace(
+                runner,
+                f"{runner}    if: github.event_name == 'pull_request'\n",
+                1,
+            ),
+            "continue on error": contents.replace(
+                runner,
+                f"{runner}    continue-on-error: true\n",
+                1,
+            ),
+        }
+
+        for name, workflow in mutations.items():
+            expected_error = "runs-on" if name == "runner" else "changes job schema"
+            with self.subTest(field=name), self.assertRaisesRegex(
+                AssertionError,
+                expected_error,
+            ):
+                _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
+
+    def test_changes_job_rejects_job_environment_in_block_and_flow_styles(
+        self,
+    ) -> None:
+        contents = _CI_WORKFLOW.read_text(encoding="utf-8")
+        _assert_safe_filter_workflow(contents, _CI_WORKFLOW.name)
+        expected = "    runs-on: ubuntu-latest\n"
+        self.assertIn(expected, contents)
+        environments = {
+            "block": "    env:\n      PATH: /tmp/filter-bin\n",
+            "flow": "    env: {PATH: /tmp/filter-bin}\n",
+        }
+
+        for style, environment in environments.items():
+            workflow = contents.replace(
+                expected,
+                f"{expected}{environment}",
+                1,
+            )
+            with self.subTest(style=style), self.assertRaisesRegex(
+                AssertionError,
+                "changes job schema|job environment",
+            ):
+                _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
+
+    def test_filter_step_accepts_equivalent_flow_style_environment(self) -> None:
+        contents = _CI_WORKFLOW.read_text(encoding="utf-8")
+        _assert_safe_filter_workflow(contents, _CI_WORKFLOW.name)
+        block_environment = (
+            "        env:\n"
+            "          CI_BASE_SHA: ${{ github.event.pull_request.base.sha || "
+            "github.event.merge_group.base_sha || github.event.before }}\n"
+            "          CI_HEAD_SHA: ${{ github.event.merge_group.head_sha || "
+            "github.sha }}\n"
+        )
+        flow_environment = (
+            '        env: {CI_BASE_SHA: "${{ github.event.pull_request.base.sha || '
+            'github.event.merge_group.base_sha || github.event.before }}", '
+            'CI_HEAD_SHA: "${{ github.event.merge_group.head_sha || github.sha }}"}\n'
+        )
+        self.assertIn(block_environment, contents)
+        workflow = contents.replace(block_environment, flow_environment, 1)
+
+        _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
+
     def test_detector_reader_event_matrix_is_complete(self) -> None:
         self.assertEqual(_DETECTOR_EVENTS, ("pull_request", "merge_group"))
 
@@ -1039,7 +1436,9 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
             f"{marker}",
             1,
         )
-        step = f"{step}          fi\n"
+        changed = '          CHANGED=$(<"$CHANGED_FILE")\n'
+        self.assertIn(changed, step)
+        step = step.replace(changed, f"{changed}          fi\n", 1)
         workflow = self._ci_workflow_with_filter_step(step)
 
         with self.assertRaisesRegex(AssertionError, "top level"):
@@ -1109,7 +1508,7 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
                 workflow = self._ci_workflow_with_filter_step(mutated_step)
                 with self.assertRaisesRegex(
                     AssertionError,
-                    "step metadata|shell command",
+                    "step metadata|shell command|valid workflow YAML",
                 ):
                     _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
 
@@ -1166,7 +1565,7 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
         for name, workflow in mutations.items():
             with self.subTest(scope=name), self.assertRaisesRegex(
                 AssertionError,
-                "defaults|environment|merge",
+                "defaults|environment|schema|valid workflow YAML",
             ):
                 _assert_safe_filter_workflow(workflow, _CI_WORKFLOW.name)
 
@@ -1174,14 +1573,14 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
         for relative_path in _REQUIRED_WORKFLOWS:
             with self.subTest(workflow=relative_path):
                 contents = (_ROOT / relative_path).read_text(encoding="utf-8")
-                step = _workflow_step_by_id(
-                    _workflow_job(contents, "changes"),
+                document = _parse_workflow(contents, relative_path)
+                job = _parsed_workflow_job(document, "changes", relative_path)
+                _, step = _parsed_workflow_step_by_id(
+                    job,
                     "filter",
+                    relative_path,
                 )
-                self.assertIn(
-                    f"        shell: {_TRUSTED_FILTER_SHELL}\n",
-                    step,
-                )
+                self.assertEqual(step.get("shell"), _TRUSTED_FILTER_SHELL)
 
     def test_filter_workflow_rejects_unsanitized_detector_commands(self) -> None:
         contents = _CI_WORKFLOW.read_text(encoding="utf-8")

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -518,20 +518,98 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
             ("engine=true", "tune=true"),
         )
 
-    def test_change_jobs_extract_detector_immediately_after_checkout(self) -> None:
+    def test_change_jobs_start_filter_immediately_after_checkout(self) -> None:
+        detector_load = (
+            'if git --no-replace-objects show '
+            '"${CI_BASE_SHA}:scripts/ci-changed-files.sh" '
+            '> "$TRUSTED_DETECTOR"; then'
+        )
+        repository_command = re.compile(
+            r"""(?mx)
+            (?:^[ \t]*|[;&|][ \t]*)
+            (?:(?:if|elif|while|until)[ \t]+)?
+            (?:
+                (?:source|\.)[ \t]+
+              | (?:bash|sh|python(?:3)?|node|deno|cargo|make|git)(?:[ \t]|$)
+              | (?:\./|\.\./|(?:\.github|apps|crates|scripts|tests)/)
+            )
+            """
+        )
+
         for relative_path in _REQUIRED_WORKFLOWS:
             with self.subTest(workflow=relative_path):
                 contents = (_ROOT / relative_path).read_text(encoding="utf-8")
                 job = _workflow_job(contents, "changes")
-                step_headers = re.findall(
-                    r"^      - ((?:uses|id|name): .+)$",
+                step_entries = re.findall(
+                    r"^      -(?: .*)?$",
                     job,
                     re.MULTILINE,
                 )
 
-                self.assertGreaterEqual(len(step_headers), 2)
-                self.assertRegex(step_headers[0], r"^uses: actions/checkout@")
-                self.assertEqual(step_headers[1], "id: filter")
+                self.assertGreaterEqual(len(step_entries), 2)
+                self.assertRegex(
+                    step_entries[0],
+                    r"^      - uses: actions/checkout@[0-9a-f]{40}(?: # .*)?$",
+                )
+                self.assertEqual(step_entries[1], "      - id: filter")
+
+                script = _workflow_run_script(
+                    _ROOT / relative_path,
+                    "changes",
+                    "filter",
+                )
+                prefix, separator, _ = script.partition(detector_load)
+                self.assertEqual(separator, detector_load)
+                self.assertIsNone(
+                    repository_command.search(prefix),
+                    f"{relative_path} runs repository commands before detector loading",
+                )
+
+    def test_app_binaries_full_selection_exceptions_are_exactly_enumerated(
+        self,
+    ) -> None:
+        script = _workflow_run_script(
+            _APP_BINARIES_WORKFLOW,
+            "changes",
+            "filter",
+        )
+        prefix, separator, _ = script.partition("TRUSTED_DETECTOR=$(mktemp)")
+        self.assertEqual(separator, "TRUSTED_DETECTOR=$(mktemp)")
+
+        exceptions = tuple(
+            (
+                condition,
+                tuple(
+                    re.findall(
+                        r'^  echo "((?:bins|swift)=true)" '
+                        r'>> "\$GITHUB_OUTPUT"$',
+                        body,
+                        re.MULTILINE,
+                    )
+                ),
+            )
+            for condition, body in re.findall(
+                r"^if ([^\n]+); then\n(.*?)^fi$",
+                prefix,
+                re.MULTILINE | re.DOTALL,
+            )
+            if re.search(r"^  exit 0$", body, re.MULTILINE) is not None
+        )
+
+        self.assertEqual(
+            exceptions,
+            (
+                (
+                    '[ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]',
+                    ("bins=true", "swift=true"),
+                ),
+                (
+                    f'[ "$CI_BASE_SHA" = "{_ZERO_SHA}" ]',
+                    ("bins=true", "swift=true"),
+                ),
+            ),
+        )
+        self.assertEqual(prefix.count("  exit 0\n"), 2)
 
     def test_unavailable_base_fails_without_selector_outputs(self) -> None:
         head = self._commit("README.md", "head\n")

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -265,11 +265,31 @@ class ChangedFilesTests(unittest.TestCase):
             result.stderr,
         )
 
-    def test_resolved_empty_range_succeeds_without_changed_paths(self) -> None:
+    def test_degenerate_equal_commit_range_fails_with_named_error(self) -> None:
         head = self._commit("README.md", "base\n")
 
-        result = self._run("pull_request", head, head, check=False)
+        for base in (head, head[:12], head.upper()):
+            with self.subTest(base=base):
+                result = self._run("pull_request", base, head, check=False)
 
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(result.stdout, "")
+                self.assertEqual(
+                    result.stderr,
+                    f"event base {base} and event head {head} resolve to the "
+                    "same commit; refusing degenerate range\n",
+                )
+
+    def test_distinct_commit_empty_range_succeeds_without_changed_paths(
+        self,
+    ) -> None:
+        base = self._commit("README.md", "base\n")
+        self._git("commit", "--allow-empty", "-q", "-m", "empty change")
+        head = self._git("rev-parse", "HEAD")
+
+        result = self._run("pull_request", base, head, check=False)
+
+        self.assertNotEqual(base, head)
         self.assertEqual(result.returncode, 0)
         self.assertEqual(result.stdout.strip(), "")
         self.assertEqual(result.stderr, "")

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -25,6 +25,69 @@ _E2E_PARITY_WORKFLOW = _ROOT / ".github/workflows/e2e-parity.yml"
 _CI_WORKFLOW = _ROOT / ".github/workflows/ci.yml"
 _CARGO_AUDIT_WORKFLOW = _ROOT / ".github/workflows/cargo-audit.yml"
 _APP_BINARIES_WORKFLOW = _ROOT / ".github/workflows/app-binaries.yml"
+_DETECTOR_LOAD = re.compile(
+    r'^[ \t]*if git(?: --no-replace-objects)? show '
+    r'"\$\{CI_BASE_SHA\}:scripts/ci-changed-files\.sh" '
+    r'> "\$TRUSTED_DETECTOR"; then$',
+    re.MULTILINE,
+)
+_SAFE_FILTER_PROLOGUE_PRIMITIVES = (
+    ("strict shell options", re.compile(r"set -euo pipefail")),
+    (
+        "event policy condition",
+        re.compile(
+            r'if \[ "\$GITHUB_EVENT_NAME" = "(?:pull_request|workflow_dispatch)" \]'
+            r'(?: \|\| \[ "\$GITHUB_EVENT_NAME" = "(?:merge_group|schedule)" \])?; then'
+        ),
+    ),
+    (
+        "base format condition",
+        re.compile(
+            r'if \[\[ ! "\$CI_BASE_SHA" =~ \^\[0-9a-fA-F\]\{40\}\$ \]\]; then'
+        ),
+    ),
+    (
+        "all-zero base condition",
+        re.compile(r'if \[ "\$CI_BASE_SHA" = "0{40}" \]; then'),
+    ),
+    (
+        "selector output",
+        re.compile(
+            r'echo "(?:code|deps|bins|swift|engine|tune)=true" '
+            r'>> "\$GITHUB_OUTPUT"'
+        ),
+    ),
+    (
+        "base validation diagnostic",
+        re.compile(
+            r'echo "::error::base revision must be a nonempty '
+            r'40-character hexadecimal commit ID" >&2'
+        ),
+    ),
+    (
+        "selection diagnostic",
+        re.compile(
+            r'echo "→ (?:'
+            r'all-zero base revision: '
+            r'(?:full matrix|audit|app-binary and Swift builds|full parity suite) '
+            r'REQUIRED'
+            r'|manual dispatch: app-binary and Swift builds REQUIRED'
+            r'|\$GITHUB_EVENT_NAME trigger: full parity suite REQUIRED)"'
+        ),
+    ),
+    ("early exit", re.compile(r"exit [02]")),
+    ("conditional terminator", re.compile(r"fi")),
+    (
+        "temporary-file allocation",
+        re.compile(r"(?:TRUSTED_DETECTOR|CHANGED_FILE)=\$\(mktemp\)"),
+    ),
+    (
+        "temporary-file cleanup",
+        re.compile(
+            r'''trap 'rm -f "\$TRUSTED_DETECTOR" "\$CHANGED_FILE"' EXIT'''
+        ),
+    ),
+)
 
 
 def _workflow_job(contents: str, job_id: str) -> str:
@@ -81,6 +144,31 @@ def _workflow_run_script(workflow: Path, job_id: str, step_id: str) -> str:
     if marker not in step:
         raise AssertionError(f"workflow step id {step_id!r} has no run script")
     return textwrap.dedent(step.split(marker, maxsplit=1)[1])
+
+
+def _assert_safe_filter_prologue(script: str, workflow: str) -> set[str]:
+    """Reject every undeclared executable statement before detector loading."""
+    detector_load = _DETECTOR_LOAD.search(script)
+    if detector_load is None:
+        raise AssertionError(f"{workflow} does not load the base detector")
+    prefix = script[: detector_load.start()]
+    used_primitives = set()
+    for line_number, raw_line in enumerate(prefix.splitlines(), start=1):
+        statement = raw_line.strip()
+        if not statement or statement.startswith("#"):
+            continue
+        matches = tuple(
+            name
+            for name, pattern in _SAFE_FILTER_PROLOGUE_PRIMITIVES
+            if pattern.fullmatch(statement) is not None
+        )
+        if len(matches) != 1:
+            raise AssertionError(
+                f"{workflow} has an undeclared statement before detector "
+                f"loading on line {line_number}: {statement!r}"
+            )
+        used_primitives.add(matches[0])
+    return used_primitives
 
 
 def _require_tests_collected(test_suite: unittest.TestSuite) -> None:
@@ -455,6 +543,12 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
         for expected_output in expected_outputs:
             self.assertIn(expected_output, output)
 
+    def _ci_filter_with_added_prologue(self, statement: str) -> str:
+        script = _workflow_run_script(_CI_WORKFLOW, "changes", "filter")
+        marker = "TRUSTED_DETECTOR=$(mktemp)"
+        self.assertIn(marker, script)
+        return script.replace(marker, f"{statement}\n{marker}", 1)
+
     def test_ci_runs_the_base_detector_and_classifies_its_change(self) -> None:
         self._assert_base_detector_wins(_CI_WORKFLOW, ("code=true",))
 
@@ -519,18 +613,6 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
         )
 
     def test_change_jobs_start_filter_immediately_after_checkout(self) -> None:
-        repository_command = re.compile(
-            r"""(?mx)
-            (?:^[ \t]*|[;&|][ \t]*)
-            (?:(?:if|elif|while|until)[ \t]+)?
-            (?:
-                (?:source|\.)[ \t]+
-              | (?:bash|sh|python(?:3)?|node|deno|cargo|make|git)(?:[ \t]|$)
-              | (?:\./|\.\./|(?:\.github|apps|crates|scripts|tests)/)
-            )
-            """
-        )
-
         for relative_path in _REQUIRED_WORKFLOWS:
             with self.subTest(workflow=relative_path):
                 contents = (_ROOT / relative_path).read_text(encoding="utf-8")
@@ -548,24 +630,54 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
                 )
                 self.assertEqual(step_entries[1], "      - id: filter")
 
+    def test_change_filter_prologues_allow_only_declared_operations(
+        self,
+    ) -> None:
+        used_primitives = set()
+        for relative_path in _REQUIRED_WORKFLOWS:
+            with self.subTest(workflow=relative_path):
                 script = _workflow_run_script(
                     _ROOT / relative_path,
                     "changes",
                     "filter",
                 )
-                detector_load = re.search(
-                    r'^[ \t]*if git[^\n]* show '
-                    r'"\$\{CI_BASE_SHA\}:scripts/ci-changed-files\.sh" '
-                    r'> "\$TRUSTED_DETECTOR"; then$',
-                    script,
-                    re.MULTILINE,
+                used_primitives.update(
+                    _assert_safe_filter_prologue(script, relative_path)
                 )
-                self.assertIsNotNone(detector_load)
-                prefix = script[: detector_load.start()]
-                self.assertIsNone(
-                    repository_command.search(prefix),
-                    f"{relative_path} runs repository commands before detector loading",
-                )
+
+        self.assertEqual(
+            used_primitives,
+            {name for name, _ in _SAFE_FILTER_PROLOGUE_PRIMITIVES},
+        )
+
+    def test_filter_prologue_rejects_command_substitution(self) -> None:
+        script = self._ci_filter_with_added_prologue(
+            "probe=$(git rev-parse --show-toplevel)"
+        )
+
+        with self.assertRaisesRegex(AssertionError, "before detector loading"):
+            _assert_safe_filter_prologue(script, _CI_WORKFLOW.name)
+
+    def test_filter_prologue_rejects_eval_indirection(self) -> None:
+        script = self._ci_filter_with_added_prologue(
+            "eval 'git rev-parse --show-toplevel'"
+        )
+
+        with self.assertRaisesRegex(AssertionError, "before detector loading"):
+            _assert_safe_filter_prologue(script, _CI_WORKFLOW.name)
+
+    def test_filter_prologue_rejects_indirection_in_detector_load(self) -> None:
+        script = _workflow_run_script(_CI_WORKFLOW, "changes", "filter")
+        script, replacements = re.subn(
+            r"if git(?: --no-replace-objects)? show ",
+            'if git "$(scripts/preload-detector)" show ',
+            script,
+            count=1,
+        )
+        self.assertEqual(replacements, 1)
+
+        with self.assertRaisesRegex(AssertionError, "base detector"):
+            _assert_safe_filter_prologue(script, _CI_WORKFLOW.name)
 
     def test_app_binaries_full_selection_exceptions_are_exactly_enumerated(
         self,

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -433,6 +433,28 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
         self.assertEqual(output, "")
         self.assertIn("change detector failed with status 23", result.stderr)
 
+    def _assert_replacement_ref_is_ignored(
+        self,
+        workflow: Path,
+        expected_outputs: tuple[str, ...],
+    ) -> None:
+        base = self._commit(
+            "scripts/ci-changed-files.sh",
+            "#!/bin/sh\necho scripts/ci-changed-files.sh\n",
+        )
+        self._commit("README.md", "head\n")
+        replacement = self._commit(
+            "scripts/ci-changed-files.sh",
+            "#!/bin/sh\nexit 29\n",
+        )
+        self._git("replace", base, replacement)
+
+        result, output = self._run_filter(workflow, base, replacement)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for expected_output in expected_outputs:
+            self.assertIn(expected_output, output)
+
     def test_ci_runs_the_base_detector_and_classifies_its_change(self) -> None:
         self._assert_base_detector_wins(_CI_WORKFLOW, ("code=true",))
 
@@ -468,6 +490,67 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
 
     def test_e2e_parity_observes_detector_failure_status(self) -> None:
         self._assert_detector_failure_is_observed(_E2E_PARITY_WORKFLOW)
+
+    def test_ci_ignores_replacement_ref_when_loading_detector(self) -> None:
+        self._assert_replacement_ref_is_ignored(_CI_WORKFLOW, ("code=true",))
+
+    def test_cargo_audit_ignores_replacement_ref_when_loading_detector(
+        self,
+    ) -> None:
+        self._assert_replacement_ref_is_ignored(
+            _CARGO_AUDIT_WORKFLOW,
+            ("deps=true",),
+        )
+
+    def test_app_binaries_ignores_replacement_ref_when_loading_detector(
+        self,
+    ) -> None:
+        self._assert_replacement_ref_is_ignored(
+            _APP_BINARIES_WORKFLOW,
+            ("bins=true", "swift=true"),
+        )
+
+    def test_e2e_parity_ignores_replacement_ref_when_loading_detector(
+        self,
+    ) -> None:
+        self._assert_replacement_ref_is_ignored(
+            _E2E_PARITY_WORKFLOW,
+            ("engine=true", "tune=true"),
+        )
+
+    def test_change_jobs_extract_detector_immediately_after_checkout(self) -> None:
+        for relative_path in _REQUIRED_WORKFLOWS:
+            with self.subTest(workflow=relative_path):
+                contents = (_ROOT / relative_path).read_text(encoding="utf-8")
+                job = _workflow_job(contents, "changes")
+                step_headers = re.findall(
+                    r"^      - ((?:uses|id|name): .+)$",
+                    job,
+                    re.MULTILINE,
+                )
+
+                self.assertGreaterEqual(len(step_headers), 2)
+                self.assertRegex(step_headers[0], r"^uses: actions/checkout@")
+                self.assertEqual(step_headers[1], "id: filter")
+
+    def test_unavailable_base_fails_without_selector_outputs(self) -> None:
+        head = self._commit("README.md", "head\n")
+
+        for workflow in (
+            _CI_WORKFLOW,
+            _CARGO_AUDIT_WORKFLOW,
+            _APP_BINARIES_WORKFLOW,
+            _E2E_PARITY_WORKFLOW,
+        ):
+            with self.subTest(workflow=workflow.name):
+                result, output = self._run_filter(workflow, "f" * 40, head)
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertEqual(output, "")
+                self.assertIn(
+                    "unable to load change detector from base revision",
+                    result.stderr,
+                )
 
     def test_invalid_base_never_executes_checkout_detector(self) -> None:
         head = self._commit(

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -51,7 +51,7 @@ def _workflow_step(job: str, step_name: str) -> str:
         raise AssertionError(f"workflow step {step_name!r} is missing")
     body_start = start + len(marker)
     next_match = re.search(
-        r"^      - (?:name:|uses:)",
+        r"^(?:      -(?: .*)?| {0,4}\S.*)$",
         job[body_start:],
         re.MULTILINE,
     )
@@ -66,7 +66,7 @@ def _workflow_step_by_id(job: str, step_id: str) -> str:
         raise AssertionError(f"workflow step id {step_id!r} is missing")
     body_start = start + len(marker)
     next_match = re.search(
-        r"^      - (?:id:|name:|uses:)",
+        r"^(?:      -(?: .*)?| {0,4}\S.*)$",
         job[body_start:],
         re.MULTILINE,
     )
@@ -519,11 +519,6 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
         )
 
     def test_change_jobs_start_filter_immediately_after_checkout(self) -> None:
-        detector_load = (
-            'if git --no-replace-objects show '
-            '"${CI_BASE_SHA}:scripts/ci-changed-files.sh" '
-            '> "$TRUSTED_DETECTOR"; then'
-        )
         repository_command = re.compile(
             r"""(?mx)
             (?:^[ \t]*|[;&|][ \t]*)
@@ -558,8 +553,15 @@ class ChangeDetectorWorkflowTests(unittest.TestCase):
                     "changes",
                     "filter",
                 )
-                prefix, separator, _ = script.partition(detector_load)
-                self.assertEqual(separator, detector_load)
+                detector_load = re.search(
+                    r'^[ \t]*if git[^\n]* show '
+                    r'"\$\{CI_BASE_SHA\}:scripts/ci-changed-files\.sh" '
+                    r'> "\$TRUSTED_DETECTOR"; then$',
+                    script,
+                    re.MULTILINE,
+                )
+                self.assertIsNotNone(detector_load)
+                prefix = script[: detector_load.start()]
                 self.assertIsNone(
                     repository_command.search(prefix),
                     f"{relative_path} runs repository commands before detector loading",

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -6,6 +6,7 @@ import os
 import re
 import subprocess
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 
@@ -21,6 +22,9 @@ _REQUIRED_WORKFLOWS = (
     ".github/workflows/e2e-parity.yml",
 )
 _E2E_PARITY_WORKFLOW = _ROOT / ".github/workflows/e2e-parity.yml"
+_CI_WORKFLOW = _ROOT / ".github/workflows/ci.yml"
+_CARGO_AUDIT_WORKFLOW = _ROOT / ".github/workflows/cargo-audit.yml"
+_APP_BINARIES_WORKFLOW = _ROOT / ".github/workflows/app-binaries.yml"
 
 
 def _workflow_job(contents: str, job_id: str) -> str:
@@ -53,6 +57,41 @@ def _workflow_step(job: str, step_name: str) -> str:
     )
     end = len(job) if next_match is None else body_start + next_match.start()
     return job[start:end]
+
+
+def _workflow_step_by_id(job: str, step_id: str) -> str:
+    marker = f"      - id: {step_id}\n"
+    start = job.find(marker)
+    if start < 0:
+        raise AssertionError(f"workflow step id {step_id!r} is missing")
+    body_start = start + len(marker)
+    next_match = re.search(
+        r"^      - (?:id:|name:|uses:)",
+        job[body_start:],
+        re.MULTILINE,
+    )
+    end = len(job) if next_match is None else body_start + next_match.start()
+    return job[start:end]
+
+
+def _workflow_run_script(workflow: Path, job_id: str, step_id: str) -> str:
+    contents = workflow.read_text(encoding="utf-8")
+    step = _workflow_step_by_id(_workflow_job(contents, job_id), step_id)
+    marker = "        run: |\n"
+    if marker not in step:
+        raise AssertionError(f"workflow step id {step_id!r} has no run script")
+    return textwrap.dedent(step.split(marker, maxsplit=1)[1])
+
+
+def _require_tests_collected(test_suite: unittest.TestSuite) -> None:
+    if test_suite.countTestCases() == 0:
+        raise SystemExit("ERROR: no tests collected")
+
+
+class _FailOnEmptyTestProgram(unittest.TestProgram):
+    def runTests(self) -> None:
+        _require_tests_collected(self.test)
+        super().runTests()
 
 
 def _engine_change_pattern(contents: str) -> re.Pattern[str]:
@@ -214,6 +253,27 @@ class ChangedFilesTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("does not match event head", result.stderr)
 
+    def test_unavailable_base_is_a_named_range_resolution_failure(self) -> None:
+        head = self._commit("README.md", "base\n")
+
+        result = self._run("pull_request", _ZERO_SHA, head, check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn(
+            f"event base {_ZERO_SHA} is not available as a commit",
+            result.stderr,
+        )
+
+    def test_resolved_empty_range_succeeds_without_changed_paths(self) -> None:
+        head = self._commit("README.md", "base\n")
+
+        result = self._run("pull_request", head, head, check=False)
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "")
+        self.assertEqual(result.stderr, "")
+
     def test_non_ancestor_base_fails_closed(self) -> None:
         base = self._commit("README.md", "base\n")
         self._git("checkout", "-q", "--orphan", "other")
@@ -253,6 +313,144 @@ class MergeQueueWorkflowTests(unittest.TestCase):
             with self.subTest(workflow=relative_path):
                 contents = (_ROOT / relative_path).read_text(encoding="utf-8")
                 self.assertIn(trigger, contents)
+
+
+class ChangeDetectorWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tempdir = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tempdir.name)
+        self._git("init", "-q", "-b", "main")
+        self._git("config", "user.name", "CI Test")
+        self._git("config", "user.email", "ci-test@example.invalid")
+
+    def tearDown(self) -> None:
+        self._tempdir.cleanup()
+
+    def _git(self, *args: str) -> str:
+        result = subprocess.run(
+            [*_GIT, *args],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    def _commit(self, path: str, contents: str) -> str:
+        target = self.repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(contents, encoding="utf-8")
+        self._git("add", path)
+        self._git("commit", "-q", "-m", f"write {path}")
+        return self._git("rev-parse", "HEAD")
+
+    def _run_filter(
+        self,
+        workflow: Path,
+        base_sha: str,
+        head_sha: str,
+    ) -> tuple[subprocess.CompletedProcess[str], str]:
+        output = self.repo / "github-output"
+        env = os.environ.copy()
+        env.update(
+            GITHUB_EVENT_NAME="pull_request",
+            GITHUB_OUTPUT=str(output),
+            CI_BASE_SHA=base_sha,
+            CI_HEAD_SHA=head_sha,
+        )
+        result = subprocess.run(
+            [
+                "bash",
+                "--noprofile",
+                "--norc",
+                "-o",
+                "pipefail",
+                "-c",
+                _workflow_run_script(workflow, "changes", "filter"),
+            ],
+            cwd=self.repo,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        contents = output.read_text(encoding="utf-8") if output.exists() else ""
+        return result, contents
+
+    def _assert_base_detector_wins(
+        self,
+        workflow: Path,
+        expected_outputs: tuple[str, ...],
+    ) -> None:
+        base = self._commit(
+            "scripts/ci-changed-files.sh",
+            _SCRIPT.read_text(encoding="utf-8"),
+        )
+        head = self._commit(
+            "scripts/ci-changed-files.sh",
+            "#!/bin/sh\nexit 0\n",
+        )
+
+        result, output = self._run_filter(workflow, base, head)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for expected_output in expected_outputs:
+            self.assertIn(expected_output, output)
+
+    def _assert_detector_failure_is_observed(self, workflow: Path) -> None:
+        base = self._commit(
+            "scripts/ci-changed-files.sh",
+            "#!/bin/sh\nexit 23\n",
+        )
+        head = self._commit("README.md", "change\n")
+
+        result, output = self._run_filter(workflow, base, head)
+
+        self.assertEqual(result.returncode, 23)
+        self.assertEqual(output, "")
+        self.assertIn("change detector failed with status 23", result.stderr)
+
+    def test_ci_runs_the_base_detector_and_classifies_its_change(self) -> None:
+        self._assert_base_detector_wins(_CI_WORKFLOW, ("code=true",))
+
+    def test_ci_observes_detector_failure_status(self) -> None:
+        self._assert_detector_failure_is_observed(_CI_WORKFLOW)
+
+    def test_cargo_audit_runs_the_base_detector_and_classifies_its_change(
+        self,
+    ) -> None:
+        self._assert_base_detector_wins(_CARGO_AUDIT_WORKFLOW, ("deps=true",))
+
+    def test_cargo_audit_observes_detector_failure_status(self) -> None:
+        self._assert_detector_failure_is_observed(_CARGO_AUDIT_WORKFLOW)
+
+    def test_app_binaries_runs_the_base_detector_and_classifies_its_change(
+        self,
+    ) -> None:
+        self._assert_base_detector_wins(
+            _APP_BINARIES_WORKFLOW,
+            ("bins=true", "swift=true"),
+        )
+
+    def test_app_binaries_observes_detector_failure_status(self) -> None:
+        self._assert_detector_failure_is_observed(_APP_BINARIES_WORKFLOW)
+
+    def test_e2e_parity_runs_the_base_detector_and_classifies_its_change(
+        self,
+    ) -> None:
+        self._assert_base_detector_wins(
+            _E2E_PARITY_WORKFLOW,
+            ("engine=true", "tune=true"),
+        )
+
+    def test_e2e_parity_observes_detector_failure_status(self) -> None:
+        self._assert_detector_failure_is_observed(_E2E_PARITY_WORKFLOW)
+
+
+class TestRunnerContractTests(unittest.TestCase):
+    def test_empty_collection_fails_closed(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "no tests collected"):
+            _require_tests_collected(unittest.TestSuite())
 
 
 class E2eParityChangeFilterTests(unittest.TestCase):
@@ -722,5 +920,7 @@ class E2eRunnerSpecializationWorkflowTests(unittest.TestCase):
         for name, mutated in mutations.items():
             with self.subTest(mutation=name), self.assertRaises(AssertionError):
                 self._assert_split_is_fail_closed(mutated)
+
+
 if __name__ == "__main__":
-    unittest.main()
+    _FailOnEmptyTestProgram()


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- parse the four changed-files workflow consumers as YAML with GitHub-compatible boolean resolution and duplicate-key rejection
- enforce the exact `changes` job schema, runner, checkout step, filter step, and job-output bindings
- reject unapproved job execution settings, including containers, services, defaults, environment, conditions, and failure overrides
- validate the ordered detector handoff from trusted load through status handling, clean execution, and selector classification
- require every selector to be classified exactly once as an explicit boolean before a no-work success path is accepted
- treat block-style and flow-style YAML mappings by their parsed meaning
- install a pinned workflow parser in the CI job that runs the validation suite

The workflow contract is checked against the structure GitHub Actions executes. Each changed-files job must retain its trusted execution envelope and publish only the expected step outputs.

## Validation

- `python3 tests/test_ci_changed_files.py -v` — expected 73 tests, ran 73, all passed; the expected count is asserted nonzero
- `actionlint` — passed across the complete workflow set
- `python3 -m py_compile tests/test_ci_changed_files.py` — passed
- `cargo fmt --all -- --check` — passed
- `./scripts/lint-docs.sh` — passed
- `git diff --check` — passed

## Bench-compare disposition

No benchmark was run. This PR changes no `crates/` path, so no A/B comparison is required. No performance claim is made.

## Relationship to #1278

This PR owns changed-files detector validation across all four consumers; #1278 owns release gating.
