### PR TITLE
ci: pause the post-merge perf lane's automatic trigger

### DIFF
--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -1,4 +1,9 @@
-name: perf post-merge detection (informational)
+name: perf post-merge detection (informational, PAUSED)
+#
+# PAUSED 2026-08-01: this lane no longer runs automatically. It is on-demand only
+# (workflow_dispatch). The rest of this header describes the lane's design and is
+# unchanged; the reason for the pause and the conditions for lifting it are in the
+# block immediately above `on:`. Read that before restoring the trigger.
 #
 # WHAT THIS IS, AND WHAT IT IS NOT (lattice#1105).
 #
@@ -33,27 +38,63 @@ name: perf post-merge detection (informational)
 # range back to that recorded commit instead of putting the skipped change in
 # both arms. The first run falls back to the event parent and says so.
 
+# PAUSED 2026-08-01, NOT FIXED. The automatic push trigger is removed; the lane
+# still runs on demand via workflow_dispatch, unchanged in every other respect.
+#
+# Why. Across its 15 verdict-producing runs this lane reported a confirmed
+# regression every single time, on 15 unrelated merges. The cause is its
+# decision rule, not its plumbing: the rule fails a run when a group's LOWER
+# confidence bound exceeds 7%, applied one-sidedly across 263 group comparisons
+# per run. Criterion's confidence intervals are tight WITHIN a run (median width
+# across the 82 FAIL rows: 0.280 percentage points) while the same groups swing
+# widely BETWEEN runs, and a within-run interval cannot bound between-run
+# variability. With 263 groups and that spread, at least one positive excursion
+# past 7% is close to certain, so the rule converts roughly half of a symmetric
+# noise distribution into "confirmed regressions". The recurrence signature
+# confirms the reading: the same groups flag across unrelated merges
+# (simd_throughput_384/normalize in 7 of 15 runs), and if those were genuine
+# per-merge regressions that group would by now be about twice as slow, which it
+# is not. Large deltas are symmetric overall (85 head-slower vs 119 head-faster
+# past 7%), so this is not an arm-ordering artifact.
+#
+# Cost of leaving it on: roughly 88 minutes of wall clock per run, on each of two
+# runner jobs, for every qualifying merge, producing a verdict that cannot be
+# acted on. Excursions to 169 minutes were observed.
+#
+# What must be true before the push trigger returns. The rule needs a
+# between-run variance estimate rather than a within-run confidence interval;
+# it needs multiple-comparison handling across its 263 groups; and the
+# chronically unstable groups need identifying and either stabilising or
+# excluding. Any change to which groups are gated requires a repeated A/A on the
+# target machine class plus a re-derivation of the threshold FIRST. Restoring
+# the trigger without those changes would not restore a working detector, it
+# would resume a false alarm on every merge.
+#
+# The paths list below is retained verbatim, commented, so that restoring the
+# trigger is a revert of this block rather than a re-derivation of coverage.
+#
+# on:
+#   push:
+#     branches: [main]
+#     paths:
+#       - 'crates/inference/src/forward/cpu/**'
+#       - 'crates/inference/src/attention/**'
+#       - 'crates/inference/benches/elementwise_cpu_bench.rs'
+#       - 'crates/inference/Cargo.toml'
+#       - 'crates/embed/src/simd/**'
+#       - 'crates/embed/benches/simd.rs'
+#       - 'crates/embed/Cargo.toml'
+#       - 'Cargo.lock'
+#       # Root Cargo.toml can carry [profile.bench] (it does not today) and
+#       # .cargo/ can carry rustflags. Either can change codegen for both bench
+#       # targets without touching a single line of crate source, so both must
+#       # trigger this lane.
+#       - 'Cargo.toml'
+#       - '.cargo/**'
+#       # Harness-only changes are validated before merge and deliberately do not
+#       # trigger this lane: the head harness drives both A/B arms, so such a run
+#       # cannot attribute a measured delta to the merged diff.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'crates/inference/src/forward/cpu/**'
-      - 'crates/inference/src/attention/**'
-      - 'crates/inference/benches/elementwise_cpu_bench.rs'
-      - 'crates/inference/Cargo.toml'
-      - 'crates/embed/src/simd/**'
-      - 'crates/embed/benches/simd.rs'
-      - 'crates/embed/Cargo.toml'
-      - 'Cargo.lock'
-      # Root Cargo.toml can carry [profile.bench] (it does not today) and
-      # .cargo/ can carry rustflags. Either can change codegen for both bench
-      # targets without touching a single line of crate source, so both must
-      # trigger this lane.
-      - 'Cargo.toml'
-      - '.cargo/**'
-      # Harness-only changes are validated before merge and deliberately do not
-      # trigger this lane: the head harness drives both A/B arms, so such a run
-      # cannot attribute a measured delta to the merged diff.
   workflow_dispatch:
     inputs:
       base_ref:

