### PR TITLE
fix(bench): fail closed on missing state checkpoints

### DIFF
--- a/scripts/bench_cpu_flagship_supervisor.py
+++ b/scripts/bench_cpu_flagship_supervisor.py
@@ -76,8 +76,19 @@ import sys
 import threading
 import time
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
+
+_RUNNING_PYTHON = ".".join(str(part) for part in sys.version_info[:3])
+_PYTHON_REQUIREMENT_ERROR = (
+    f"{sys.argv[0]} requires Python 3.11 or newer; "
+    f"running Python {_RUNNING_PYTHON} at {sys.executable}"
+)
+try:
+    from datetime import UTC, datetime
+except ImportError:
+    raise SystemExit(_PYTHON_REQUIREMENT_ERROR) from None
+if sys.version_info[:2] < (3, 11):
+    raise SystemExit(_PYTHON_REQUIREMENT_ERROR)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPTS_DIR = Path(__file__).resolve().parent

--- a/scripts/bench_decode_harness.py
+++ b/scripts/bench_decode_harness.py
@@ -130,12 +130,23 @@ import statistics
 import subprocess
 import sys
 import time
-import tomllib
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Protocol
+
+_RUNNING_PYTHON = ".".join(str(part) for part in sys.version_info[:3])
+_PYTHON_REQUIREMENT_ERROR = (
+    f"{sys.argv[0]} requires Python 3.11 or newer; "
+    f"running Python {_RUNNING_PYTHON} at {sys.executable}"
+)
+try:
+    import tomllib
+    from datetime import UTC, datetime
+except ImportError:
+    raise SystemExit(_PYTHON_REQUIREMENT_ERROR) from None
+if sys.version_info[:2] < (3, 11):
+    raise SystemExit(_PYTHON_REQUIREMENT_ERROR)
 
 sys.modules.setdefault("bench_decode_harness", sys.modules[__name__])
 

--- a/scripts/lib/bench-compare-impl.sh
+++ b/scripts/lib/bench-compare-impl.sh
@@ -248,13 +248,14 @@ machine_state_probe() {
       python3 "$REPO/scripts/lib/machine-state-probe.py" --label "$label"
     )" || rc=$?
   fi
+  if [ "$rc" -ne 0 ] || [ -z "$record" ]; then
+    echo "bench-compare: machine-state checkpoint '$label' failed or returned" \
+         "no record — refusing to certify this A/B." >&2
+    exit 2
+  fi
   echo "[state] $label: $record"
   MACHINE_STATE_SAMPLES="${MACHINE_STATE_SAMPLES}${MACHINE_STATE_SAMPLES:+
 }$record"
