### PR TITLE
chore: ignore root-level analysis scratch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,16 @@ Thumbs.db
 /review*.md
 /pr_review*.md
 
+# Local analysis scratch produced at the repository root. These are working
+# notes, not source, and they are easy to sweep into a commit with `git add -A`.
+# Every pattern here is root-anchored on purpose: an unanchored `*_report.md`
+# would also match tracked paths such as .github/ISSUE_TEMPLATE/bug_report.md.
+/*_report.md
+/*_verdict.md
+/verdict*.md
+/FIX_INPUTS/
+/REVIEW_INPUTS/
+
 *__pycache__/
 uv.lock
 


### PR DESCRIPTION
## What

Adds five root-anchored `.gitignore` patterns for working notes that get written at the repository root while investigating a change: `/*_report.md`, `/*_verdict.md`, `/verdict*.md`, `/FIX_INPUTS/`, `/REVIEW_INPUTS/`.

They sit alongside the existing root-anchored review-scratch block (`/review*.md`, `/pr_review*.md`), which is the precedent this follows.

## Why

These files are working notes, not source. They are trivially swept into a commit by `git add -A` or `git commit -a`, and once that happens the content is in the branch history of a public repository. Relying on the author of each change to remember not to stage them is a convention, not a control; this is the control.

## Root-anchoring is deliberate

An unanchored `*_report.md` would also match tracked paths such as `.github/ISSUE_TEMPLATE/bug_report.md`. Every pattern is therefore anchored with a leading `/` so it applies only at the repository root, and the comment in the file says so, so a later edit does not quietly drop the anchor.

## Validation

`git check-ignore -v` run in both directions in a single pass.

Must match, each reporting the specific pattern that caught it:

```
fix_r6_report.md                 .gitignore:76:/*_report.md
verdict_r7.md                    .gitignore:78:/verdict*.md
bench_anchor_fix_report.md       .gitignore:76:/*_report.md
fix_conflict_verdict.md          .gitignore:77:/*_verdict.md
REVIEW_INPUTS/x.md               .gitignore:80:/REVIEW_INPUTS/
FIX_INPUTS/y.md                  .gitignore:79:/FIX_INPUTS/
```

Must not match:

```
.github/ISSUE_TEMPLATE/bug_report.md           not ignored (correct)
crates/inference/docs/perf_report.md           not ignored (correct)
docs/verdict.md                                not ignored (correct)
```

`git ls-files --error-unmatch .github/ISSUE_TEMPLATE/bug_report.md` still resolves, confirming the tracked template is unaffected.

## Bench disposition

No `crates/inference/`, `crates/embed/`, or `crates/fann/` source is touched. One file changed, `.gitignore`, ten added lines, no Rust and no build inputs, so no benchmark target's effective source differs between base and head. No A/B was run and no timing number is quoted.

## Verification

Checked with `git check-ignore -v`, which names the deciding pattern line, at
`61049c7443526418f7537f97f64eaa6ff251373d`. Both arms run in the same pass.

Must be ignored:

```text
gates_report.md      -> .gitignore:76
fix_r5_report.md     -> .gitignore:76
verdict_r1.md        -> .gitignore:78
FIX_INPUTS/x.md      -> .gitignore:79
REVIEW_INPUTS/y.md   -> .gitignore:80
```

Must not be ignored, and are not:

```text
.github/ISSUE_TEMPLATE/bug_report.md
docs/adr/some_report.md
crates/inference/verdict_notes.md
```

The first of those is a tracked file that exists in the tree, so the arm is a
real must-not-match rather than a hypothetical one.

The root-anchoring rationale in the comment is also checked rather than asserted:
running the same probe against an unanchored `*_report.md` pattern does match
`.github/ISSUE_TEMPLATE/bug_report.md`, which is the outcome the leading `/`
prevents.

What this does not show: `check-ignore` answers what git would do with a path, so
it establishes the patterns' behaviour and not that this is the complete set of
scratch filenames worth ignoring.

## bench-compare disposition

Documentation and repository configuration only. No file under
`crates/inference/`, `crates/embed/`, or `crates/fann/` is touched, so the rule
does not trigger.
