### PR TITLE
fix(perf): refuse unbaselined head benchmarks

### DIFF
--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -690,6 +690,20 @@ def artifact_bench_id(estimate_file: Path, root: Path, artifact_parts: int) -> s
     return Path(*relative_parts[:-trim]).as_posix()
 
 
+def _below_benchmark_dir(estimate_file: Path, root: Path, artifact_parts: int) -> bool:
+    """True if estimate_file sits below a Criterion benchmark directory.
+
+    Root-level debris (e.g. a bare `cargo bench` writing `new/estimates.json`
+    or `change/estimates.json` directly under the Criterion root) has no
+    benchmark directory to attribute to and must be excluded before calling
+    artifact_bench_id, mirroring the length guard find_selected_baseline_files
+    already applies to the selected-baseline inventory.
+    """
+    relative_parts = estimate_file.relative_to(root).parts
+    trim = artifact_parts + 1
+    return len(relative_parts) > trim
+
+
 def selected_baseline_bench_ids(root: Path, baseline_name: str) -> set[str]:
     """Return bench IDs measured by the exact named base arm."""
     artifact_parts = len(_baseline_parts(baseline_name))
@@ -1596,7 +1610,7 @@ def run_selftest() -> int:
                 "the baseline-without-head refusal"
             )
 
-        # lattice#1298 F1: a stale/non-selected change/ dir must not exempt an
+        # A stale/non-selected change/ dir must not exempt an
         # uncovered head artifact. existing_group/existing_bench compares
         # cleanly against the selected baseline; stale_group/stale_bench has a
         # head new/ artifact and a change/ comparison, but that change/ is
@@ -1885,11 +1899,11 @@ def run_selftest() -> int:
                 "same-path output"
             )
 
-        # lattice#1298 F1's fix (reconciling missing_baseline_ids against
-        # baseline_ids instead of any change/ presence) means an unrelated
-        # named-baseline bench surviving cleanup now correctly reports its own
-        # NO COVERAGE gap. Test that survival-of-cleanup property in isolation
-        # so it does not also contaminate the single-direction check above.
+        # Reconciling missing_baseline_ids against baseline_ids instead of any
+        # change/ presence means an unrelated named-baseline bench surviving
+        # cleanup now correctly reports its own NO COVERAGE gap. Test that
+        # survival-of-cleanup property in isolation so it does not also
+        # contaminate the single-direction check above.
         freshness_unrelated_root = Path(td) / "freshness-unrelated" / "criterion"
         unrelated_bench = freshness_unrelated_root / "legacy_group" / "legacy_bench"
         _fabricate_bench(unrelated_bench, "previous-run")
@@ -2529,16 +2543,26 @@ def main() -> int:
         print(f"error: invalid --baseline-name: {error}", file=sys.stderr)
         return finish("error", EXIT_ERROR, f"invalid baseline name: {error}")
 
-    all_change_files = find_change_files(args.criterion_root)
+    all_change_files = [
+        change_file
+        for change_file in find_change_files(args.criterion_root)
+        if _below_benchmark_dir(change_file, args.criterion_root, artifact_parts=1)
+    ]
     change_file_ids = {
         change_file: artifact_bench_id(
             change_file, args.criterion_root, artifact_parts=1
         )
         for change_file in all_change_files
     }
+    # Root-level new/estimates.json (a bare `cargo bench` writing directly under
+    # the Criterion root, or stray debris) has no benchmark directory to
+    # attribute to; silently excluded here, the same disposition
+    # find_selected_baseline_files already gives the mirror-image root-level
+    # case in the selected-baseline inventory, rather than crashing the gate.
     head_ids = {
         artifact_bench_id(head_file, args.criterion_root, artifact_parts=1)
         for head_file in args.criterion_root.rglob("new/estimates.json")
+        if _below_benchmark_dir(head_file, args.criterion_root, artifact_parts=1)
     }
     # A stale/non-selected change/estimates.json is not evidence of coverage: the
     # enforcing filter below only trusts a change file whose id is in baseline_ids,

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -27,8 +27,9 @@ Exit codes:
   2 — parse error / bad input, or (with --require-measurements) the gate
       refusing to certify a run it could not judge: no comparison data, or
       no gating comparison among the parsed results, or a benchmark in the
-      selected baseline set with no head comparison. An automated lane must not
-      read "nothing was measured" as "nothing regressed".
+      selected baseline set with no head comparison, or a head benchmark with
+      no selected baseline. An automated lane must not read "nothing was
+      measured" as "nothing regressed".
   3 — not measurable: the automated lane's before/between/after ambient sample
       stream is missing, malformed, duplicated, or below BENCH_IDLE_FLOOR.
 
@@ -1526,6 +1527,75 @@ def run_selftest() -> int:
             failures.append("require-measurements: a parsed gating comparison "
                             "was rejected — the flag over-fails")
 
