### PR TITLE
docs(adr): mark ADR-087 accepted

### DIFF
--- a/docs/adr/ADR-087-bench-compare-gate-calibration-and-coverage.md
+++ b/docs/adr/ADR-087-bench-compare-gate-calibration-and-coverage.md
@@ -1,6 +1,6 @@
 # ADR-087: bench-compare gate calibration, coverage, and admissible structural proof
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2026-08-01
 **Crate**: workspace (bench harness; governs PRs touching lattice-inference, lattice-embed, lattice-fann)
 


### PR DESCRIPTION
One-word status flip: ADR-087 was approved and merged but its Status field still reads Proposed, which understates the decision's standing to any reader citing D1-D4. No other content changes.