--- a/tests/test_perf_postmerge_workflow.py
+++ b/tests/test_perf_postmerge_workflow.py
@@ -23,19 +23,65 @@ _BENCH_BINARY_INPUTS = {
     ".cargo/**",
 }
 _PATH_ENTRY = re.compile(r"^      - '([^']+)'$")
+_ACTIVE_PUSH = "  push:"
+_PAUSED_PUSH = "#   push:"
+
+
+def _uncomment(line: str) -> str:
+    if line.startswith("# "):
+        return line[2:]
+    if line == "#":
+        return ""
+    return line
+
+
+def _trigger_state() -> str:
+    """Return 'active' or 'paused', failing if the file is in neither or both.
+
+    The lane can be paused by commenting out its push trigger, leaving
+    workflow_dispatch as the only entry point. In that state the paths list is
+    retained verbatim as comments so restoring the trigger is a revert rather
+    than a re-derivation of coverage, and the path contract below keeps pinning
+    the retained list. A file carrying both forms, or neither, is ambiguous
+    about which one governs, so it is rejected rather than guessed at.
+    """
+    lines = _WORKFLOW.read_text(encoding="utf-8").splitlines()
+    active = _ACTIVE_PUSH in lines
+    paused = _PAUSED_PUSH in lines
+    if active and paused:
+        raise AssertionError("workflow carries both a live and a commented push trigger")
+    if not active and not paused:
+        raise AssertionError("post-merge workflow push paths block is missing")
+    return "active" if active else "paused"
 
 
 def _push_paths() -> set[str]:
-    lines = _WORKFLOW.read_text(encoding="utf-8").splitlines()
+    raw = _WORKFLOW.read_text(encoding="utf-8").splitlines()
+    if _trigger_state() == "active":
+        try:
+            push_start = raw.index(_ACTIVE_PUSH)
+            block_end = raw.index("  workflow_dispatch:", push_start)
+            lines = raw
+        except ValueError as error:
+            raise AssertionError("post-merge workflow push paths block is missing") from error
+    else:
+        try:
+            start = raw.index(_PAUSED_PUSH)
+            # The commented block is terminated by the live `on:` that follows it.
+            block_end_raw = raw.index("on:", start)
+        except ValueError as error:
+            raise AssertionError("commented push paths block is malformed") from error
+        lines = [_uncomment(line) for line in raw[start:block_end_raw]]
+        push_start = 0
+        block_end = len(lines)
+
     try:
-        push_start = lines.index("  push:")
-        dispatch_start = lines.index("  workflow_dispatch:", push_start)
-        paths_start = lines.index("    paths:", push_start, dispatch_start)
+        paths_start = lines.index("    paths:", push_start, block_end)
     except ValueError as error:
         raise AssertionError("post-merge workflow push paths block is missing") from error
 
     paths: set[str] = set()
-    for line in lines[paths_start + 1 : dispatch_start]:
+    for line in lines[paths_start + 1 : block_end]:
         if line.lstrip().startswith("- "):
             match = _PATH_ENTRY.fullmatch(line)
             if match is None:
@@ -50,6 +96,24 @@ def _push_paths() -> set[str]:
 class PerfPostmergeWorkflowTests(unittest.TestCase):
     def test_push_filter_contains_only_bench_binary_inputs(self) -> None:
         self.assertEqual(_push_paths(), _BENCH_BINARY_INPUTS)