+        no_coverage_root = Path(td) / "no-baseline-coverage" / "criterion"
+        _fabricate_bench(
+            no_coverage_root / "existing_group" / "existing_bench",
+            "compare-base",
+        )
+        head_only = no_coverage_root / "new_group" / "new_bench" / "new"
+        head_only.mkdir(parents=True)
+        (head_only / "estimates.json").write_text(
+            json.dumps({"mean": {"point_estimate": 100.0}})
+        )
+        no_coverage_ambient = no_coverage_root.parent / "ambient.jsonl"
+        no_coverage_ambient.write_text(
+            "".join(
+                json.dumps(
+                    {
+                        "schema": AMBIENT_SAMPLE_SCHEMA,
+                        "phase": phase,
+                        "idle_pct": 95.0,
+                    }
+                )
+                + "\n"
+                for phase in REQUIRED_AMBIENT_PHASES
+            )
+        )
+        no_coverage_status = no_coverage_root.parent / "status.json"
+        no_coverage = _run(
+            no_coverage_root,
+            "--require-measurements",
+            "--target",
+            "lattice-inference:elementwise_cpu_bench",
+            "--ambient-samples",
+            str(no_coverage_ambient),
+            "--status-out",
+            str(no_coverage_status),
+        )
+        if no_coverage.returncode != 2:
+            failures.append(
+                "head-baseline-completeness: head benchmark without baseline exited "
+                f"{no_coverage.returncode} instead of 2"
+            )
+        if "NO COVERAGE" not in no_coverage.stderr:
+            failures.append(
+                "head-baseline-completeness: refusal did not label unbaselined "
+                "head benchmarks NO COVERAGE"
+            )
+        no_coverage_payload = json.loads(no_coverage_status.read_text())
+        if (
+            no_coverage_payload["verdict"] != "error"
+            or no_coverage_payload["exit_code"] != 2
+            or "NO COVERAGE" not in no_coverage_payload["reason"]
+        ):
+            failures.append(
+                "head-baseline-completeness: status surface rendered unbaselined "
+                "head benchmark as a pass"
+            )
+        if (
+            "  - lattice-inference:elementwise_cpu_bench: new_group/new_bench"
+            not in no_coverage.stderr
+        ):
+            failures.append(
+                "head-baseline-completeness: refusal did not name exact head-only "
+                "bench ID 'new_group/new_bench'"
+            )
+        if "produced no head comparison" in no_coverage.stderr:
+            failures.append(
+                "inventory-direction: head-without-baseline was collapsed into "
+                "the baseline-without-head refusal"
+            )
+
         # A target can be intentionally all-informational only when the exact
         # target key accompanies both the root and the demotion. This remains a
         # measured target and is valid in an enforcing multi-target run; another
@@ -1622,6 +1692,16 @@ def run_selftest() -> int:
                     "baseline-completeness: refusal did not name exact missing "
                     f"bench ID {expected_id!r}"
                 )
+        if "produced no head comparison" not in coverage.stderr:
+            failures.append(
+                "inventory-direction: baseline-without-head refusal lost its "
+                "direction-specific description"
+            )
+        if "NO COVERAGE" in coverage.stderr:
+            failures.append(
+                "inventory-direction: baseline-without-head was collapsed into "
+                "the head-without-baseline NO COVERAGE disposition"
+            )
         for unrelated_id in ("stale_default/bench", "stale_named/bench"):
             if unrelated_id in coverage.stderr:
                 failures.append(
@@ -2199,10 +2279,11 @@ def main() -> int:
                          "(default: full).")
     ap.add_argument("--require-measurements", action="store_true",
                     help="Fail (exit 2) instead of passing when the run produced no gating "
-                         "comparison to judge or a selected-base benchmark has no head "
-                         "comparison. Without this, an absent baseline exits 0, which is "
-                         "right for a first run but wrong for an automated lane: it cannot "
-                          "tell 'nothing regressed' from 'nothing was measured'.")
+                         "comparison to judge, a selected-base benchmark has no head "
+                         "comparison, or a head benchmark has no selected baseline. "
+                         "Without this, an absent baseline exits 0, which is right for a "
+                         "first run but wrong for an automated lane: it cannot tell "
+                         "'nothing regressed' from 'nothing was measured'.")
     ap.add_argument("--ambient-samples", type=Path,
                     help="JSONL before/between/after ambient samples. Requires "
                          "--status-out; an invalid or busy run exits 3.")
@@ -2410,6 +2491,47 @@ def main() -> int:
         print(f"error: invalid --baseline-name: {error}", file=sys.stderr)
         return finish("error", EXIT_ERROR, f"invalid baseline name: {error}")
 
+    all_change_files = find_change_files(args.criterion_root)
+    change_file_ids = {
+        change_file: artifact_bench_id(
+            change_file, args.criterion_root, artifact_parts=1
+        )
+        for change_file in all_change_files
+    }
+    head_ids = {
+        artifact_bench_id(head_file, args.criterion_root, artifact_parts=1)
+        for head_file in args.criterion_root.rglob("new/estimates.json")
+    }
+    # Existing comparison artifacts can belong to preserved, unrelated baseline trees;
+    # only a head artifact with no comparison at all proves the first-run coverage gap.
+    all_change_ids = set(change_file_ids.values())
+    missing_baseline_ids = sorted(head_ids - baseline_ids - all_change_ids)
+
+    def refuse_missing_baseline() -> int:
+        print(
+            f"error: NO COVERAGE: --require-measurements set but "
+            f"{len(missing_baseline_ids)} benchmark(s) ran in the head with no "
+            f"estimate in selected baseline {args.baseline_name!r}:",
+            file=sys.stderr,
+        )
+        for bench_id in missing_baseline_ids:
+            print(
+                f"  - {args.target + ': ' if args.target else ''}{bench_id}",
+                file=sys.stderr,
+            )
+        print(
+            "Record a baseline for these benchmarks before enforcing the A/B gate.",
+            file=sys.stderr,
+        )
+        return finish(
+            "error",
+            EXIT_ERROR,
+            f"NO COVERAGE: {len(missing_baseline_ids)} head benchmarks have no selected baseline",
+        )
+
+    if require_measurements and missing_baseline_ids:
+        return refuse_missing_baseline()
+
     if require_measurements and not baseline_ids:
         print(
             f"error: --require-measurements set but selected baseline "
@@ -2421,13 +2543,6 @@ def main() -> int:
         )
         return finish("error", EXIT_ERROR, "the selected baseline set is empty")
 
