### PR TITLE
ci: scope toolchain components to consuming jobs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,6 +250,7 @@ The `perf-baselines` branch is still updated by `bench-update.yml` on merge to m
 ## Commands
 
 ```bash
+make setup           # install rustfmt + clippy for the pinned toolchain
 make ci              # full local CI (fmt + clippy + deno lint + test + build)
 make fmt             # cargo fmt + deno fmt on markdown
 make lint-docs       # deno doc lint only

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: check clippy test test-timing fmt fmt-check build clean ci publish publish-dry publish-npm publish-npm-dry lint-docs bench-ci bench-gate bench-compare bench-agentic bench-agentic-quick wasm-parity e2e-parity bench-decode-slopefit
+.PHONY: setup check clippy test test-timing fmt fmt-check build clean ci publish publish-dry publish-npm publish-npm-dry lint-docs bench-ci bench-gate bench-compare bench-agentic bench-agentic-quick wasm-parity e2e-parity bench-decode-slopefit
+
+setup:
+	rustup component add rustfmt clippy
 
 check:
 	cargo check --workspace

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,2 @@
 [toolchain]
 channel = "1.94.1"
-components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Problem

Some GitHub runner images ship a `cargo-clippy` binary that rustup did not place. When rustup
is then asked to install the `clippy` component onto that toolchain, it refuses rather than
overwriting the existing file:

```
error: failed to install component: 'clippy-preview-aarch64-apple-darwin',
detected conflict: 'bin/cargo-clippy'
```

That failure happens during toolchain setup, so the job fails before anything is compiled. It
has been seen on both `ubuntu-24.04-arm` and macOS ARM runners, so it is not specific to one
runner distribution — it tracks the image.

`rust-toolchain.toml` declared the components globally:

```toml
[toolchain]
channel = "1.94.1"
components = ["rustfmt", "clippy"]
```

rustup honours that file, so every job installing this toolchain requested `clippy` — including
the large majority that never run it.

## What the workflow tree actually needs

The tree contains 22 `dtolnay/rust-toolchain` invocations. Three pass a `components:` input:
the required `ci` job requests `rustfmt, clippy`, and `feature-matrix` and `unwrap-in-lib-lint`
each request `clippy`.

Four steps consume these tools:

| Consumer | Tool | Governing toolchain step declares |
| --- | --- | --- |
| `ci` → `scripts/ci.sh` | `cargo fmt --all -- --check`, `cargo clippy --workspace` | `rustfmt, clippy` |
| `feature-matrix` inference Metal lint | `cargo clippy -p lattice-inference` | `clippy` |
| `feature-matrix` embed Metal lint | `cargo clippy -p lattice-embed` | `clippy` |
| `unwrap-in-lib-lint` | `cargo clippy --workspace --lib` | `clippy` |

Every consumer is already governed by a step that declares what it needs. The other 19
invocations have no rustfmt or clippy consumer at all.

Note that the `ci` consumer is reached indirectly through `scripts/ci.sh`, so a search for
`cargo clippy` in the workflow files alone does not find it.

## Why removing the global list is safe

At the pinned action SHA, the install step is:

```
rustup toolchain install <version> <targets> <components> --profile minimal --no-self-update
```

where the `<components>` fragment is built solely from the action's `components:` input. The
three jobs that need these tools therefore keep getting them from their own declarations,
independently of the toolchain file.

## This is a reduction, not a fix

Component-install attempts drop from 22 invocations to the 3 that genuinely request them. The
conflict itself is not eliminated: those three jobs still ask rustup to install `clippy` and can
still meet a conflicting preinstalled binary on an affected runner image.

## Local development

Removing the global list means a fresh checkout no longer installs `rustfmt` and `clippy`
automatically for the pinned toolchain, so `cargo fmt` and `cargo clippy` fail with an
unrecognised-subcommand error until they are added. `make setup` does that, and the contributor
command list in `AGENTS.md` now points at it. The failure mode is loud rather than silent.

## Validation

`git diff --check`, `make setup`, `cargo fmt --version`, `cargo clippy --version`,
`make lint-docs`.

The workspace build and test suite were not run: this change touches toolchain setup and
contributor documentation only, and compiles nothing. `make setup` was exercised on a machine
where both components were already present, so it establishes the target's syntax and
idempotence rather than the fresh-install path.