+
+    def test_trigger_state_is_unambiguous(self) -> None:
+        self.assertIn(_trigger_state(), {"active", "paused"})
+
+    def test_paused_lane_has_no_automatic_trigger(self) -> None:
+        if _trigger_state() != "paused":
+            self.skipTest("lane is active; this contract governs the paused state")
+        workflow = _WORKFLOW.read_text(encoding="utf-8").splitlines()
+        on_index = workflow.index("on:")
+        block: list[str] = []
+        for line in workflow[on_index + 1 :]:
+            # The `on:` block ends at the next top-level key.
+            if re.fullmatch(r"\w[\w-]*:.*", line):
+                break
+            block.append(line)
+        trigger_keys = [line for line in block if re.fullmatch(r"  \w+:", line)]
+        self.assertEqual(trigger_keys, ["  workflow_dispatch:"])
+        self.assertIn("PAUSED", workflow[0])
 
     def test_automated_lane_wires_ambient_status_contract(self) -> None:
         workflow = _WORKFLOW.read_text()


### PR DESCRIPTION
## Summary

Removes the automatic `push` trigger from the post-merge perf lane. The lane is **paused, not fixed**: `workflow_dispatch` is unchanged, and the paths list is retained verbatim as a comment so that restoring the trigger is a revert of one block rather than a re-derivation of coverage.

## Why

The lane has produced 15 verdict-bearing runs. All 15 reported a confirmed regression, on 15 unrelated merges.

The cause is the decision rule, not the plumbing. The rule fails a run when a group's **lower** confidence bound exceeds 7%, applied one-sidedly across **263 group comparisons per run**. Reading the gate's own published tables across all 15 runs (3,948 group comparisons):

- Criterion's intervals are tight **within** a run: median width across the 82 FAIL rows is 0.280 percentage points.
- The same groups swing widely **between** runs. `simd_throughput_384/normalize` flagged in 7 of the 15 runs; `simd_dot_product/simd/768` in 5; `simd_query_batch_dot_product/simd_batch/768d_16c` and `layer_norm/4096` in 4 each.
- A within-run interval cannot bound between-run variability, and the gate asks it to. With 263 groups and that spread, at least one positive excursion past 7% per run is close to certain, so a one-sided rule converts roughly half of a symmetric noise distribution into confirmed regressions.

Two alternative explanations were tested and rejected rather than assumed:

- **Real compounding regressions.** If those recurrences were genuine per-merge regressions, `normalize` alone would have compounded roughly 8–11% seven times over and be about twice as slow today. It is not.
- **Arm-ordering bias.** The harness on `main` runs base-then-head, so drift over a run would push head systematically slower. Measured, it does not: among the 3,948 comparisons, excursions past ±7% split 85 head-slower against 119 head-**faster**, and past ±10%, 49 against 86. Large deltas are symmetric and slightly favour improvement, which refutes a sign-aligned whole-run artifact by its own signature.

So each individual verdict is a correct application of a stated rule to a tightly-measured number. The rule is what is wrong.

## Cost of leaving it on

Roughly 88 minutes of wall clock per run on each of two runner jobs, for every qualifying merge, with observed excursions to 116, 145 and 169 minutes. Four recent runs completed the full A/B and then discarded it at the upload step, burning the entire duration for nothing.

This repository is public, so hosted runner minutes are free and the billing field reads zero. That is a billing fact, not a time fact; the wall-clock occupancy and the serial concurrency group are real.

## What is deliberately not done here

Making the failing upload step non-fatal would be the tempting smaller change. It is the wrong one: with that defect masked the lane would resume reaching its gate, and the gate's demonstrated behaviour is to call a regression on essentially every merge. That does not produce a false all-clear, it restores a false alarm.

## Restoring the trigger

Named in the workflow comment so the conditions travel with the file:

1. a between-run variance estimate rather than a within-run confidence interval;
2. multiple-comparison handling across the 263 groups;
3. identifying the chronically unstable groups and either stabilising or excluding them — and any change to which groups are gated requires a repeated A/A on the target machine class plus a re-derivation of the threshold first.

## Safety

`perf-postmerge-gate` is not a required status check. The required contexts on `main` are `ci-gate`, `cargo-deny`, `parity-gate`, `app-binaries-gate`, `typos`, `actionlint`, `cargo-audit-gate`; this lane is in none of them, and the workflow's own header already instructs that it must never be added, since a post-merge job cannot be satisfied pre-merge. Pausing it therefore cannot affect any merge.

`actionlint` passes on the edited file. The check was validated against a deliberately broken copy of the same file, which it rejects with a parse error, so a clean result is a working linter rather than a silent one.

## bench-compare disposition

Not applicable: this PR changes one file under `.github/workflows/` and touches no code in `crates/inference/`, `crates/embed/` or `crates/fann/`.