-    all_change_files = find_change_files(args.criterion_root)
-    change_file_ids = {
-        change_file: artifact_bench_id(
-            change_file, args.criterion_root, artifact_parts=1
-        )
-        for change_file in all_change_files
-    }
     # Enforcing A/B runs judge only the exact selected base set. A persistent
     # Criterion root can contain change output from other named baselines or
     # bench targets; letting those rows into this run can create either a stale

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -733,10 +733,24 @@ def _require_within_root(path: Path, root_resolved: Path, description: str) -> P
 
 
 def clear_selected_baseline_artifacts(root: Path, baseline_name: str) -> int:
-    """Validate, then remove exact baseline dirs before copying a fresh base set."""
+    """Validate, then remove exact baseline dirs before copying a fresh base set.
+
+    A pruned baseline dir drops its bench out of the selected set, so any
+    `new/`/`change/` siblings left behind become unreachable debris that the
+    head-side inventory later rglobs up as a phantom, unbaselined head
+    measurement. Remove those siblings here, atomically with the baseline dir,
+    since this is the only prune step that runs before the fresh base copy.
+    Siblings are validated like the baseline dir itself (real dir, no
+    symlinks, resolves under root) but excluded from the returned count, which
+    stays the exact-baseline-dir total callers already print. Only baseline
+    dirs found by find_selected_baseline_files enter the plan, so an unrelated
+    target's Criterion data sharing this root is never touched.
+    """
     root_resolved = _checked_criterion_root(root)
+    baseline_parts = _baseline_parts(baseline_name)
     baseline_files = find_selected_baseline_files(root, baseline_name)
     deletion_plan: set[Path] = set()
+    sibling_plan: set[Path] = set()
 
     for baseline_file in baseline_files:
         if baseline_file.is_symlink() or not baseline_file.is_file():
@@ -754,8 +768,23 @@ def clear_selected_baseline_artifacts(root: Path, baseline_name: str) -> int:
         )
         deletion_plan.add(baseline_dir)
 
-    for baseline_dir in sorted(deletion_plan):
-        shutil.rmtree(baseline_dir)
+        bench_dir = baseline_file.parents[len(baseline_parts)]
+        _require_within_root(bench_dir, root_resolved, "selected baseline benchmark")
+        for artifact_name in ("new", "change"):
+            artifact_dir = bench_dir / artifact_name
+            if artifact_dir.is_symlink():
+                raise ValueError(f"refusing to remove symlinked Criterion artifact: {artifact_dir}")
+            if not artifact_dir.exists():
+                continue
+            if not artifact_dir.is_dir():
+                raise ValueError(
+                    f"Criterion artifact is not a directory: {artifact_dir}"
+                )
+            _require_within_root(artifact_dir, root_resolved, "Criterion artifact")
+            sibling_plan.add(artifact_dir)
+
+    for path in sorted(deletion_plan | sibling_plan):
+        shutil.rmtree(path)
 
     return len(deletion_plan)
 
@@ -1831,10 +1860,10 @@ def run_selftest() -> int:
             failures.append(
                 "baseline-copy freshness: stale exact selected baseline survived"
             )
-        if not (stale_selected / "change" / "estimates.json").exists():
+        if (stale_selected / "new").exists() or (stale_selected / "change").exists():
             failures.append(
-                "baseline-copy freshness: comparison output was removed before "
-                "the fresh selected set existed"
+                "baseline-copy freshness: stale new/change siblings of a pruned "
+                "selected baseline survived to false-fail head coverage"
             )
         if not (preserved_other / "previous-run" / "estimates.json").exists():
             failures.append(

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -1596,6 +1596,48 @@ def run_selftest() -> int:
                 "the baseline-without-head refusal"
             )
 
+        # lattice#1298 F1: a stale/non-selected change/ dir must not exempt an
+        # uncovered head artifact. existing_group/existing_bench compares
+        # cleanly against the selected baseline; stale_group/stale_bench has a
+        # head new/ artifact and a change/ comparison, but that change/ is
+        # against a non-selected "stale-baseline", not "compare-base".
+        # Mutation-sensitive: restore the `- all_change_ids` subtraction and
+        # this exits 0 instead of 2.
+        stale_change_root = Path(td) / "stale-change-coverage" / "criterion"
+        _fabricate_bench(
+            stale_change_root / "existing_group" / "existing_bench",
+            "compare-base",
+        )
+        _fabricate_bench(
+            stale_change_root / "stale_group" / "stale_bench",
+            "stale-baseline",
+        )
+        stale_change = _run(
+            stale_change_root,
+            "--require-measurements",
+            "--target",
+            "lattice-inference:elementwise_cpu_bench",
+        )
+        if stale_change.returncode != 2:
+            failures.append(
+                "stale-change-coverage: a head artifact whose only companion "
+                "is a stale non-selected change/ exited "
+                f"{stale_change.returncode} instead of 2"
+            )
+        if "NO COVERAGE" not in stale_change.stderr:
+            failures.append(
+                "stale-change-coverage: refusal did not label the "
+                "stale-change-only head artifact NO COVERAGE"
+            )
+        if (
+            "  - lattice-inference:elementwise_cpu_bench: stale_group/stale_bench"
+            not in stale_change.stderr
+        ):
+            failures.append(
+                "stale-change-coverage: refusal did not name exact bench ID "
+                "'stale_group/stale_bench'"
+            )
+
         # A target can be intentionally all-informational only when the exact
         # target key accompanies both the root and the demotion. This remains a
         # measured target and is valid in an enforcing multi-target run; another
