### PR TITLE
docs(ci): state perf-gate figures over named populations

### DIFF
--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -31,12 +31,17 @@ name: perf post-merge detection (informational, PAUSED)
 # absence of a FAIL as evidence of a small change's absence.
 #
 # WHY AN A/B AGAINST THE LAST MEASURED COMMIT rather than perf-baselines:
-# bench-update.yml rewrites perf-baselines on every perf-path push to main, so a
-# regression can be absorbed before a scheduled comparison. This lane instead
-# advances one lightweight branch per architecture only after its own A/B
-# succeeds. If GitHub drops an intermediate pending run, the next run widens its
-# range back to that recorded commit instead of putting the skipped change in
-# both arms. The first run falls back to the event parent and says so.
+# bench-update.yml rewrites perf-baselines on nearly every perf-path push to
+# main -- 121 of its 123 recorded push-triggered runs (`gh run list
+# --workflow=bench-update.yml --json event,conclusion`); the other 2 failed the
+# bench step and their publish job was skipped, so perf-baselines was not
+# rewritten for those 2 pushes -- so a regression can usually be absorbed
+# before a scheduled comparison. This lane instead advances one lightweight
+# branch per architecture only after its own A/B succeeds. If GitHub drops an
+# intermediate pending run, the next run widens its range back to that
+# recorded commit instead of putting the skipped change in both arms. When
+# that state branch has no recorded commit yet, the run falls back to the
+# triggering push's event-before SHA instead.
 
 # PAUSED 2026-08-01, NOT FIXED. The automatic push trigger is removed; the lane
 # still runs on demand via workflow_dispatch, unchanged in every other respect.
@@ -89,25 +94,61 @@ name: perf post-merge detection (informational, PAUSED)
 # reports named above. Enumeration: `gh run list --repo ohdearquant/lattice
 # --workflow=perf-postmerge-gate.yml --limit 100 --json
 # databaseId,headSha,event,createdAt,conclusion` returns 23 runs: 1
-# workflow_dispatch, 1 cancelled push, 21 completed push runs. Of those 21,
-# 16 carry a confirmed-regression x86_64-linux verdict; this population
-# drops the earliest, run 29879966073, whose A/B baseline falls back to the
-# event parent rather than the last-measured-commit baseline the other 15
-# share (see the "first run" note above), leaving the same 15 runs -- and
-# the same 14 with a completed aarch64-linux leg -- used above.
+# workflow_dispatch, 1 cancelled push, 21 completed push runs.
+#
+# Of those 21, every x86_64-linux leg's gate step exits either 1 (confirmed
+# regression) or 2 (refused to certify -- no comparison data, checked via
+# `AB_RC:` in each job's "Classify the gate outcome" log): 15 exit 1, 6 exit
+# 2. None exit 0 (clean pass) or 3 (not measurable). The 15-run population
+# used throughout this header is the 15 exit-1 runs.
+#
+# Correction: an earlier version of this text said the run excluded from the
+# 15 was the earliest, 29879966073, on the ground that its baseline fell back
+# to the event parent instead of a last-measured-commit branch the other 15
+# use.
+# That claim does not survive checking the run's own log. Its "Resolve the
+# A/B endpoints" step printed `A/B endpoints: 05291c5ddb02... ->
+# d7929307de...`, and `05291c5d` is `git rev-parse d7929307de^` -- its
+# ordinary immediate parent, reached via the same event-before code path
+# every one of the other 14 runs in this population also used (checked the
+# same log line in each; none differ). The `scripts/perf-postmerge-base.py` /
+# `perf-postmerge-measured-*` state-branch mechanism referenced two
+# paragraphs up postdates this entire 15-run population -- it first appears
+# in a run's log on 2026-07-31, after run 30489540763, the last of the 15.
+# 29879966073 belongs in the population on identical footing to the rest.
+#
+# The run actually excluded is 30472160128 (created 2026-07-29T16:44:53Z, a
+# member of neither the 15 nor the 14): its x86_64-linux gate step ran the
+# full ~87 minutes but exited 2, producing zero rows in its `Delta point`
+# table, so it cannot contribute to the row counts, FAIL rate, sign split, or
+# recurrence figures above -- those were in fact already computed over the
+# corrected 15-run population (reproduced independently: 12x263 + 3x264 =
+# 3948 total rows, 220 FAIL rows, 5.6%, sign split 232/273, recurrence 3/6/7,
+# all match this header's existing figures exactly), so only this paragraph's
+# prose needed correcting, not the numbers past it.
 #
 # Per-job on-runner duration of the "Full-mode A/B, failing on a confirmed
 # regression" step (`gh run view <id> --json jobs --jq '.jobs[] |
 # {name,steps}'`, startedAt/completedAt of that step): x86_64-linux median
