### PR TITLE
docs: record which crate dependency edges are feature-gated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,17 @@ inference (~118K)                                 ← optional dep on fann (`mix
 embed (12K)   tune (20K)                          ← embed uses inference; tune uses fann + inference
 ```
 
+Three of those four edges are feature-gated, and the gates do not all default the
+same way, so "depends on" in the diagram is not one relationship. `tune` depends on
+`fann` unconditionally. The other three are optional deps: `embed` to `inference` is
+enabled through `native`, which is in embed's default set, so it is present in an
+ordinary build; `inference` to `fann` is behind `mixture` and `tune` to `inference` is
+behind `inference-hook` or `train-backward`, and neither of those is in its crate's
+default set. A default `cargo build -p lattice-tune` therefore does not compile
+`lattice-inference` at all — six targets pull it in through `required-features` and
+that is the whole of its reach. Check the manifest before assuming an edge is live in
+the build you are looking at.
+
 ### lattice-inference — Transformer kernel
 
 | Module           | Purpose                      | Key Exports                                                                       |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ current main during review, not just against the PR's own diff.
 
 ## Crate Ownership
 
-Changes to `inference` affect `embed` and `tune`. Changes to `fann` affect `inference` (via the optional `mixture` feature) and `tune`. Only `fann` and `transport` are leaf crates; `transport` has no internal dependents (`embed` uses it in dev-tests only).
+Changes to `inference` affect `embed` in an ordinary build, and affect `tune` only under `inference-hook` or `train-backward` — neither is in tune's default set, so a default `cargo build -p lattice-tune` does not compile `lattice-inference` at all. Changes to `fann` affect `tune` unconditionally and `inference` only under the optional `mixture` feature, which is likewise off by default. Only `fann` and `transport` are leaf crates; `transport` has no internal dependents (`embed` uses it in dev-tests only). When sizing the blast radius of a change, read the consuming crate's default feature set rather than the arrow: two of these four edges are absent from a default build.
 
 ## Publishing
 


### PR DESCRIPTION
## Problem

The crate-structure diagram in `AGENTS.md` renders all four internal dependency
edges as equivalent lines, annotated "embed uses inference; tune uses fann +
inference". Three of the four are optional deps, and their feature gates do not
default the same way, so a reader sizing a build or reasoning about blast radius
gets two of them wrong.

The document already flags one of the three as optional (`inference` to `fann`,
via `mixture`), which is what makes this a defect rather than an omission: the
distinction is known and applied inconsistently.

## What the manifests say

| Edge | Declaration | In a default build? |
| --- | --- | --- |
| `tune` to `fann` | `crates/tune/Cargo.toml:35`, no `optional` | yes, unconditionally |
| `embed` to `inference` | `crates/embed/Cargo.toml:56`, optional, enabled by `native`; embed default is `["native", "download"]` (`:108`) | yes |
| `inference` to `fann` | `crates/inference/Cargo.toml:86`, optional, behind `mixture` (`:37`); inference default is `["std", "download", "serve"]` (`:16`) | no |
| `tune` to `inference` | `crates/tune/Cargo.toml:56`, optional, behind `inference-hook` (`:24`) or `train-backward` (`:25`); tune default is `["std", "sqlite"]` (`:12`) | no |

The consequential one is the last row: a default `cargo build -p lattice-tune`
does not compile `lattice-inference` at all. Six targets reach it through
`required-features` (`:61`, `:66`, `:71`, `:76`, `:81`, `:86`) and that is the
whole of its reach.

## Change

Documentation only, two files.

`AGENTS.md`: the diagram is left as-is and a paragraph beneath it states which
edges are gated and how each defaults, with the direction of the build-time
consequence.

`CLAUDE.md`: the crate-ownership note carried the same flattening in the form a
contributor actually acts on, saying changes to `inference` affect `embed` and
`tune` without qualification. It now states which edges are absent from a default
build and says to read the consuming crate's default feature set when sizing a
change rather than following the arrow.

## Validation

- every value above read from the named manifest at this head
- `make lint-docs` runs in the pre-commit path and passed
- the "only" quantifiers were checked against the FULL `[features]` table of each
  manifest, not a line grep: `inference-hook` and `train-backward` are the only
  tune features that enable `dep:lattice-inference`, and `mixture` the only
  inference feature that enables `dep:lattice-fann`
- no code, test, or manifest was modified


## Verification

Every claim added here is a statement about the manifests, so each was read at
`9d521449325ab76a3bef7cf6dac4665001c358ca` rather than asserted. The read was
preceded by a non-empty control on the manifest itself.

| Claim | Evidence at that ref |
|---|---|
| `tune` depends on `fann` unconditionally | `crates/tune/Cargo.toml:35` — `lattice-fann = { version = "0.7.1", path = "../fann" }`, no `optional` |
| `embed` to `inference` is enabled through `native`, which is default | `crates/embed/Cargo.toml:108` `default = ["native", "download"]`, `:109` `native = ["dep:lattice-inference"]`, `:56` dep is `optional = true` |
| `inference` to `fann` is behind `mixture`, not default | `crates/inference/Cargo.toml:16` `default = ["std", "download", "serve"]`, `:37` `mixture = ["dep:lattice-fann"]`, `:86` dep is `optional = true` |
| `tune` to `inference` is behind `inference-hook` or `train-backward`, neither default | `crates/tune/Cargo.toml:12` `default = ["std", "sqlite"]`, `:24` and `:25` declare the two features, `:56` dep is `optional = true` |
| six targets pull `lattice-inference` in through `required-features` | `crates/tune/Cargo.toml` lines 61, 66, 71, 76, 81, 86 — count is exactly 6 |

What this does not show: these are declarations, not a build. They establish which
edges a default feature resolution activates, not that any particular build
command produced the artifact you expect.

## bench-compare disposition

Documentation only. No file under `crates/inference/`, `crates/embed/`, or
`crates/fann/` is touched, so the rule does not trigger.