@@ -1660,12 +1702,6 @@ def run_selftest() -> int:
         _fabricate_bench(
             coverage_root / "renamed_rms_norm" / "4096", "compare-base"
         )
-        _fabricate_bench(
-            coverage_root / "stale_default" / "bench", "base"
-        )
-        _fabricate_bench(
-            coverage_root / "stale_named" / "bench", "previous-run"
-        )
         # An estimates file directly under the selected baseline directory has
         # no benchmark ID and is unrelated Criterion-tree debris, not a bench.
         (coverage_root / "compare-base").mkdir(parents=True)
@@ -1702,17 +1738,6 @@ def run_selftest() -> int:
                 "inventory-direction: baseline-without-head was collapsed into "
                 "the head-without-baseline NO COVERAGE disposition"
             )
-        for unrelated_id in ("stale_default/bench", "stale_named/bench"):
-            if unrelated_id in coverage.stderr:
-                failures.append(
-                    "baseline-completeness: unrelated baseline tree leaked into "
-                    f"selected set: {unrelated_id}"
-                )
-            if unrelated_id in coverage.stdout:
-                failures.append(
-                    "baseline-completeness: unrelated stale comparison was "
-                    f"judged by the enforcing run: {unrelated_id}"
-                )
         if _run(
             coverage_root,
         ).returncode != 0:
@@ -1835,8 +1860,6 @@ def run_selftest() -> int:
         freshness_root = Path(td) / "freshness" / "criterion"
         removed_bench = freshness_root / "rms_norm" / "4096"
         _fabricate_bench(removed_bench, "compare-base")
-        unrelated_bench = freshness_root / "legacy_group" / "legacy_bench"
-        _fabricate_bench(unrelated_bench, "previous-run")
         sibling_root = Path(td) / "freshness-sibling" / "criterion"
         sibling_bench = sibling_root / "simd_dot_product" / "scalar" / "384"
         _fabricate_bench(sibling_bench, "compare-base")
@@ -1851,10 +1874,6 @@ def run_selftest() -> int:
             failures.append(
                 "head-freshness: stale selected-bench new/change artifacts survived"
             )
-        if not (unrelated_bench / "new" / "estimates.json").exists():
-            failures.append(
-                "head-freshness: unrelated named-baseline benchmark was cleaned"
-            )
         if not (sibling_bench / "change" / "estimates.json").exists():
             failures.append(
                 "head-freshness: preparing one target root touched its sibling"
@@ -1864,6 +1883,25 @@ def run_selftest() -> int:
             failures.append(
                 "head-freshness: deleted head benchmark was masked by stale "
                 "same-path output"
+            )
+
+        # lattice#1298 F1's fix (reconciling missing_baseline_ids against
+        # baseline_ids instead of any change/ presence) means an unrelated
+        # named-baseline bench surviving cleanup now correctly reports its own
+        # NO COVERAGE gap. Test that survival-of-cleanup property in isolation
+        # so it does not also contaminate the single-direction check above.
+        freshness_unrelated_root = Path(td) / "freshness-unrelated" / "criterion"
+        unrelated_bench = freshness_unrelated_root / "legacy_group" / "legacy_bench"
+        _fabricate_bench(unrelated_bench, "previous-run")
+        prepared_unrelated = _prepare(freshness_unrelated_root, "--prepare-head")
+        if prepared_unrelated.returncode != 0:
+            failures.append(
+                "head-freshness: unrelated-baseline prepare step failed: "
+                f"{prepared_unrelated.stderr}"
+            )
+        if not (unrelated_bench / "new" / "estimates.json").exists():
+            failures.append(
+                "head-freshness: unrelated named-baseline benchmark was cleaned"
             )
 
         unsafe_root = Path(td) / "not-the-criterion-root"
@@ -2502,10 +2540,12 @@ def main() -> int:
         artifact_bench_id(head_file, args.criterion_root, artifact_parts=1)
         for head_file in args.criterion_root.rglob("new/estimates.json")
     }
-    # Existing comparison artifacts can belong to preserved, unrelated baseline trees;
-    # only a head artifact with no comparison at all proves the first-run coverage gap.
-    all_change_ids = set(change_file_ids.values())
-    missing_baseline_ids = sorted(head_ids - baseline_ids - all_change_ids)
+    # A stale/non-selected change/estimates.json is not evidence of coverage: the
+    # enforcing filter below only trusts a change file whose id is in baseline_ids,
+    # so exempting on any change/ presence here would fail open on exactly the
+    # artifact that filter later excludes. Reconcile against baseline_ids directly,
+    # the same selected-baseline inventory the enforcing path trusts.
+    missing_baseline_ids = sorted(head_ids - baseline_ids)
 
     def refuse_missing_baseline() -> int:
         print(
@@ -2529,9 +2569,9 @@ def main() -> int:
             f"NO COVERAGE: {len(missing_baseline_ids)} head benchmarks have no selected baseline",
         )
 