-# 87m42s, range 86m04s-88m29s (n=15); aarch64-linux median 82m30s, range
-# 77m30s-83m04s (n=14).
+# 87m42s, range 86m04s-88m29s (n=15); aarch64-linux median 82m32s, range
+# 82m20s-83m04s (n=14). The aarch64 range previously read 77m30s-83m04s: the
+# low end was run 29881462420's aarch64 leg, the one CANCELLED leg the "14
+# completed" population is defined to exclude -- its 77m30s runtime is how
+# long it ran before cancellation, not a completed-leg data point.
 #
 # Separately: queue-inclusive workflow latency (workflow createdAt to the
 # later of the two jobs' completedAt, same 15 runs) is a different clock:
 # median 88m25s, range 86m40s-177m47s. The earlier-cited 168m39s (run
 # 30479549447) is not even the largest excursion in this population; run
-# 30452387834 queued to 177m47s. That tail is scheduling/runner-availability
-# variance upstream of job start, not on-runner execution time.
+# 30452387834 queued to 177m47s. Checked what the two largest excursions
+# actually spend their time on, via each job's own startedAt: run
+# 30452387834's jobs did not start until 89m39s after workflow createdAt,
+# then ran their normal ~83-88m; run 30479549447's jobs waited 80m before
+# starting. Both tails are time before the job starts running, not slow
+# on-runner execution -- consistent with "queue-inclusive latency", though
+# this header does not establish WHY those two runs queued that long
+# (concurrent same-ref run, hosted-runner pool contention, or something
+# else).
 #
 # What must be true before the push trigger returns. The rule needs a
 # between-run variance estimate rather than a within-run confidence interval;
@@ -115,8 +156,11 @@ name: perf post-merge detection (informational, PAUSED)
 # chronically unstable groups need identifying and either stabilising or
 # excluding. Any change to which groups are gated requires a repeated A/A on the
 # target machine class plus a re-derivation of the threshold FIRST. Restoring
-# the trigger without those changes would not restore a working detector, it
-# would resume a false alarm on every merge.
+# the trigger without those changes would not restore a working detector: of
+# the 21 historical push runs, 15 produced a confirmed-regression x86_64-linux
+# verdict and the other 6 refused to certify rather than passing cleanly (see
+# "Cost of leaving it on" above) -- on this record, resuming the trigger would
+# reproduce a false alarm on most merges, not a working signal on any of them.
 #
 # The paths list below is retained verbatim, commented, so that restoring the
 # trigger is a revert of this block rather than a re-derivation of coverage.

--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -79,10 +79,11 @@ name: perf post-merge detection (informational, PAUSED)
 # architecture and never pooled. aarch64 leans slower while x86_64 leans
 # faster, so a pooled figure is partly cancellation and overstates how
 # symmetric the distribution is. The conclusion survives either way; the
