### PR TITLE
perf(embed): compile the AVX-512 VNNI int8 kernel into default x86_64 builds

### DIFF
--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -124,7 +124,13 @@ download = ["native", "lattice-inference/download"]
 # enabling this feature on a non-wasm target is a no-op rather than a build error.
 wasm = ["native", "dep:wasm-bindgen", "dep:console_error_panic_hook"]
 metal-gpu = ["lattice-inference/metal-gpu"]
-avx512 = []  # Requires nightly Rust (stdarch_x86_avx512)
+# Deprecated no-op: the AVX-512 VNNI int8 kernel this used to gate is now
+# compiled unconditionally on x86_64 (runtime-dispatched via
+# `SimdConfig::avx512vnni_enabled`, same pattern as the ungated f32 AVX-512F
+# kernel in dot_product.rs) and no longer needs an opt-in Cargo feature. Kept
+# as a no-op because it is part of the published surface (removing it would
+# break manifests that list `--features avx512`).
+avx512 = []
 # Deprecated no-op: gated a bench module for a service removed long ago, but the
 # feature is part of the published 0.4.x surface (removing it would break manifests
 # that list it). Remove in 0.5.0.

--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -588,7 +588,7 @@ unsafe fn dot_product_i8_neon_unrolled(a: &[i8], b: &[i8]) -> f32 {
 ///
 /// # Safety
 /// Requires AVX-512BW.
-#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+#[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx512f", enable = "avx512bw")]
 #[inline]
 unsafe fn mm512_sign_epi8(b: __m512i, a: __m512i) -> __m512i {
@@ -609,7 +609,7 @@ unsafe fn mm512_sign_epi8(b: __m512i, a: __m512i) -> __m512i {
 /// # Safety
 /// Caller must provide AVX-512F/VNNI/BW and equal `[-127, 127]` slices; bounds are chunked.
 /// See [`docs/simd.md`](../../docs/simd.md#int8-vectors) for signed-product transformation details.
-#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+#[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx512f", enable = "avx512vnni", enable = "avx512bw")]
 unsafe fn dot_product_i8_avx512vnni(a: &[i8], b: &[i8]) -> f32 {
     const SIMD_WIDTH: usize = 64; // 64 int8s per 512-bit register
@@ -795,11 +795,8 @@ fn resolve_i8_dot_kernel() -> I8DotKernel {
 
     #[cfg(target_arch = "x86_64")]
     {
-        #[cfg(feature = "avx512")]
-        {
-            if config.avx512vnni_enabled {
-                return dot_product_i8_avx512vnni_kernel;
-            }
+        if config.avx512vnni_enabled {
+            return dot_product_i8_avx512vnni_kernel;
         }
         if config.avx2_enabled {
             return dot_product_i8_avx2_kernel;
@@ -815,7 +812,7 @@ fn dot_product_i8_neon_kernel(a: &[i8], b: &[i8]) -> f32 {
     unsafe { dot_product_i8_neon_unrolled(a, b) }
 }
 
-#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+#[cfg(target_arch = "x86_64")]
 fn dot_product_i8_avx512vnni_kernel(a: &[i8], b: &[i8]) -> f32 {
     debug_assert!(a.iter().all(|&v| v != i8::MIN));
     debug_assert!(b.iter().all(|&v| v != i8::MIN));
@@ -1137,10 +1134,10 @@ mod simd_parity_tests {
     }
 
     // FP-034: AVX-512 VNNI vs scalar parity for INT8 dot product.
-    // Gated on the `avx512` build feature: the VNNI kernel only compiles then.
-    // Runs only when the host advertises AVX-512F+BW+VNNI, matching the kernel's
+    // Compiled unconditionally on x86_64 (the kernel is no longer feature-gated);
+    // runs only when the host advertises AVX-512F+BW+VNNI, matching the kernel's
     // safety contract and SimdConfig::avx512vnni_enabled.
-    #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+    #[cfg(target_arch = "x86_64")]
     #[test]
     fn test_i8_avx512vnni_scalar_parity() {
         if std::arch::is_x86_feature_detected!("avx512f")


### PR DESCRIPTION
## What this changes

The AVX-512 VNNI int8 dot-product kernel was behind an opt-in `avx512` Cargo feature. A default
`cargo build` on x86_64 did not compile it, so int8 dot products ran the AVX2 emulation path
(`_mm256_maddubs_epi16` + `_mm256_madd_epi16`, 32 lanes per step) even on a host that advertises
VNNI and could have used `_mm512_dpbusd_epi32` (64 lanes, hardware multiply-accumulate).

Five `#[cfg]` sites in `crates/embed/src/simd/quantized.rs` drop the feature predicate and keep
`target_arch = "x86_64"`: the `mm512_sign_epi8` helper, the `dot_product_i8_avx512vnni` kernel,
the dispatch branch in `resolve_i8_dot_kernel`, the safe wrapper, and the scalar-parity test.

## Why the Cargo feature was not the safety contract

Kernel selection is a runtime decision. `SimdConfig::avx512vnni_enabled` (`simd/mod.rs`) is
built from `is_x86_feature_detected!("avx512f")`, `"avx512bw"` and `"avx512vnni"` — the exact
three bits the kernel declares in `#[target_feature(enable = ...)]`. That detection block is
gated only on `target_arch`, never on the Cargo feature, so the feature decided whether the
kernel *existed*, never whether calling it was safe. Removing it therefore adds no reachable
unsafety: on a host without the bits, `avx512vnni_enabled` is false and dispatch falls through
to AVX2 exactly as before.

This also makes int8 consistent with f32, where the AVX-512F kernel in `dot_product.rs` has
always been compiled unconditionally and dispatched purely on runtime detection.

## The feature stays, as a no-op

`avx512 = []` remains in the manifest so manifests passing `--features avx512` keep building,
following the existing deprecation style in that file. Its old comment said the feature
"Requires nightly Rust (stdarch_x86_avx512)". That was not true of this code: the AVX-512
intrinsics used here have been stable since 1.89, and the crate builds on stable 1.94.1 with no
`#![feature(...)]` anywhere in the tree.

## Verification

- `cargo check -p lattice-embed --target x86_64-apple-darwin`, no feature flags: passes with the
  VNNI kernel now in the build.
- `cargo check -p lattice-embed --features avx512 --target x86_64-apple-darwin`: passes, the
  no-op feature breaks nothing.
- `cargo clippy -p lattice-embed --all-targets -- -D warnings` (aarch64 host): clean.
- `cargo test -p lattice-embed --lib simd` (aarch64 host): 104 passed, 0 failed.

**Negative control**, because "it compiles" is otherwise indistinguishable from "it is still
being skipped": inserting a deliberate syntax error inside `dot_product_i8_avx512vnni` makes the
plain default-feature x86_64 check fail at that exact line. Reverting it returns the build to
green. That is what establishes the kernel is genuinely compiled into a default build.

## Coverage gap this exposes, stated rather than fixed

`grep -rln 'avx512' .github/workflows/` returns nothing. Before this change the parity test
compiled in zero CI jobs, since no workflow passes `--features avx512`. It now compiles wherever
x86_64 is built, but it still only *executes* on a runner whose CPU advertises AVX-512-VNNI,
which is a separate question about runner hardware that this PR does not answer.

## bench-compare disposition

Structural waiver, per the compiled-out case in CONTRIBUTING guidance. Every changed line sits
inside `#[cfg(target_arch = "x86_64")]`; the manifest hunk is a comment plus a feature that
expands to nothing. The bench host is aarch64, where all of it is compiled out, so base and head
bench binaries are built from identical effective source and no A/B could attribute a delta to
this diff. An A/B on x86_64 hardware with VNNI is the measurement that would be informative here,
and this host cannot produce it.