-    if require_measurements and missing_baseline_ids:
-        return refuse_missing_baseline()
-
+    # An entirely empty selected baseline gets its own clearer message: check
+    # it first, since a fully empty baseline_ids would otherwise put every
+    # head id into missing_baseline_ids and mask the more specific diagnosis.
     if require_measurements and not baseline_ids:
         print(
             f"error: --require-measurements set but selected baseline "
@@ -2542,6 +2582,9 @@ def main() -> int:
             file=sys.stderr,
         )
         return finish("error", EXIT_ERROR, "the selected baseline set is empty")
+
+    if require_measurements and missing_baseline_ids:
+        return refuse_missing_baseline()
 
     # Enforcing A/B runs judge only the exact selected base set. A persistent
     # Criterion root can contain change output from other named baselines or

--- a/tests/test_bench_compare_measurement.py
+++ b/tests/test_bench_compare_measurement.py
@@ -14,6 +14,7 @@ disposable git repo, copies the shipping script and its lib/ into it, and puts a
 stub `cargo` on PATH that exits 0 and prints no measurement lines — exactly the
 shape that used to pass.
 """
+import importlib.util
 import os
 import re
 import shutil
@@ -27,6 +28,12 @@ REPO = Path(__file__).resolve().parent.parent
 SCRIPT = REPO / "scripts" / "bench-compare.sh"
 GATE = REPO / "scripts" / "perf-bench-gate.py"
 LIB = REPO / "scripts" / "lib"
+
+_GATE_SPEC = importlib.util.spec_from_file_location("perf_bench_gate", GATE)
+assert _GATE_SPEC is not None and _GATE_SPEC.loader is not None
+gate = importlib.util.module_from_spec(_GATE_SPEC)
+sys.modules[_GATE_SPEC.name] = gate
+_GATE_SPEC.loader.exec_module(gate)
 
 # Exits 0 for every subcommand and prints nothing a measurement filter matches.
 STUB_CARGO = """#!/usr/bin/env bash
@@ -222,6 +229,7 @@ def _run(
     extra_env=None,
     emit_criterion_home=False,
     stub_machine_state=None,
+    post_run=None,
 ):
     """Run the shipping bench-compare.sh in a throwaway repo with a stub cargo."""
     with tempfile.TemporaryDirectory() as tmp:
@@ -322,9 +330,54 @@ def _run(
             **(extra_env or {}),
             "STUB_EMIT_CRITERION_HOME": "1" if emit_criterion_home else "0",
         }