-# pooled version of it does not survive scrutiny. Separately, the CI-lower >
-# 7% FAIL population (220 rows, all positive by construction of the
-# one-sided rule) is the population the 5.6% FAIL rate above is stated over,
-# and is not the population this split is drawn from.
+# pooled version of it does not survive scrutiny. Separately, the 5.6% FAIL
+# rate is 220 CI-lower > 7% rows out of the 3948 x86_64-linux comparison
+# rows; that one-sided 220-row subset is the rate's numerator, not a
+# population, and is not the population the signed Delta-point split is
+# drawn from.
 #
 # Cost of leaving it on: roughly 88 minutes of wall clock per run, on each of two
 # runner jobs, for every qualifying merge, producing a verdict that cannot be

--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -85,9 +85,29 @@ name: perf post-merge detection (informational, PAUSED)
 # population, and is not the population the signed Delta-point split is
 # drawn from.
 #
-# Cost of leaving it on: roughly 88 minutes of wall clock per run, on each of two
-# runner jobs, for every qualifying merge, producing a verdict that cannot be
-# acted on. Excursions to 169 minutes were observed.
+# Cost of leaving it on, over the same 15 x86_64-linux / 14 aarch64-linux
+# reports named above. Enumeration: `gh run list --repo ohdearquant/lattice
+# --workflow=perf-postmerge-gate.yml --limit 100 --json
+# databaseId,headSha,event,createdAt,conclusion` returns 23 runs: 1
+# workflow_dispatch, 1 cancelled push, 21 completed push runs. Of those 21,
+# 16 carry a confirmed-regression x86_64-linux verdict; this population
+# drops the earliest, run 29879966073, whose A/B baseline falls back to the
+# event parent rather than the last-measured-commit baseline the other 15
+# share (see the "first run" note above), leaving the same 15 runs -- and
+# the same 14 with a completed aarch64-linux leg -- used above.
+#
+# Per-job on-runner duration of the "Full-mode A/B, failing on a confirmed
+# regression" step (`gh run view <id> --json jobs --jq '.jobs[] |
+# {name,steps}'`, startedAt/completedAt of that step): x86_64-linux median
+# 87m42s, range 86m04s-88m29s (n=15); aarch64-linux median 82m30s, range
+# 77m30s-83m04s (n=14).
+#
+# Separately: queue-inclusive workflow latency (workflow createdAt to the
+# later of the two jobs' completedAt, same 15 runs) is a different clock:
+# median 88m25s, range 86m40s-177m47s. The earlier-cited 168m39s (run
+# 30479549447) is not even the largest excursion in this population; run
+# 30452387834 queued to 177m47s. That tail is scheduling/runner-availability
+# variance upstream of job start, not on-runner execution time.
 #
 # What must be true before the push trigger returns. The rule needs a
 # between-run variance estimate rather than a within-run confidence interval;

--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -56,21 +56,30 @@ name: perf post-merge detection (informational, PAUSED)
 # in this header were quoted over populations that were never their own. The
 # settled population is x86_64-linux alone: 15 reports declaring 263 comparisons
 # twelve times and 264 three times, 3948 in total. Over that: 220 FAIL rows,
-# 5.6%. Within-run intervals are tight — median CI width 0.280 percentage points
-# across the FAIL rows accumulated through run 7 of the 15, which is the subset
-# that median was computed on and not the full set.
+# 5.6%. Within-run intervals are tight — median CI width 0.4650 percentage
+# points across the 82 FAIL rows accumulated through run 7 of the 15 (derived
+# from the seven x86_64-linux job logs for those runs, `Delta point` table,
+# rows with CI-lower > 7%, sorted CI-upper minus CI-lower, middle pair
+# 0.46/0.47), which is the subset that median was computed on and not the
+# full set.
 #
-# The recurrence signature confirms the reading: the same groups flag across
-# unrelated merges (simd_throughput_384/normalize in 7 of 15 runs), and if those
-# were genuine per-merge regressions that group would by now be about twice as
-# slow, which it is not.
+# The recurrence signature: simd_throughput_384/normalize flags a CI-lower
+# past 7% in 3 of the 15 x86_64-linux reports and 6 of the 14 available
+# aarch64-linux reports (the aarch64 report for run 29881462420 is absent);
+# the union across either architecture is 7 of 15 workflow runs. Read per
+# architecture, not pooled: if those were genuine per-merge regressions that
+# group would by now be about twice as slow, which it is not.
 #
 # Large deltas are not sign-aligned, which is what rules out an arm-ordering
