### PR TITLE
chore(release): v0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lattice-embed"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "blake3",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "lattice-fann"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "approx",
  "bytemuck",
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "lattice-inference"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "approx",
  "axum",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "lattice-transport"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "proptest",
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "lattice-tune"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arc-swap",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2024"
 # MSRV, verified end-to-end (workspace + deps) on 1.93.1 and guarded by the msrv CI
 # job (aarch64 macOS, f16,metal-gpu, --all-targets) so a newer-toolchain-only API

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -53,7 +53,7 @@ tracing = "0.1"
 # its own ureq/download stack to non-wasm targets, so a plain `--features wasm`
 # build stays download-free; edge/cross builds drop it with
 # `--no-default-features --features native`. See issue #1095.
-lattice-inference = { version = "0.7.0", path = "../inference", optional = true, default-features = false, features = [
+lattice-inference = { version = "0.7.1", path = "../inference", optional = true, default-features = false, features = [
     "std",
     "f16",
 ] }

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -83,7 +83,7 @@ bytemuck = { version = "1", features = ["derive"], optional = true }
 ort = { version = "2.0.0-rc.12", optional = true }
 tokenizers = { version = "0.22", optional = true, default-features = false, features = ["progressbar", "onig"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-lattice-fann = { version = "0.7.0", path = "../fann", optional = true }
+lattice-fann = { version = "0.7.1", path = "../fann", optional = true }
 
 # `fcntl(F_GETPATH)` for `weights/f32_weights.rs`'s `real_path_of_open_file`, which reports the
 # real path of an already-open shard descriptor for diagnostics and error text. Containment is

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -32,7 +32,7 @@ mixture = ["lattice-fann/online-router"]
 simulated-teacher = []
 
 [dependencies]
-lattice-fann = { version = "0.7.0", path = "../fann" }
+lattice-fann = { version = "0.7.1", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -53,7 +53,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook and training backward pass (optional — for LoRA adapter injection and gradients)
-lattice-inference = { version = "0.7.0", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.7.1", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"

--- a/docs/releases/v0.7.1.md
+++ b/docs/releases/v0.7.1.md
@@ -1,0 +1,92 @@
+# lattice v0.7.1
+
+Additive release. No breaking changes; every item below is new surface or a
+runtime dispatch improvement, and `0.7.0` code compiles unchanged against it.
+
+All three changes are in `lattice-embed`.
+
+## New: SIMD Manhattan (L1) distance
+
+`lattice_embed::simd::manhattan_distance`, re-exported through the stable utility
+facade as `lattice_embed::utils::manhattan_distance`.
+
+```rust
+use lattice_embed::utils::manhattan_distance;
+
+let d = manhattan_distance(&a, &b);
+```
+
+This completes the distance set alongside `euclidean_distance`,
+`cosine_similarity`, and `dot_product`, so consumers implementing a four-variant
+distance metric no longer have to supply their own L1 path.
+
+The kernels mirror the existing squared-L2 ones: same dispatch shape, same 4x
+unroll, same remainder handling, with `|a - b|` accumulated per lane instead of
+`(a - b)^2`. Paths are selected by the existing runtime CPU detection:
+
+| target          | instruction                         |
+| --------------- | ----------------------------------- |
+| x86-64 AVX-512F | `_mm512_abs_ps`                     |
+| x86-64 AVX2     | `_mm256_andnot_ps` with a sign mask |
+| aarch64 NEON    | `vabsq_f32`                         |
+| wasm32 SIMD128  | `f32x4_abs`                         |
+| all others      | scalar fallback                     |
+
+The AVX2 path needs only the `avx2` target feature; there is no FMA in these
+kernels, so it does not require `fma`.
+
+Behaviour matches `euclidean_distance` at the boundaries: unequal-length inputs
+return `f32::MAX`, and empty inputs return `0.0`. Agreement with the scalar
+reference is tested across 19 dimensions spanning every vector-width boundary and
+remainder case, at four seeds each.
+
+## New: cosine similarity against a precomputed query norm
+
+`lattice_embed::simd::query_norm` and
+`lattice_embed::simd::cosine_similarity_pre_normalized`.
+
+Scoring one query against many candidates previously recomputed the query's norm
+once per candidate. The new entry point takes that norm as a parameter so callers
+can hoist it out of their loop:
+
+```rust
+use lattice_embed::simd::{cosine_similarity_pre_normalized, query_norm};
+
+let nq = query_norm(&query);
+let scores: Vec<f32> = candidates
+    .iter()
+    .map(|c| cosine_similarity_pre_normalized(&query, c, nq))
+    .collect();
+```
+
+`batch_cosine_one_vs_many` now hoists the norm internally, so existing callers of
+that function get the reduced work with no source change.
+
+Results are identical to `cosine_similarity`, which is asserted by test rather
+than assumed. Degenerate inputs continue to return `0.0` rather than `NaN`, and
+the zero-magnitude threshold is unchanged and shared by both entry points.
+
+No speed claim accompanies this release. The change removes redundant work by
+construction; the repository's benchmark harness is under threshold
+re-derivation, so no A/B figure is quoted for it.
+
+## Improved: AVX-512 VNNI int8 kernel now in default x86-64 builds
+
+The VNNI int8 dot-product kernel sat behind an `avx512` cargo feature that no
+default build enabled, so x86-64 hosts with VNNI silently ran the AVX2 path. The
+kernel is now compiled into every x86-64 build and selected by the existing
+runtime CPU detection.
+
+The `avx512` feature is retained as a documented no-op so existing manifests
+enabling it continue to build.
+
+This affects x86-64 hosts only. Hosts without VNNI are unchanged, since selection
+remains a runtime check.
+
+## Upgrading
+
+```toml
+lattice-embed = "0.7.1"
+```
+
+No source changes are required.


### PR DESCRIPTION
## What

Version bump to **v0.7.1** plus release notes. Additive release, no breaking changes.

Three changes have landed since the `v0.7.0` tag, all in `lattice-embed`:

| commit | change |
|---|---|
| `ae80a93d` | SIMD Manhattan (L1) distance kernels |
| `12e6a997` | cosine similarity against a precomputed query norm |
| `9f377e2a` | AVX-512 VNNI int8 kernel compiled into default x86-64 builds |

None removes or changes an existing signature, so `0.7.0` source compiles
unchanged against `0.7.1`.

## Version pins move in lockstep

The workspace version and every internal path-dep pin were enumerated before
editing and re-counted after, rather than assumed:

| file | pins |
|---|---|
| `Cargo.toml` (`[workspace.package]`) | 1 |
| `crates/embed/Cargo.toml` | 1 (`lattice-inference`) |
| `crates/inference/Cargo.toml` | 1 (`lattice-fann`) |
| `crates/tune/Cargo.toml` | 2 (`lattice-fann`, `lattice-inference`) |

`crates/fann` and `crates/transport` are leaves and carry no internal pins. After
the edit, occurrences of `version = "0.7.0"` in those four files are 0 and
occurrences of `version = "0.7.1"` are 1/1/1/2 respectively. A sweep of tracked
`*.toml` and `*.md` files found no other `0.7.0` reference needing to move.

## Cargo.lock

The lockfile delta is **five lines**, all of them `lattice-*` package versions
(`fann`, `transport`, `inference`, `embed`, `tune`). Zero non-lattice packages are
touched, asserted by counting `name =` lines in the diff that do not match
`lattice`.

## Bench-compare disposition: not applicable, and why that is stated rather than assumed

This PR changes no code. The diff is four manifest version strings, the generated
lockfile, and one new documentation file. No function body, signature, generic
instantiation, or control-flow path is altered anywhere, so there is nothing for a
before/after comparison to measure and both arms would build identical object code.

This is a genuine not-applicable rather than a waiver of an applicable
obligation. The three feature commits above each carried their own disposition at
merge time.

## Publishing

Publish order follows the internal dependency DAG and is unchanged by this
release: `fann`, `transport` (leaves), then `inference`, then `embed`, `tune`. No
feature added a new internal dependency edge this cycle.