-  if [ "$rc" -ne 0 ] && [ "$FAIL_ON_REGRESSION" = "1" ]; then
-    echo "bench-compare: machine-state checkpoint '$label' failed — refusing to certify this A/B." >&2
-    exit 2
-  fi
 }
 
 quiet_gate() {

--- a/scripts/lib/bench-compare-impl.sh
+++ b/scripts/lib/bench-compare-impl.sh
@@ -562,8 +562,8 @@ HEAD_CRITERION="$(criterion_version "$HEAD_DIR")"
 copy_base_artifacts() {
   local what="$1"; shift
   local rc=0
-  rsync "$@" 2>/dev/null || rc=$?
-  if [ "$rc" -ne 0 ] && [ "$FAIL_ON_REGRESSION" = "1" ]; then
+  rsync "$@" || rc=$?
+  if [ "$rc" -ne 0 ]; then
     echo "bench-compare: $what failed (rsync exit $rc) — refusing to certify a partial A/B." >&2
     return 2
   fi

--- a/scripts/lib/machine-state-probe.py
+++ b/scripts/lib/machine-state-probe.py
@@ -9,7 +9,18 @@ import json
 import re
 import subprocess
 import sys
-from datetime import UTC, datetime
+
+_RUNNING_PYTHON = ".".join(str(part) for part in sys.version_info[:3])
+_PYTHON_REQUIREMENT_ERROR = (
+    f"{sys.argv[0]} requires Python 3.11 or newer; "
+    f"running Python {_RUNNING_PYTHON} at {sys.executable}"
+)
+try:
+    from datetime import UTC, datetime
+except ImportError:
+    raise SystemExit(_PYTHON_REQUIREMENT_ERROR) from None
+if sys.version_info[:2] < (3, 11):
+    raise SystemExit(_PYTHON_REQUIREMENT_ERROR)
 
 SCHEMA = "lattice-machine-state-v1"
 

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -60,8 +60,19 @@ import re
 import shutil
 import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
+
+_RUNNING_PYTHON = ".".join(str(part) for part in sys.version_info[:3])
+_PYTHON_REQUIREMENT_ERROR = (
+    f"{sys.argv[0]} requires Python 3.11 or newer; "
+    f"running Python {_RUNNING_PYTHON} at {sys.executable}"
+)
+try:
+    from datetime import UTC, datetime
+except ImportError:
+    raise SystemExit(_PYTHON_REQUIREMENT_ERROR) from None
+if sys.version_info[:2] < (3, 11):
+    raise SystemExit(_PYTHON_REQUIREMENT_ERROR)
 
 PROVENANCE_SCHEMA = "lattice-bench-provenance-v1"
 MACHINE_STATE_SCHEMA = "lattice-machine-state-v1"

--- a/tests/test_bench_compare_measurement.py
+++ b/tests/test_bench_compare_measurement.py
@@ -208,6 +208,7 @@ for bench in rms_norm/896 simd_dot_product/scalar/384; do
     cp -R "$src/$bench/compare-base" "$dst/$bench/"
   fi
 done
+printf '%s\n' 'fixture rsync: partial baseline transfer' >&2
 exit 23
 """
 
@@ -352,6 +353,29 @@ class BenchCompareMeasurementGuard(unittest.TestCase):
                     f"report-only run accepted {name} state checkpoint\n"
                     f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
                 )
+
+    def test_reporter_mode_refuses_a_partial_baseline_copy(self):
+        """A partial baseline copy must void a report-only A/B."""
+        self.assertTrue(STALE_CHANGE_CARGO.strip())
+        self.assertTrue(PARTIAL_COPY_RSYNC.strip())
+        control = _run([], stub_cargo=STALE_CHANGE_CARGO)
+        self.assertEqual(
+            control.returncode,
+            0,
+            f"valid report-only fixture did not produce a usable A/B\n"
+            f"stdout:\n{control.stdout}\nstderr:\n{control.stderr}",
+        )
+        result = _run(
+            [],
+            stub_cargo=STALE_CHANGE_CARGO,
+            stub_rsync=PARTIAL_COPY_RSYNC,
+        )
+        self.assertEqual(
+            result.returncode,
+            2,
+            "report-only run accepted a partial baseline copy and could "
+            "return uncertified A/B output",
+        )
 
     def test_datetime_utc_entrypoints_reject_python_3_9_explicitly(self):
         """The declared Python minimum must fail before datetime.UTC imports."""
@@ -583,6 +607,7 @@ class BenchCompareMeasurementGuard(unittest.TestCase):
             "failed (rsync exit 23)",
             result.stderr,
         )
+        self.assertIn("fixture rsync: partial baseline transfer", result.stderr)
 
     def test_each_bench_target_gets_a_distinct_criterion_root(self):
         """Target identity must be structural, not reconstructed from group names.

--- a/tests/test_bench_compare_measurement.py
+++ b/tests/test_bench_compare_measurement.py
@@ -18,6 +18,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -73,6 +74,51 @@ print(json.dumps({
     },
 }, separators=(",", ":"), sort_keys=True))
 """
+
+STUB_MACHINE_PROBE = """#!/usr/bin/env python3
+import datetime
+import json
+import sys
+
+label = sys.argv[sys.argv.index("--label") + 1]
+print(json.dumps({
+    "schema": "lattice-machine-state-v1",
+    "label": label,
+    "captured_at_utc": datetime.datetime.now(datetime.UTC).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    ),
+    "power": {"status": "unavailable", "reason": "fixture"},
+    "thermal": {"status": "unavailable", "reason": "fixture"},
+    "idle": {"status": "unavailable", "reason": "fixture"},
+}, separators=(",", ":"), sort_keys=True))
+"""
+
+def _stub_machine_probe_with_first_failure(failure_statement):
+    if not failure_statement:
+        raise ValueError("failure statement must be non-empty")
+    marker = "print(json.dumps({"
+    if marker not in STUB_MACHINE_PROBE:
+        raise ValueError("machine-state fixture print marker is missing")
+    return STUB_MACHINE_PROBE.replace(
+        marker,
+        "if label == 'before base':\n"
+        f"    {failure_statement}\n"
+        f"{marker}",
+        1,
+    )
+
+
+FAILED_MACHINE_STATE_PROBES = {
+    "nonzero": _stub_machine_probe_with_first_failure("raise SystemExit(19)"),
+    "empty": _stub_machine_probe_with_first_failure("raise SystemExit(0)"),
+}
+
+PYTHON_ENTRYPOINTS_USING_DATETIME_UTC = (
+    REPO / "scripts" / "lib" / "machine-state-probe.py",
+    REPO / "scripts" / "perf-bench-gate.py",
+    REPO / "scripts" / "bench_decode_harness.py",
+    REPO / "scripts" / "bench_cpu_flagship_supervisor.py",
+)
 
 # Test helpers invoking real Git must disable repository hooks.
 GIT = ("git", "-c", "core.hooksPath=/dev/null")
@@ -174,6 +220,7 @@ def _run(
     setup=None,
     extra_env=None,
     emit_criterion_home=False,
+    stub_machine_state=None,
 ):
     """Run the shipping bench-compare.sh in a throwaway repo with a stub cargo."""
     with tempfile.TemporaryDirectory() as tmp:
@@ -184,7 +231,9 @@ def _run(
         shutil.copytree(LIB, root / "scripts" / "lib")
         shutil.copy2(REPO / ".gitignore", root / ".gitignore")
         governor = root / "scripts" / "perf_governor.py"
-        governor.write_text(STUB_GOVERNOR)
+        governor.write_text(
+            STUB_GOVERNOR if stub_machine_state is None else stub_machine_state
+        )
         governor.chmod(0o755)
         quiet_probe = root / "scripts" / "lib" / "quiet-probe.py"
         quiet_probe.write_text(
@@ -195,16 +244,9 @@ def _run(
         )
         machine_probe = root / "scripts" / "lib" / "machine-state-probe.py"
         machine_probe.write_text(
-            "#!/usr/bin/env python3\n"
-            "import datetime, json, sys\n"
-            "label = sys.argv[sys.argv.index('--label') + 1]\n"
-            "print(json.dumps({'schema':'lattice-machine-state-v1','label':label,"
-            "'captured_at_utc':datetime.datetime.now(datetime.UTC)"
-            ".strftime('%Y-%m-%dT%H:%M:%SZ'),"
-            "'power':{'status':'unavailable','reason':'fixture'},"
-            "'thermal':{'status':'unavailable','reason':'fixture'},"
-            "'idle':{'status':'unavailable','reason':'fixture'}},"
-            "separators=(',', ':'), sort_keys=True))\n"
+            STUB_MACHINE_PROBE
+            if stub_machine_state is None
+            else stub_machine_state
         )
 
         env_git = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
@@ -285,6 +327,99 @@ def _run(
 
 
 class BenchCompareMeasurementGuard(unittest.TestCase):
+    def test_reporter_mode_refuses_failed_machine_state_checkpoints(self):
+        """A missing state record must void a report-only A/B."""
+        self.assertGreater(len(FAILED_MACHINE_STATE_PROBES), 0)
+        control = _run([], stub_cargo=STALE_CHANGE_CARGO)
+        self.assertEqual(
+            control.returncode,
+            0,
+            f"valid report-only fixture did not produce a usable A/B\n"
+            f"stdout:\n{control.stdout}\nstderr:\n{control.stderr}",
+        )
+        for name, probe in FAILED_MACHINE_STATE_PROBES.items():
+            with self.subTest(probe=name):
+                self.assertTrue(name)
+                self.assertTrue(probe.strip())
+                result = _run(
+                    [],
+                    stub_cargo=STALE_CHANGE_CARGO,
+                    stub_machine_state=probe,
+                )
+                self.assertEqual(
+                    result.returncode,
+                    2,
+                    f"report-only run accepted {name} state checkpoint\n"
+                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+                )
+
+    def test_datetime_utc_entrypoints_reject_python_3_9_explicitly(self):
+        """The declared Python minimum must fail before datetime.UTC imports."""
+        bootstrap = (
+            "import runpy,sys;"
+            "target=sys.argv[1];"
+            "sys.argv=[target];"
+            "sys.version_info=(3,9,6);"
+            "runpy.run_path(target,run_name='__main__')"
+        )
+        self.assertTrue(bootstrap)
+        self.assertGreater(len(PYTHON_ENTRYPOINTS_USING_DATETIME_UTC), 0)
+        for entrypoint in PYTHON_ENTRYPOINTS_USING_DATETIME_UTC:
+            with self.subTest(entrypoint=entrypoint.name):
+                self.assertTrue(str(entrypoint))
+                result = subprocess.run(
+                    [sys.executable, "-c", bootstrap, str(entrypoint)],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                self.assertEqual(
+                    result.returncode,
+                    1,
+                    f"unsupported interpreter was not rejected by {entrypoint}\n"
+                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+                )
+                self.assertIn("requires Python 3.11 or newer", result.stderr)
+                self.assertIn("running Python 3.9.6", result.stderr)
+                self.assertIn(sys.executable, result.stderr)
+
+    def test_machine_state_probe_handles_missing_datetime_utc(self):
+        """A Python 3.9-shaped datetime module must yield the minimum diagnostic."""
+        bootstrap = (
+            "import runpy,sys;"
+            "target=sys.argv[1];"
+            "sys.argv=[target,'--label','compatibility-control'];"
+            "sys.version_info=(3,9,6);"
+            "runpy.run_path(target,run_name='__main__')"
+        )
+        datetime_stub = "class datetime:\n    pass\n"
+        self.assertTrue(bootstrap)
+        self.assertTrue(datetime_stub)
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "datetime.py").write_text(datetime_stub)
+            python_path = os.pathsep.join(
+                part
+                for part in (tmp, os.environ.get("PYTHONPATH"))
+                if part
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    bootstrap,
+                    str(REPO / "scripts" / "lib" / "machine-state-probe.py"),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env={**os.environ, "PYTHONPATH": python_path},
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("requires Python 3.11 or newer", result.stderr)
+        self.assertIn("running Python 3.9.6", result.stderr)
+        self.assertIn(sys.executable, result.stderr)
+        self.assertNotIn("Traceback", result.stderr)
+
     def test_every_bench_command_requires_the_committed_lockfile(self):
         """Every A/B build and measurement must refuse dependency re-resolution."""
         source = (LIB / "bench-compare-impl.sh").read_text()

--- a/tests/test_bench_locks.py
+++ b/tests/test_bench_locks.py
@@ -730,51 +730,33 @@ class MachineStateGate(unittest.TestCase):
             self.assertIn("machine-state checkpoint 'before base' failed", r.stderr)
             self.assertNotIn("Building + benching BASE", r.stdout)
 
-    def test_blocked_macos_checkpoint_reports_or_refuses_by_enforcement_mode(self):
-        with _Sandbox() as sb:
-            sb.force_platform("Darwin")
-            report_only = sb.run(
-                [sb.entry],
-                BENCH_IDLE_FLOOR="0",
-                STUB_GOVERNOR_RC="2",
-            )
-            self.assertEqual(
-                report_only.returncode,
-                0,
-                f"stdout:\n{report_only.stdout}\nstderr:\n{report_only.stderr}",
-            )
-            self.assertIn("Building + benching BASE", report_only.stdout)
-            self.assertIn("=== Run conditions ===", report_only.stdout)
-            self.assertIn("gate blocked (fixture block)", report_only.stdout)
-            self.assertIn(
-                "unsuitable as benchmark evidence",
-                report_only.stdout,
-            )
-            provenance = sb.root / ".cache" / "bench-run-provenance.txt"
-            states = [
-                json.loads(line.removeprefix("machine_state="))
-                for line in provenance.read_text().splitlines()
-                if line.startswith("machine_state=")
-            ]
-            self.assertEqual(len(states), 3)
-            self.assertTrue(
-                all(state["gate"]["status"] == "blocked" for state in states)
-            )
-
-        with _Sandbox() as sb:
-            sb.force_platform("Darwin")
-            enforcing = sb.run(
-                [sb.entry, "--fail-on-regression"],
-                BENCH_IDLE_FLOOR="0",
-                STUB_GOVERNOR_RC="2",
-            )
-            self.assertEqual(enforcing.returncode, 2, enforcing.stdout)
-            self.assertEqual(sb.machine_state_labels(), ["before base"])
-            self.assertIn(
-                "machine-state checkpoint 'before base' failed",
-                enforcing.stderr,
-            )
-            self.assertNotIn("Building + benching BASE", enforcing.stdout)
+    def test_blocked_macos_checkpoint_refuses_in_every_mode(self):
+        modes = {
+            "report-only": [],
+            "fail-on-regression": ["--fail-on-regression"],
+        }
+        self.assertGreater(len(modes), 0)
+        for mode, extra_args in modes.items():
+            with self.subTest(mode=mode), _Sandbox() as sb:
+                self.assertTrue(mode)
+                sb.force_platform("Darwin")
+                result = sb.run(
+                    [sb.entry, *extra_args],
+                    BENCH_IDLE_FLOOR="0",
+                    STUB_GOVERNOR_RC="2",
+                )
+                self.assertEqual(
+                    result.returncode,
+                    2,
+                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+                )
+                self.assertEqual(sb.machine_state_labels(), ["before base"])
+                self.assertIn(
+                    "machine-state checkpoint 'before base' failed",
+                    result.stderr,
+                )
+                self.assertNotIn("Building + benching BASE", result.stdout)
+                self.assertNotIn("=== Run conditions ===", result.stdout)
 
 
 class ContentionDiagnostics(unittest.TestCase):


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- stop `bench-compare` with exit 2 when any machine-state checkpoint exits nonzero or emits an empty record, in both report-only and `--fail-on-regression` modes
- stop `bench-compare` with exit 2 when the selected Criterion baseline copy fails, in both modes, while preserving the underlying `rsync` diagnostic
- enforce the repository Python 3.11 minimum with an immediate diagnostic that names the running version and executable before benchmark entry points can fail on `datetime.UTC` or `tomllib`
- cover nonzero and empty checkpoint results, partial baseline transfers, simulated Python 3.9 startup, the missing-`datetime.UTC` import path, and both benchmark enforcement modes

## Why

Report-only runs are used to produce A/B numbers for pull requests, so their measurement prerequisites must be as strict as the enforcing lane. A failed state checkpoint or selected-baseline transfer could previously be swallowed in report-only mode, allowing incomplete evidence to continue into normal-looking timing and gate tables. Suppressing `rsync` stderr also removed the actionable transfer failure reason.

The change does not alter thresholds, target or group selection, target classification, arm ordering, or which measurements can contribute to a FAIL verdict.

## Validation

- `python3 tests/test_bench_compare_measurement.py -v` (11 passed)
- inverse-edit control for `test_reporter_mode_refuses_a_partial_baseline_copy`: failed with `0 != 2` under the old guard, then passed after restoration
- `python3 tests/test_bench_locks.py -v` (36 passed)
- `python3 tests/test_bench_decode_harness.py -v` (122 passed)
- `python3 tests/test_bench_cpu_flagship_supervisor.py -v` (37 passed)
- `python3 scripts/perf-bench-gate.py --selftest`
- `python3 tests/test_perf_bench_gate_resolution.py -v` (5 passed)
- `python3 tests/test_perf_bench_gate_status.py -v` (6 passed)
- pre-commit hook: `cargo fmt --all -- --check`, workspace/all-targets Clippy with warnings denied, and documentation lint
- Python byte-compilation, `bash -n`, and `git diff --check`

No benchmark was run.