-# artifact: past 7% the x86_64 split is 232 head-slower against 273 head-faster.
-# Read that per architecture and never pooled. aarch64 leans slower (44 against
-# 30) while x86_64 leans faster, so a pooled figure is partly cancellation and
-# overstates how symmetric the distribution is. The conclusion survives either
-# way; the pooled version of it does not survive scrutiny.
+# artifact: past 7% CI-lower, the Delta point split is 232 head-slower against
+# 273 head-faster over the 15 x86_64-linux reports (3948 rows), and 44
+# head-slower against 30 head-faster over the 14 completed aarch64-linux
+# reports (3685 rows; the 15th report is absent, so this is a 14-report
+# denominator, not a matching 15). Read that per architecture and never
+# pooled. aarch64 leans slower while x86_64 leans faster, so a pooled figure
+# is partly cancellation and overstates how symmetric the distribution is.
+# The conclusion survives either way; the pooled version of it does not
+# survive scrutiny.
 #
 # Cost of leaving it on: roughly 88 minutes of wall clock per run, on each of two
 # runner jobs, for every qualifying merge, producing a verdict that cannot be

--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -44,18 +44,33 @@ name: perf post-merge detection (informational, PAUSED)
 # Why. Across its 15 verdict-producing runs this lane reported a confirmed
 # regression every single time, on 15 unrelated merges. The cause is its
 # decision rule, not its plumbing: the rule fails a run when a group's LOWER
-# confidence bound exceeds 7%, applied one-sidedly across 263 group comparisons
-# per run. Criterion's confidence intervals are tight WITHIN a run (median width
-# across the 82 FAIL rows: 0.280 percentage points) while the same groups swing
-# widely BETWEEN runs, and a within-run interval cannot bound between-run
-# variability. With 263 groups and that spread, at least one positive excursion
-# past 7% is close to certain, so the rule converts roughly half of a symmetric
-# noise distribution into "confirmed regressions". The recurrence signature
-# confirms the reading: the same groups flag across unrelated merges
-# (simd_throughput_384/normalize in 7 of 15 runs), and if those were genuine
-# per-merge regressions that group would by now be about twice as slow, which it
-# is not. Large deltas are symmetric overall (85 head-slower vs 119 head-faster
-# past 7%), so this is not an arm-ordering artifact.
+# confidence bound exceeds 7%, applied one-sidedly across the 263-264 group
+# comparisons a run declares, per architecture. Criterion's confidence intervals
+# are tight WITHIN a run while the same groups swing widely BETWEEN runs, and a
+# within-run interval cannot bound between-run variability. With that many
+# groups and that spread, at least one positive excursion past 7% is close to
+# certain, so the rule converts roughly half of a symmetric noise distribution
+# into "confirmed regressions".
+#
+# Figures below are stated over a named population, because two earlier numerals
+# in this header were quoted over populations that were never their own. The
+# settled population is x86_64-linux alone: 15 reports declaring 263 comparisons
+# twelve times and 264 three times, 3948 in total. Over that: 220 FAIL rows,
+# 5.6%. Within-run intervals are tight — median CI width 0.280 percentage points
+# across the FAIL rows accumulated through run 7 of the 15, which is the subset
+# that median was computed on and not the full set.
+#
+# The recurrence signature confirms the reading: the same groups flag across
+# unrelated merges (simd_throughput_384/normalize in 7 of 15 runs), and if those
+# were genuine per-merge regressions that group would by now be about twice as
+# slow, which it is not.
+#
+# Large deltas are not sign-aligned, which is what rules out an arm-ordering
+# artifact: past 7% the x86_64 split is 232 head-slower against 273 head-faster.
+# Read that per architecture and never pooled. aarch64 leans slower (44 against
+# 30) while x86_64 leans faster, so a pooled figure is partly cancellation and
+# overstates how symmetric the distribution is. The conclusion survives either
+# way; the pooled version of it does not survive scrutiny.
 #
 # Cost of leaving it on: roughly 88 minutes of wall clock per run, on each of two
 # runner jobs, for every qualifying merge, producing a verdict that cannot be
