### PR TITLE
fix(ci): make pre-commit hook remediation messages reachable

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,16 +3,20 @@ set -e
 
 echo "Running pre-commit checks..."
 
+# Tooling
+if ! cargo fmt --version >/dev/null 2>&1 || ! cargo clippy --version >/dev/null 2>&1; then
+    echo "rustfmt or clippy is unavailable. Run 'make setup' to install both."
+    exit 1
+fi
+
 # Format check
-cargo fmt --all -- --check
-if [ $? -ne 0 ]; then
+if ! cargo fmt --all -- --check; then
     echo "Format check failed. Run 'make fmt' to fix."
     exit 1
 fi
 
 # Clippy
-cargo clippy --workspace --all-targets -- -D warnings
-if [ $? -ne 0 ]; then
+if ! cargo clippy --workspace --all-targets -- -D warnings; then
     echo "Clippy check failed. Fix warnings before committing."
     exit 1
 fi


### PR DESCRIPTION
## Problem

The opt-in pre-commit hook printed remediation advice that never reached the terminal, and
the advice it carried had stopped being correct.

The hook runs under `set -e` and used this shape twice:

```sh
cargo fmt --all -- --check
if [ $? -ne 0 ]; then
    echo "Format check failed. Run 'make fmt' to fix."
    exit 1
fi
```

Under `set -e` the shell exits the moment `cargo fmt` returns non-zero, so the `if` below it
never runs. Both remediation messages in the file were unreachable, and a contributor whose
check failed saw cargo's raw output with no guidance at all.

Separately, the advice no longer holds. `rust-toolchain.toml` declares only the channel, so a
fresh checkout has neither `rustfmt` nor `clippy` until `make setup` runs. In that state
`cargo fmt` exits non-zero with a "component is not installed for the toolchain" error rather
than a formatting error, and the suggested `make fmt` runs `cargo fmt --all`, which fails the
same way. The hint named a command that reproduces the failure instead of one that resolves
it.

## Change

- Preflight `cargo fmt --version` and `cargo clippy --version`. If either component is
  unavailable, exit 1 and point at `make setup`.
- Run the format and clippy checks inside `if ! ...; then`, a form `set -e` does not preempt,
  so their failure handlers are reachable.
- Genuine formatting failures still point at `make fmt`; genuine clippy failures still point
  at fixing the warnings.
- The doc-lint step and its fail-closed behaviour are unchanged.

## Scope

This affects a local contributor path only. The hook is opt-in through
`git config core.hooksPath .githooks` and no workflow sets `core.hooksPath`, so CI behaviour
is unchanged and no pipeline was affected by the old form.

## Testing

Each branch was driven with a stub `cargo` placed first on `PATH`:

| case | output | exit |
| --- | --- | --- |
| tools unavailable | `rustfmt or clippy is unavailable. Run 'make setup' to install both.` | 1 |
| formatting wrong | `Format check failed. Run 'make fmt' to fix.` | 1 |
| clippy failing | `Clippy check failed. Fix warnings before committing.` | 1 |
| clean | `Pre-commit checks passed.` | 0 |

Every remediation message was mutation-checked individually: restoring its guarded command to
the unreachable `set -e` form makes that message disappear while the other messages still
print, and each mutation was reverted by its exact inverse edit. Before the change, all three
failure cases exited non-zero without printing any remediation message.

`/bin/sh -n .githooks/pre-commit` and `git diff --check` both pass. No workspace build,
test suite, or benchmark was run: this is a shell control-flow change and those would add no
evidence about it.
