### PR TITLE
docs: point performance workflow citations at ADR-087

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,7 @@ make publish         # publish (dependency order, sleeps for indexing)
 # E2E parity (HF reference vs lattice)
 make e2e-parity                          # run locally (needs torch + transformers)
 
-# Perf benchmarking (ADR-058, trend data)
+# Perf benchmarking (ADR-087, trend data)
 # bench-compare takes the machine-wide bench-window and GPU locks itself and
 # gates on ambient CPU idle — do NOT wrap it in an external bench-window helper.
 make bench-compare                       # A/B: origin/main vs HEAD (~2 min, --quick)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ current main during review, not just against the PR's own diff.
 - Do not run the full Criterion suite when you can filter to relevant groups.
 - Do not submit a perf PR without `make bench-compare` output.
 
-## Performance Workflow (ADR-058)
+## Performance Workflow (ADR-087)
 
 - **Every perf PR must include before/after numbers.** No exception. Run `make bench-compare` (or `scripts/bench-compare.sh <base> <head>`) to get an A/B table. Paste the output in the PR description.
 - Default to `--quick` (~2 min). Use `--full` only when CIs are too wide to tell.


### PR DESCRIPTION
Executes ADR-087 D4: the Performance Workflow section in CLAUDE.md and the perf benchmarking block in AGENTS.md cited superseded ADR-058; both now cite ADR-087, the live decision record for the bench-compare gate.

Two-line citation change, no rule content modified. This is the exact citation-decay defect ADR-087's Problem 1 documents; the ADR merged without the update it decided, so this closes that gap.

No bench-compare disposition owed: no crate source touched.