@@ -63,7 +78,7 @@ name: perf post-merge detection (informational, PAUSED)
 #
 # What must be true before the push trigger returns. The rule needs a
 # between-run variance estimate rather than a within-run confidence interval;
-# it needs multiple-comparison handling across its 263 groups; and the
+# it needs multiple-comparison handling across its 263-264 groups; and the
 # chronically unstable groups need identifying and either stabilising or
 # excluding. Any change to which groups are gated requires a repeated A/A on the
 # target machine class plus a re-derivation of the threshold FIRST. Restoring

--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -71,15 +71,18 @@ name: perf post-merge detection (informational, PAUSED)
 # group would by now be about twice as slow, which it is not.
 #
 # Large deltas are not sign-aligned, which is what rules out an arm-ordering
-# artifact: past 7% CI-lower, the Delta point split is 232 head-slower against
-# 273 head-faster over the 15 x86_64-linux reports (3948 rows), and 44
-# head-slower against 30 head-faster over the 14 completed aarch64-linux
-# reports (3685 rows; the 15th report is absent, so this is a 14-report
-# denominator, not a matching 15). Read that per architecture and never
-# pooled. aarch64 leans slower while x86_64 leans faster, so a pooled figure
-# is partly cancellation and overstates how symmetric the distribution is.
-# The conclusion survives either way; the pooled version of it does not
-# survive scrutiny.
+# artifact: for Delta point excursions above +7% or below -7%, the split is
+# 232 head-slower against 273 head-faster over the 15 x86_64-linux reports
+# (3948 rows), and 44 head-slower against 30 head-faster over the 14
+# completed aarch64-linux reports (3685 rows; the 15th report is absent, so
+# this is a 14-report denominator, not a matching 15). Read that per
+# architecture and never pooled. aarch64 leans slower while x86_64 leans
+# faster, so a pooled figure is partly cancellation and overstates how
+# symmetric the distribution is. The conclusion survives either way; the
+# pooled version of it does not survive scrutiny. Separately, the CI-lower >
+# 7% FAIL population (220 rows, all positive by construction of the
+# one-sided rule) is the population the 5.6% FAIL rate above is stated over,
+# and is not the population this split is drawn from.
 #
 # Cost of leaving it on: roughly 88 minutes of wall clock per run, on each of two
 # runner jobs, for every qualifying merge, producing a verdict that cannot be


### PR DESCRIPTION
## What this changes

Comment-only. `perf-postmerge-gate.yml` explains why the lane is paused, and two
figures in that explanation were quoted against populations that were not their
own. Both are corrected. The conclusions they support are unchanged, which is the
harder case to notice: a wrong supporting number under a conclusion that still
holds gives a reader nothing to trip over.

## The two corrections

**"82 FAIL rows" was a seven-run numerator against a fifteen-run denominator.**
The 82 is the cumulative count at run 7 of the 15 x86_64-linux reports, and 220
is the cumulative count at run 15; both endpoints are the ones the header itself
documents. Pairing it with the
full denominator is what made the rate read low at 2.1%. The settled population
is x86_64-linux alone — fifteen reports declaring 263 comparisons twelve times
and 264 three times, 3948 total — over which the figure is 220 FAIL rows, 5.6%.
The median CI width is restated as 0.4650 points over that same population's
named 82-row FAIL subset, with the subset named rather than presented as the
full set.