-        return subprocess.run(
+        result = subprocess.run(
             ["bash", str(root / "scripts" / SCRIPT.name), *extra_args, "HEAD~1", "HEAD"],
             capture_output=True, text=True, env=env, timeout=300)
+        if post_run is not None:
+            post_run(root)
+        return result
+
+
+class ClearSelectedBaselineArtifactsSiblingPrune(unittest.TestCase):
+    """Isolated repro for the round-4 fix: clear_selected_baseline_artifacts
+
+    must remove a pruned baseline dir's new/change siblings, and must not
+    touch a differently-named baseline tree sharing the same criterion root.
+    """
+
+    def _make_root(self, tmp):
+        root = Path(tmp) / "criterion"
+        pruned = root / "old_group" / "42"
+        (pruned / "compare-base").mkdir(parents=True)
+        (pruned / "new").mkdir()
+        (pruned / "change").mkdir()
+        (pruned / "compare-base" / "estimates.json").write_text(
+            '{"mean":{"point_estimate":90.0}}\n'
+        )
+        (pruned / "new" / "estimates.json").write_text(
+            '{"mean":{"point_estimate":100.0}}\n'
+        )
+        (pruned / "change" / "estimates.json").write_text(
+            '{"mean":{"point_estimate":0.01,'
+            '"confidence_interval":{"lower_bound":0.0,"upper_bound":0.02}}}\n'
+        )
+
+        unrelated = root / "other_group" / "7" / "manual-snapshot"
+        unrelated.mkdir(parents=True)
+        (unrelated / "estimates.json").write_text('{"mean":{"point_estimate":50.0}}\n')
+        return root, pruned, unrelated
+
+    def test_removes_pruned_siblings_and_spares_unrelated_tree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root, pruned, unrelated = self._make_root(tmp)
+
+            removed = gate.clear_selected_baseline_artifacts(root, "compare-base")
+
+            self.assertEqual(removed, 1)
+            self.assertFalse((pruned / "compare-base").exists())
+            self.assertFalse((pruned / "new").exists())
+            self.assertFalse((pruned / "change").exists())
+            self.assertTrue((unrelated / "estimates.json").exists())
 
 
 class BenchCompareMeasurementGuard(unittest.TestCase):
@@ -548,12 +601,26 @@ class BenchCompareMeasurementGuard(unittest.TestCase):
         stale compare-base artifact remains selected. The later head cleanup
         removes its old comparison, so completeness false-fails old_group/42
         even though every benchmark in today's fresh base set ran on HEAD.
+
+        The pruned baseline dir's `new/`/`change/` siblings must go with it
+        (mutation-sensitive on their own: leaving them behind resurrects
+        old_group/42 as a phantom unbaselined head measurement via the
+        root-wide new/estimates.json inventory — see
+        ClearSelectedBaselineArtifactsSiblingPrune for the isolated repro).
+        A second, differently-named baseline snapshot sharing the same
+        Criterion root must survive untouched, proving the prune did not
+        widen past the exact selected baseline.
         """
+        old_group_dir = None
+        unrelated_dir = None
+
         def seed_unrelated_run(root):
+            nonlocal old_group_dir, unrelated_dir
             bench = (
                 root / ".cache" / "bench-compare-criterion" / "head" /
                 "inference" / "criterion" / "old_group" / "42"
             )
+            old_group_dir = bench
             (bench / "compare-base").mkdir(parents=True)
             (bench / "new").mkdir()
             (bench / "change").mkdir()
@@ -568,10 +635,35 @@ class BenchCompareMeasurementGuard(unittest.TestCase):
                 '"confidence_interval":{"lower_bound":0.0,"upper_bound":0.02}}}\n'
             )
 
+            # A different target's persistent, differently-named baseline
+            # snapshot in the same criterion root. It has no new/change, so
+            # it cannot trip the head-ids coverage check either way; it is
+            # here purely to prove clear_selected_baseline_artifacts does not
+            # widen its deletion past the exact selected baseline name.
+            other = (
+                root / ".cache" / "bench-compare-criterion" / "head" /
+                "inference" / "criterion" / "other_group" / "7"
+            )
+            unrelated_dir = other / "manual-snapshot"
+            unrelated_dir.mkdir(parents=True)
+            (unrelated_dir / "estimates.json").write_text(
+                '{"mean":{"point_estimate":50.0}}\n'
+            )
+
+        snapshot = {}
+
+        def capture(root):
+            snapshot["old_group_new_exists"] = old_group_dir and (old_group_dir / "new").exists()
+            snapshot["old_group_change_exists"] = old_group_dir and (old_group_dir / "change").exists()
+            snapshot["unrelated_exists"] = (
+                unrelated_dir and (unrelated_dir / "estimates.json").exists()
+            )
+
         result = _run(
             ["--fail-on-regression"],
             stub_cargo=STALE_CHANGE_CARGO,
             setup=seed_unrelated_run,
+            post_run=capture,
         )
         self.assertEqual(
             result.returncode, 0,
@@ -583,6 +675,18 @@ class BenchCompareMeasurementGuard(unittest.TestCase):
             result.stdout,
         )
         self.assertNotIn("old_group/42", result.stdout)
+        self.assertFalse(
+            snapshot["old_group_new_exists"],
+            "stale old_group/42/new must be pruned along with its baseline dir",
+        )
+        self.assertFalse(
+            snapshot["old_group_change_exists"],
+            "stale old_group/42/change must be pruned along with its baseline dir",
+        )
+        self.assertTrue(
+            snapshot["unrelated_exists"],
+            "an unrelated target's differently-named baseline snapshot must survive the prune",
+        )
 
     def test_enforcing_mode_refuses_a_partial_baseline_copy(self):
         """A failed partial copy must not shrink the selected set and certify.

--- a/tests/test_perf_bench_gate_status.py
+++ b/tests/test_perf_bench_gate_status.py
@@ -211,6 +211,44 @@ class PerfBenchGateStatusTests(unittest.TestCase):
             self.assertEqual(payload["exit_code"], 2)
             self.assertEqual(payload["ambient"]["assessment"], "invalid")
 
+    def test_stale_change_does_not_exempt_uncovered_head_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            criterion = _criterion_root(root, "covered", 0.0)
+
+            uncovered = criterion / "new_group" / "new_bench"
+            (uncovered / "new").mkdir(parents=True)
+            (uncovered / "new" / "estimates.json").write_text(
+                '{"mean":{"point_estimate":100.0}}\n'
+            )
+            # A stale, non-selected baseline comparison sits beside the head
+            # artifact. It must not be read as coverage for the selected
+            # baseline ("compare-base"), which has no estimate here at all.
+            (uncovered / "stale-baseline").mkdir(parents=True)
+            (uncovered / "stale-baseline" / "estimates.json").write_text(
+                '{"mean":{"point_estimate":90.0}}\n'
+            )
+            (uncovered / "change").mkdir(parents=True)
+            (uncovered / "change" / "estimates.json").write_text(json.dumps({
+                "mean": {
+                    "point_estimate": 0.10,
+                    "confidence_interval": {"lower_bound": 0.05, "upper_bound": 0.15},
+                },
+            }))
+
+            samples = root / "ambient.jsonl"
+            _samples(samples, {"before": 95.0, "between": 95.0, "after": 95.0})
+            status = root / "status.json"
+            result = _run(criterion, samples, status, "lattice-inference:fixture")
+
+            self.assertEqual(result.returncode, 2, result.stderr)
+            self.assertIn("NO COVERAGE", result.stderr)
+            self.assertIn("new_group/new_bench", result.stderr)
+            payload = json.loads(status.read_text())
+            self.assertEqual(payload["verdict"], "error")
+            self.assertEqual(payload["exit_code"], 2)
+            self.assertIn("NO COVERAGE", payload["reason"])
+
     def test_non_voting_phase_is_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/tests/test_perf_bench_gate_status.py
+++ b/tests/test_perf_bench_gate_status.py
@@ -249,48 +249,58 @@ class PerfBenchGateStatusTests(unittest.TestCase):
             self.assertEqual(payload["exit_code"], 2)
             self.assertIn("NO COVERAGE", payload["reason"])
 
-    def test_root_level_new_estimates_ignored_in_report_only_mode(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            criterion = _criterion_root(root, "pass", 0.0)
-            # Root-level debris: a bare `cargo bench` (or stray output) can
-            # write new/estimates.json directly under the Criterion root,
-            # with no benchmark directory above it.
-            (criterion / "new").mkdir(parents=True)
-            (criterion / "new" / "estimates.json").write_text(
-                '{"mean":{"point_estimate":100.0}}\n'
-            )
+    def test_root_level_estimates_ignored_in_report_only_mode(self) -> None:
+        # Root-level debris: a bare `cargo bench` (or stray output) can write
+        # new/estimates.json OR change/estimates.json directly under the
+        # Criterion root, with no benchmark directory above it. Both the
+        # head-side (new/) and change-side (change/) artifact names must be
+        # excluded the same way.
+        for debris_name in ("new", "change"):
+            with self.subTest(debris_name=debris_name):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    criterion = _criterion_root(root, "pass", 0.0)
+                    (criterion / debris_name).mkdir(parents=True)
+                    (criterion / debris_name / "estimates.json").write_text(
+                        '{"mean":{"point_estimate":100.0}}\n'
+                    )
 
-            result = subprocess.run(
-                ["python3", str(GATE), str(criterion), "fixture/report-only"],
-                text=True,
-                capture_output=True,
-            )
+                    result = subprocess.run(
+                        ["python3", str(GATE), str(criterion), "fixture/report-only"],
+                        text=True,
+                        capture_output=True,
+                    )
 
-            self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertNotIn("Traceback", result.stderr)
-            self.assertNotIn("is not below a Criterion benchmark directory", result.stderr)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertNotIn("Traceback", result.stderr)
+                    self.assertNotIn(
+                        "is not below a Criterion benchmark directory", result.stderr
+                    )
 
-    def test_root_level_new_estimates_ignored_with_status_out(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            criterion = _criterion_root(root, "pass", 0.0)
-            (criterion / "new").mkdir(parents=True)
-            (criterion / "new" / "estimates.json").write_text(
-                '{"mean":{"point_estimate":100.0}}\n'
-            )
+    def test_root_level_estimates_ignored_with_status_out(self) -> None:
+        for debris_name in ("new", "change"):
+            with self.subTest(debris_name=debris_name):
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    criterion = _criterion_root(root, "pass", 0.0)
+                    (criterion / debris_name).mkdir(parents=True)
+                    (criterion / debris_name / "estimates.json").write_text(
+                        '{"mean":{"point_estimate":100.0}}\n'
+                    )
 
-            samples = root / "ambient.jsonl"
-            _samples(samples, {phase: 95.0 for phase in PHASES})
-            status = root / "status.json"
-            result = _run(criterion, samples, status, "lattice-inference:fixture")
+                    samples = root / "ambient.jsonl"
+                    _samples(samples, {phase: 95.0 for phase in PHASES})
+                    status = root / "status.json"
+                    result = _run(criterion, samples, status, "lattice-inference:fixture")
 
-            self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertNotIn("Traceback", result.stderr)
-            self.assertTrue(status.exists(), "status file must be written even with root debris")
-            payload = json.loads(status.read_text())
-            self.assertEqual(payload["verdict"], "pass")
-            self.assertEqual(payload["exit_code"], 0)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertNotIn("Traceback", result.stderr)
+                    self.assertTrue(
+                        status.exists(), "status file must be written even with root debris"
+                    )
+                    payload = json.loads(status.read_text())
+                    self.assertEqual(payload["verdict"], "pass")
+                    self.assertEqual(payload["exit_code"], 0)
 
     def test_non_voting_phase_is_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_perf_bench_gate_status.py
+++ b/tests/test_perf_bench_gate_status.py
@@ -249,6 +249,49 @@ class PerfBenchGateStatusTests(unittest.TestCase):
             self.assertEqual(payload["exit_code"], 2)
             self.assertIn("NO COVERAGE", payload["reason"])
 
+    def test_root_level_new_estimates_ignored_in_report_only_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            criterion = _criterion_root(root, "pass", 0.0)
+            # Root-level debris: a bare `cargo bench` (or stray output) can
+            # write new/estimates.json directly under the Criterion root,
+            # with no benchmark directory above it.
+            (criterion / "new").mkdir(parents=True)
+            (criterion / "new" / "estimates.json").write_text(
+                '{"mean":{"point_estimate":100.0}}\n'
+            )
+
+            result = subprocess.run(
+                ["python3", str(GATE), str(criterion), "fixture/report-only"],
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+            self.assertNotIn("is not below a Criterion benchmark directory", result.stderr)
+
+    def test_root_level_new_estimates_ignored_with_status_out(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            criterion = _criterion_root(root, "pass", 0.0)
+            (criterion / "new").mkdir(parents=True)
+            (criterion / "new" / "estimates.json").write_text(
+                '{"mean":{"point_estimate":100.0}}\n'
+            )
+
+            samples = root / "ambient.jsonl"
+            _samples(samples, {phase: 95.0 for phase in PHASES})
+            status = root / "status.json"
+            result = _run(criterion, samples, status, "lattice-inference:fixture")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn("Traceback", result.stderr)
+            self.assertTrue(status.exists(), "status file must be written even with root debris")
+            payload = json.loads(status.read_text())
+            self.assertEqual(payload["verdict"], "pass")
+            self.assertEqual(payload["exit_code"], 0)
+
     def test_non_voting_phase_is_ignored(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

The "Scope" section below was added after the original description.

## Problem

The enforcing performance gate reconciled selected-baseline benchmark IDs only against Criterion comparison records. A benchmark that produced a head `new/estimates.json` artifact without a selected-baseline estimate produced no comparison record, so it was absent from both existing inventories and could be omitted from an otherwise clean verdict.

## Change

- Inventory uncompared head benchmark IDs and subtract the selected-baseline inventory.
- Refuse `--require-measurements` runs with exit 2 before report rendering when any head benchmark has no selected baseline.
- Report each affected benchmark as `NO COVERAGE` whenever the selected baseline is non-empty, prefixing the bench ID with the `<crate>:<bench-target>` identity when `--target` is supplied (it is optional, and bench-compare's own callers pass it). An entirely empty selected baseline is handled first by a separate exit-2 diagnostic that names that condition instead of listing per-benchmark rows.
- Keep that disposition distinct from the existing selected-baseline benchmark that produced no head comparison.
- Ignore root-level Criterion debris (a `new/estimates.json` or `change/estimates.json` with no benchmark directory above it) in the head and change inventories, mirroring the exclusion the selected-baseline inventory already applied.
- Extend `--prepare-baseline-copy` so that for every exact selected-baseline directory it removes, it also removes that same benchmark's `new/` and `change/` siblings before the fresh base copy. Without this a stale head artifact from a prior run survives the copy and is inventoried as head-side work the new base never produced. Criterion trees belonging to other benchmarks are left untouched.

## Validation

- `python3 -m unittest -v tests/test_perf_bench_gate_status.py` exited 0: 9 tests ran and the runner printed `OK`.
- `python3 scripts/perf-bench-gate.py --selftest` exited 0 and printed `SELFTEST: PASS`.
- `python3 -m unittest tests.test_bench_compare_measurement` ran 12 tests and printed `OK` at this head. The sibling prune is covered there by `test_removes_pruned_siblings_and_spares_unrelated_tree`, which asserts both halves (the stale siblings go, an unrelated Criterion tree stays), and by `test_stale_unrelated_selected_baseline_is_pruned_before_copy`.
- A pre-commit run was reported during authoring. That transcript was not retained, so it is recorded here as a historical note rather than as evidence for this head; the three commands above were re-run at this head and are.

## Mutation evidence

Removing the head-without-baseline refusal at `scripts/perf-bench-gate.py:2639-2640` (deleting `if require_measurements and missing_baseline_ids: return refuse_missing_baseline()`) made `python3 scripts/perf-bench-gate.py --selftest` exit 1 with:

```text
FAIL: head-baseline-completeness: head benchmark without baseline exited 0 instead of 2
FAIL: head-baseline-completeness: refusal did not label unbaselined head benchmarks NO COVERAGE
FAIL: head-baseline-completeness: status surface rendered unbaselined head benchmark as a pass
FAIL: head-baseline-completeness: refusal did not name exact head-only bench ID 'new_group/new_bench'
FAIL: stale-change-coverage: a head artifact whose only companion is a stale non-selected change/ exited 0 instead of 2
FAIL: stale-change-coverage: refusal did not label the stale-change-only head artifact NO COVERAGE
FAIL: stale-change-coverage: refusal did not name exact bench ID 'stale_group/stale_bench'
SELFTEST: FAIL (7 failure(s))
```

Collapsing the two inventory directions into the existing missing-head message, by deleting that same early return and folding its population into the other direction (`missing_head_ids = sorted((baseline_ids - change_ids) | set(missing_baseline_ids))`), made the same command exit 1 with:

```text
FAIL: head-baseline-completeness: refusal did not label unbaselined head benchmarks NO COVERAGE
FAIL: head-baseline-completeness: status surface rendered unbaselined head benchmark as a pass
FAIL: inventory-direction: head-without-baseline was collapsed into the baseline-without-head refusal
FAIL: stale-change-coverage: refusal did not label the stale-change-only head artifact NO COVERAGE
SELFTEST: FAIL (4 failure(s))
```

Both mutations were applied to a scratch copy, never to the worktree. The transcripts above are from the authoring session; the mutation of the head-without-baseline refusal was re-run against this head in a scratch copy and reproduced the same selftest failure, with the checked-in script's SHA-256 unchanged across the experiment.

## Scope

Enforcement (`require_measurements`) is on when either `--require-measurements` is
passed explicitly, or `--status-out` is passed (with or without
`--require-measurements`): `args.require_measurements or args.status_out is not None`
at `scripts/perf-bench-gate.py:2487` (unchanged by this PR; the coverage-check changes
sit downstream of this line at lines 2575–2640). Invocations that pass
neither flag are unaffected by the coverage-refusal rule and continue to report exactly
as before, with one exception: root-level Criterion debris (a `new/estimates.json` or
`change/estimates.json` with no benchmark directory above it) is now filtered out of the
head and change inventories on every invocation that reaches inventory construction —
`--selftest` and the two preparation modes return before it. Before the filter commit
`15122d03e8`, root-level `new/estimates.json` and `change/estimates.json` could both reach
`artifact_bench_id` and raise, so the filter repairs a crash on both sides rather than
adding coverage on one. In a tree holding both artifacts the `change/` inventory is
traversed first, so `change/` is the one observed to raise. Enabling the guard for any given caller is a separate
change from this one.

This is stated explicitly because the failure it addresses is a silent one: a caller
that omits both flags gets the same clean verdict before and after this change, and
nothing in the gate's output distinguishes "no uncovered benchmarks" from "the check
did not run".