**"85 head-slower vs 119 head-faster past 7%" is withdrawn.** No population,
table, statistic, threshold or chronological prefix examined here reproduces it.
Rather than back-fit a derivation, it is replaced by the re-derived split over the settled population: 232 Delta-point
excursions above +7% (head-slower) against 273 below -7% (head-faster), among
the 3948 x86_64-linux comparison rows. The one-sided CI-lower > 7% FAIL rule is
a different predicate over the same rows and cannot produce head-faster counts.

That re-derivation also surfaced something the original figure hid. The split
must be read per architecture and never pooled: aarch64 leans slower (44 against
30, over its own 14-report, 3685-row population) while x86_64 leans faster, so a pooled number is partly cancellation and
overstates how symmetric the distribution is. The anti-arm-ordering conclusion
holds either way, since a sign-aligned whole-run artifact would push head
systematically slower on both architectures and neither does.

**"88 minutes" and "169 minutes" were two different clocks reported as one.**
The cost line quoted a single duration for the A/B step and a single worst case,
mixing on-runner step time with queue-inclusive workflow latency and pooling the
two architectures. Both are now stated separately, per architecture, over the same
population the header already names. On-runner Full-mode A/B step duration:
x86_64-linux median 87m42s (range 86m04s to 88m29s), aarch64-linux median 82m32s
(range 82m20s to 83m04s). Queue-inclusive workflow latency, measured from workflow
creation rather than step start: median 88m25s, range 86m40s to 177m47s. The
previously quoted 169 minutes was 168m39s and was not the largest excursion in that
population; one run queued to 177m47s. Both of the two largest excursions are time
before the job starts: their jobs' own `startedAt` values sit 89m39s and 80m after
workflow creation, after which each ran at the ordinary 83 to 88 minute pace. The
header records that the tail is pre-start time and does not claim to know why those
two runs queued that long.

**The stated exclusion criterion was false, and the excluded run was a different one.**
The header had dropped the earliest run, 29879966073, on the ground that its A/B baseline
fell back to the event parent while the other runs used a last-measured-commit branch.
That does not survive reading the run's own log: its endpoint-resolution step resolved a
base that is the ordinary immediate parent of its head, reached through the same
event-before code path every other run in the population used, and the state-branch
mechanism the criterion appealed to first appears in a run log after the last member of
this population. The run belongs in the population. The run actually outside it is
30472160128, whose x86_64-linux gate ran its full duration and then exited 2 with an
empty comparison table, so it contributes no rows to any figure. The row counts, FAIL
rate, sign split and recurrence figures were already computed over the corrected
population and re-derive unchanged; only the prose describing which run was excluded,
and why, was wrong.

Two universal claims in the header were also narrowed to what the run record supports.
"Rewrites perf-baselines on every perf-path push to main" is now 121 of 123 recorded
push-triggered runs, with the other two failing the bench step so their publish job was
skipped. "Would resume a false alarm on every merge" is now stated over the 21 historical
push runs: 15 produced a confirmed-regression verdict and the remaining 6 refused to
certify, so the record supports a false alarm on most merges rather than on all of them,
and supports a working signal on none.

One scoping note that applies to every figure above. The 15 x86_64-linux and 14
aarch64-linux reports are a closed snapshot of the lane through 2026-07-29, not
every run it has produced. Later runs exist and none of them is inside any number
quoted here or in the header.

## Scope

- 116 insertions, 24 deletions, one file.
- Zero non-comment lines changed, verified by filtering the diff.
- YAML parses; the `actionlint` check on this PR is green.
- No workflow behaviour is affected and the lane remains paused and
  dispatch-only, exactly as before.

## Why the header carries this at all

The block exists so that restoring the push trigger is a decision made against
real numbers instead of a re-derivation from memory. A header that argues from
figures nobody can reproduce is worse than one that argues from fewer figures,
so the unreproducible pair is removed rather than softened, and the surviving
ones now state the population they were computed over.





