### PR TITLE
docs(adr): correct ADR-087 reachable surface and state the reach predicate's granularity

### DIFF
--- a/docs/adr/ADR-087-amendment-1-population-snapshot.md
+++ b/docs/adr/ADR-087-amendment-1-population-snapshot.md
@@ -1,0 +1,51 @@
+# ADR-087 Amendment 1 — open pull request population snapshot
+
+Immutable record of the population the amendment's join was measured over.
+Counts in the amendment are derived from this file, not from a live query.
+
+- Cutoff (UTC): 2026-08-04T08:26:43+00:00
+- Surface ref: `e842a892d950f3d3b2687eaf6cc573e0587785a7`
+- Open pull requests: **35**
+- Trigger the rule (touch `crates/inference/`, `crates/embed/` or `crates/fann/`): **26**
+- Reached by the default A/B surface: **1**
+
+Names are classified on both `filename` and `previous_filename`, so a rename is
+classified at both of its paths.
+
+| PR    | head                                       | draft | files | triggers | reached paths             |
+| ----- | ------------------------------------------ | ----- | ----- | -------- | ------------------------- |
+| #1021 | `fa979d957f81f91d94db99eca17ad6d2bf9385ef` | yes   | 21    | yes      | —                         |
+| #1037 | `b3fdf0e3526fa596009a5c3fce4ab427891c508b` | yes   | 11    | yes      | —                         |
+| #1039 | `032f218881f50e8da1391f6d9c837cd5831943ae` | yes   | 10    | no       | —                         |
+| #1150 | `5ff852251c0179fea47b9685b0d440a415ad8404` | yes   | 5     | yes      | —                         |
+| #1162 | `c976e1215e68f7dac82cccce5adca7c1f7bb4308` | yes   | 9     | yes      | —                         |
+| #1183 | `c249e1d0cbefccbfee69253233186397fde5d1da` | no    | 3     | yes      | —                         |
+| #1187 | `37170b4455d8077d8f761ffc443f5443b871fa84` | yes   | 1     | yes      | —                         |
+| #1208 | `929ac7c620857045f883a3cc0d2de7c59be8c30e` | yes   | 6     | yes      | —                         |
+| #1219 | `a888bf0ddef1d5624f83bcdf0943a74c7eb154f6` | no    | 8     | yes      | —                         |
+| #1230 | `852649a87248195dccf0fb63df0e4a62e3ea9ea8` | no    | 13    | yes      | —                         |
+| #1231 | `228417020736ae5b3a46aff6954b4ba7fb064f04` | yes   | 20    | yes      | —                         |
+| #1241 | `2f9950cd144c8e57f68a012fbc120d38b648988e` | no    | 4     | yes      | —                         |
+| #1244 | `1e8ba317241d7b7dc674516a67d0ef10c5dcfe03` | yes   | 2     | yes      | —                         |
+| #1245 | `a80a93a4b0d3f7cf3abcab7a2f3d3ef35e799c93` | yes   | 2     | yes      | —                         |
+| #1246 | `e6141e58d3c54b6b8625f4346ec967dbb5c79a42` | yes   | 7     | yes      | —                         |
+| #1247 | `412d00a3adb5d6e17468a304f83e8a16752569ca` | yes   | 7     | yes      | —                         |
+| #1253 | `42bcb2299e2e4a7c818c15ff9b5bfc4fbe9bd858` | yes   | 10    | yes      | —                         |
+| #1255 | `8de086f1314a25c84018a43a475deb8a352f05f7` | yes   | 5     | yes      | —                         |
+| #1256 | `2a92783e5d1f5fb4ea9e5095da24b422b1cb17c7` | yes   | 24    | yes      | —                         |
+| #1260 | `b372458dc5fb0689d583d392dee1a706ab8beddb` | yes   | 17    | no       | —                         |
+| #1262 | `a1a6e8eeb0f4676b6abd82cc995757aed91fea4f` | yes   | 4     | yes      | —                         |
+| #1263 | `16db5498945b9d57f55f8faf0330f87dd198a046` | yes   | 19    | yes      | —                         |
+| #1264 | `ad2a003d55506d396ffbfb9fca392ad4126ce550` | no    | 5     | yes      | —                         |
+| #1265 | `5a48400bd1f33a6259c23c474fa2cb0683fbad95` | no    | 3     | yes      | —                         |
+| #1266 | `a25e9053dc0f8a37f315691168a922e9bead2f70` | no    | 3     | yes      | —                         |
+| #1267 | `92a60a5b5507b29aebb613d6e790918593b56548` | yes   | 6     | yes      | —                         |
+| #1270 | `ae6d27b5a61d2a62f912d195a644b1837a893fab` | yes   | 20    | yes      | —                         |
+| #1289 | `1a77f234ad38edba155537cf7c3c375e0496dcc2` | yes   | 18    | yes      | `crates/embed/src/lib.rs` |
+| #1290 | `dcd4896b96b3eeadfb6afdf1e6b72b049fce5595` | no    | 1     | no       | —                         |
+| #1296 | `1464edf523d1de3667932fa019082337fc8fd3aa` | no    | 1     | no       | —                         |
+| #1297 | `ff38dba96fe383827fd4865898c298c5f50e6cf1` | no    | 2     | no       | —                         |
+| #1298 | `2dab9e7d2cd17a7bb5010d029bd91c3694dcecb9` | no    | 3     | no       | —                         |
+| #1303 | `61049c7443526418f7537f97f64eaa6ff251373d` | no    | 1     | no       | —                         |
+| #1304 | `9d521449325ab76a3bef7cf6dac4665001c358ca` | no    | 2     | no       | —                         |
+| #1306 | `cd6d65c753c85d28bcadb42d061988bf3a0f8b0e` | no    | 1     | no       | —                         |

--- a/docs/adr/ADR-087-bench-compare-gate-calibration-and-coverage.md
+++ b/docs/adr/ADR-087-bench-compare-gate-calibration-and-coverage.md
@@ -247,3 +247,192 @@ admission requires enumeration rather than judgement. And D3 is written to preve
 this ADR most invites, which is that a gate found to be uncalibrated and structurally silent
 was therefore never binding. It was binding, it remains binding, and what changed is that its
 output is no longer admissible as evidence without a reachability showing.
+
+## Amendment 1 (2026-08-04): reachable-surface correction and the granularity of the reach predicate
+
+### Why the surface needed re-checking
+
+D3 puts the reachability burden on any citation of bench-compare output. Interim practice now
+goes further: a PR whose changes the default A/B cannot observe may state that fact, citing the
+derivation in this record, in place of an A/B table. That promotes the reachable surface from a
+supporting measurement into the predicate that decides whether a PR owes bench evidence at all.
+A surface used that way has to be right, and this one was not.
+
+### Correction 1: two directly imported files were missing from the surface
+
+Problem 3 names three things the embed `simd` bench imports: `lattice_embed::simd`,
+`lattice_embed::service`, and `EmbeddingModel`. The surface derived in the next sentence covers
+the first two and drops the third.
+
+`EmbeddingModel` is imported at `crates/embed/benches/simd.rs:9` and constructed at `:52`. It is
+defined at `crates/embed/src/model.rs:70` and re-exported at `crates/embed/src/lib.rs:34`. Both
+files are reached directly, in exactly the sense that admitted the two directories, and neither
+matches the classification predicate as it was written.
+
+The corrected surface has five entries, three directory prefixes and two exact paths:
+
+    crates/inference/src/forward/cpu/
+    crates/embed/src/simd/
+    crates/embed/src/service/
+    crates/embed/src/lib.rs
+    crates/embed/src/model.rs
+
+Measured at `origin/main` on 2026-08-04: 14 files under `forward/cpu/`, 11 under `embed/src/simd/`,
+4 under `embed/src/service/`, plus the two exact paths, for 31 files.
+
+This record states 28 for the first three prefixes, as 14 plus 14. The embed side is 15 today
+rather than 14 because `crates/embed/src/simd/manhattan.rs` was added after this record was
+written. The 14 was correct on its date. A hardcoded file count in a decision record went stale
+in three days here, which is the argument for stating a derivation command beside any count
+rather than only the number it produced.
+
+### Correction 2: two numerals do not reproduce under the commands named
+
+- **Bench target count.** This record states 31 declared bench targets. Measured 30 at
+  `origin/main` on 2026-08-04, and 30 at the record's own date, under both available readings:
+  `[[bench]]` sections declared across `crates/*/Cargo.toml`, and files matching
+  `crates/*/benches/*.rs`. The 31 was already off by one when it was written.
+- **Trigger set size.** This record states 452 files from `git ls-files 'crates/inference/*'
+  'crates/embed/*' 'crates/fann/*'`. That command yields 473 on the current checkout, and the
+  equivalent read at the record's own date yields 472. The 452 does not reproduce under the
+  command it is attributed to. This amendment states that and does not assert what produced it.
+
+### The result is unchanged, and now reproduces under both surfaces
+
+Measured on 2026-08-04 across the 34 open pull requests: 26 trigger the rule. Under the surface
+as originally written, zero are reached. Under the corrected surface, one is reached, PR #1289,
+and it is reached through `crates/embed/src/lib.rs` alone.
+
+So the conclusion of Problem 3 survives its own evidence being corrected. What changes is the
+predicate that is about to decide 25 dispositions.
+
+The omission understated reach, which is the direction that supports this record's conclusion.
+The closing section of this record names that direction as the one in which errors are not
+investigated. It was right about itself.
+
+One further scope note, and it is not a correction. This record already declares that it
+measures direct file-surface reachability and that transitive calls out of `forward::cpu` are
+established in neither direction. That declaration holds. A concrete instance of what it leaves
+open: `crates/inference/src/forward/cpu/softmax.rs:44` reaches
+`crates/inference/src/attention/softmax_row.rs` through a function-scoped import inside
+`softmax_attention_scalar`, which is production code on a directly benched path. That file is
+absent from the surface because the surface is file-level and direct by construction. It is the
+disclosed bound working as disclosed, not a second omission, and it is recorded here so that a
+reader who finds it does not have to re-derive whether it was missed.
+
+### D3-A: the reach predicate has two granularities, and file-level reach only opens the second
+
+The surface is file-level. The judgement it feeds is not. Stating only one of those leaves the
+next reader to pick, and the two picks disagree on real PRs. The predicate is therefore:
+
+**Step 1, file-level, mechanical.** Does the diff touch any path in the corrected surface? This
+is decidable from the surface list with no reading of the diff. If no, the PR may carry an
+unreachability statement naming this record. If yes, the file-level answer is a trigger and not
+a verdict, and step 2 is owed.
+
+**Step 2, symbol-level, not mechanical.** Does the diff perturb anything the benched code path
+executes? Discharged only by naming, for every changed hunk in every reached file, why the
+benched path cannot observe it. Three forms are admissible:
+
+- the hunk adds an item and modifies none, with the added item shown to be absent from the
+  bench's import and call surface;
+- the hunk is behind a `cfg` the bench build does not enable, with the bench build's resolved
+  feature set stated rather than assumed;
+- the hunk changes only text the compiler discards, shown by the diff itself.
+
+Anything else fails step 2 and the PR runs the A/B. Not admissible at either step: an argument
+that a change is small, cold, or obviously harmless. That is the reading D3 exists to prevent,
+and it would re-enter here if this step were left to judgement without a closed list.
+
+**Step 3, residual, always stated.** A discharged symbol-level claim still leaves a
+compiled-artifact residual. Adding an item to a crate the bench links changes what the compiler
+sees, and layout and inlining are not invariant under additions. The statement says that rather
+than claiming the benched path is provably unchanged. Where the residual is load-bearing, run
+the A/B instead of arguing about it.
+
+### Worked example: PR #1289 under D3-A
+
+Step 1: reached, through `crates/embed/src/lib.rs`, and no other file in the surface.
+
+Step 2: the change to that file is two lines, `#[cfg(feature = "native")]` and `pub mod drift;`,
+inserted between existing module declarations. No existing item is modified. The bench's only
+reference into this file's surface is the `EmbeddingModel` re-export at `:34`, which the diff
+does not touch, and `mod model;` is likewise untouched. This discharges under the first form.
+
+Step 3: `native` is in `lattice-embed`'s default feature set, so the added module does compile
+into the bench build. The claim is that no benched symbol changed. It is not a claim that the
+emitted binary is identical.
+
+Disposition: PR #1289 runs the A/B regardless. It is the only reached PR in the current
+population, and running one comparison is cheaper than establishing that its step 3 residual
+does not matter. That is an operational call about a population of one, and it is recorded
+separately from the predicate so that a later reader does not mistake it for the predicate
+producing a different answer than it does.
+
+### D5: direction for the target and trigger sets
+
+D3 identifies the mismatch. This sets the direction for closing it, and any implementation
+remains subject to the D3 condition that a target change is an instrument change requiring an
+A/A null re-run before the new member gates anything.
+
+- **Widen where a bench target already exists.** `BENCHES_INFERENCE` is overridable by
+  environment variable. `BENCHES_EMBED` is a bare assignment at
+  `scripts/lib/bench-compare-impl.sh:413` with no parameter expansion, so widening the embed
+  side is a code change and not a configuration change.
+- **`lattice-fann` is a widen case, not a narrow case.** An earlier characterization of fann as
+  code the instrument cannot compile is wrong. `crates/fann/Cargo.toml` declares a bench target
+  `router_online` with `required-features = ["online-router"]`, and
+  `crates/fann/benches/router_online.rs` imports `lattice_fann::training` and
+  `lattice_fann::{Activation, Network, NetworkBuilder}`. The instrument can reach fann. The
+  default target set does not include it, and the feature is not on by default. Removing fann
+  from the trigger set would discard a bench that exists.
+- **Narrow the trigger only where no bench target reaches the code at all.** That set is
+  established per path by the same derivation used here, not by inspection.
+
+### Evidence and method for this amendment
+
+All reads are at `origin/main` at `e842a892d950f3d3b2687eaf6cc573e0587785a7` unless a ref is
+named, and use `git ls-tree` rather than `git ls-files` where the question is about a ref rather
+than about a checkout.
+
+    # bench imports, both default targets
+    grep -n '^use ' crates/inference/benches/elementwise_cpu_bench.rs crates/embed/benches/simd.rs
+
+    # surface file counts
+    git ls-tree -r --name-only origin/main -- crates/inference/src/forward/cpu/ | grep -c '\.rs$'
+    git ls-tree -r --name-only origin/main -- crates/embed/src/simd/         | grep -c '\.rs$'
+    git ls-tree -r --name-only origin/main -- crates/embed/src/service/      | grep -c '\.rs$'
+
+    # declared bench targets, both readings
+    git show origin/main:crates/<c>/Cargo.toml | grep -c '^\[\[bench\]\]'   # summed over crates
+    git ls-tree -r --name-only origin/main | grep -c '^crates/.*/benches/.*\.rs$'
+
+    # trigger set
+    git ls-tree -r --name-only origin/main -- crates/inference/ crates/embed/ crates/fann/ | wc -l
+
+    # open-PR join
+    gh pr list --state open --limit 100 --json number
+    gh api "repos/<slug>/pulls/<n>/files?per_page=300" --jq '.[].filename'
+
+The classification predicate is an anchored alternation with a trailing separator on every
+directory prefix and an end anchor on every exact path:
+
+    ^(crates/inference/src/forward/cpu/|crates/embed/src/simd/|crates/embed/src/service/|crates/embed/src/lib\.rs$|crates/embed/src/model\.rs$)
+
+Both arms were run in the same invocation before any count was taken. Must-match:
+`crates/inference/src/forward/cpu/softmax.rs`, `crates/embed/src/simd/dot.rs`,
+`crates/embed/src/lib.rs`, `crates/embed/src/model.rs`. Must-not-match:
+`crates/inference/src/forward/cpu_f16.rs`, which is the prefix error this record already
+discloses and which a missing trailing separator reintroduces;
+`crates/embed/src/model_loader.rs`, which is the same error in the new exact-path entries;
+`crates/inference/src/attention/softmax_row.rs`, which must stay out because the surface is
+direct rather than transitive; and `crates/fann/src/lib.rs`. All eight arms returned their
+expected values.
+
+### Direction of error for this amendment
+
+The surface correction increases reach, which increases work, and that is the direction that
+does not get skipped for convenience. The symbol-level step gives work back, and it is the only
+step here that rests on judgement rather than on a list. That step is therefore where a future
+permissive error will live, which is why its admissible forms are closed and why step 3 requires
+a residual statement even when step 2 succeeds.

--- a/docs/adr/ADR-087-bench-compare-gate-calibration-and-coverage.md
+++ b/docs/adr/ADR-087-bench-compare-gate-calibration-and-coverage.md
@@ -332,6 +332,12 @@ is decidable from the surface list with no reading of the diff. If no, the PR ma
 unreachability statement naming this record. If yes, the file-level answer is a trigger and not
 a verdict, and step 2 is owed.
 
+An unreachability statement names the pull request head it was evaluated at and the ref the
+surface was read from, and is void if either moves. Neither operand is stable. A PR head moves
+on every push, and the surface itself gained a file within three days of the record it is
+derived from, which is the `manhattan.rs` case above. A statement that pins neither cannot be
+checked later by anyone, including its author.
+
 **Step 2, symbol-level, not mechanical.** Does the diff perturb anything the benched code path
 executes? Discharged only by naming, for every changed hunk in every reached file, why the
 benched path cannot observe it. Three forms are admissible:

--- a/docs/adr/ADR-087-bench-compare-gate-calibration-and-coverage.md
+++ b/docs/adr/ADR-087-bench-compare-gate-calibration-and-coverage.md
@@ -299,7 +299,9 @@ rather than only the number it produced.
 
 ### The result is unchanged, and now reproduces under both surfaces
 
-Measured on 2026-08-04 across the 34 open pull requests: 26 trigger the rule. Under the surface
+Measured on 2026-08-04 across the 34 pull requests open at the time of measurement, which
+excludes the one carrying this amendment because it did not yet exist and is in any case
+documentation only: 26 trigger the rule. Under the surface
 as originally written, zero are reached. Under the corrected surface, one is reached, PR #1289,
 and it is reached through `crates/embed/src/lib.rs` alone.
 

--- a/docs/adr/ADR-087-bench-compare-gate-calibration-and-coverage.md
+++ b/docs/adr/ADR-087-bench-compare-gate-calibration-and-coverage.md
@@ -293,17 +293,39 @@ rather than only the number it produced.
   `[[bench]]` sections declared across `crates/*/Cargo.toml`, and files matching
   `crates/*/benches/*.rs`. The 31 was already off by one when it was written.
 - **Trigger set size.** This record states 452 files from `git ls-files 'crates/inference/*'
-  'crates/embed/*' 'crates/fann/*'`. That command yields 473 on the current checkout, and the
-  equivalent read at the record's own date yields 472. The 452 does not reproduce under the
-  command it is attributed to. This amendment states that and does not assert what produced it.
+  'crates/embed/*' 'crates/fann/*'`. That command yields 473 on the current checkout. At
+  `63a50832e3cfaabcb72a10a7c4639069844f64fe` — the ref this record names for its own
+  measurements, at line 13 — the equivalent read yields **465**
+  (`git ls-tree -r --name-only 63a50832e3cfaabcb72a10a7c4639069844f64fe -- crates/inference/
+  crates/embed/ crates/fann/ | wc -l`). The unreproduced gap is therefore 13, not the 20 an
+  end-of-day comparison suggests. The 452 does not reproduce under the command it is attributed
+  to, and this amendment states that without asserting what produced it.
+
+  The first draft of this correction compared against a commit chosen by calendar date rather
+  than the ref the record names, and reported 472. Both numbers are real reads of the repository
+  and they differ by eight commits of the same afternoon. **A record that names its own
+  measurement ref is re-derived at that ref**; a same-day read is a different measurement wearing
+  the same date. The correction of a numeral is not exempt from the discipline the numeral
+  failed, and a section whose entire subject is that counts must be checkable at a named ref is
+  the worst possible place to pick a ref by date.
 
 ### The result is unchanged, and now reproduces under both surfaces
 
-Measured on 2026-08-04 across the 34 pull requests open at the time of measurement, which
-excludes the one carrying this amendment because it did not yet exist and is in any case
-documentation only: 26 trigger the rule. Under the surface
-as originally written, zero are reached. Under the corrected surface, one is reached, PR #1289,
-and it is reached through `crates/embed/src/lib.rs` alone.
+Measured over the population recorded in
+[`ADR-087-amendment-1-population-snapshot.md`](ADR-087-amendment-1-population-snapshot.md),
+which pins the cutoff, every open pull request number, and each one's head OID: 35 open, of
+which 26 trigger the rule. Under the surface as originally written, zero are reached. Under the
+corrected surface, one is reached, PR #1289, and it is reached through `crates/embed/src/lib.rs`
+alone. The snapshot classifies on both `filename` and `previous_filename`, so those counts
+already carry the rename fix described below, and they are unchanged by it.
+
+**The counts are stated against a committed snapshot rather than a date, because a date does not
+identify a population that changes hourly.** An earlier version of this paragraph read "the 34
+pull requests open at the time of measurement" and gave no way to say which 34. That number was
+also self-falsifying: opening the pull request that carries this amendment made the population
+35 while the sentence claiming 34 sat inside it. A count of a moving population is a claim no
+later reader can check and no author can re-check, so it is recorded as a list or it is not
+recorded.
 
 So the conclusion of Problem 3 survives its own evidence being corrected. What changes is the
 predicate that is about to decide 25 dispositions.
@@ -321,6 +343,30 @@ open: `crates/inference/src/forward/cpu/softmax.rs:44` reaches
 absent from the surface because the surface is file-level and direct by construction. It is the
 disclosed bound working as disclosed, not a second omission, and it is recorded here so that a
 reader who finds it does not have to re-derive whether it was missed.
+
+### Correction 3: this record's Consequences say an unreached PR waits, and that is superseded
+
+The second bullet under **Consequences** reads: _"The remaining PRs do not merge on a structural
+proof, and they do not merge on an A/B either, because the A/B did not observe them. They wait
+on the instrument."_
+
+That disposition is **withdrawn and replaced** by D3-A below. It was written when the only two
+admissible artifacts were a structural proof and an A/B table, so a PR the instrument could not
+observe had nothing it could offer and waiting was the only honest option left. D3-A adds a
+third admissible artifact — a pinned unreachability statement — and a PR carrying one is not
+waiting on the instrument, it has said the true thing about the instrument.
+
+This is stated explicitly rather than left to inference because the two texts give **opposite
+dispositions to the same population**, and an amendment that adds a path without retiring the
+one it replaces leaves the next reader to pick. Whichever they pick, roughly two dozen pull
+requests move or do not move on it. An unretracted sentence is not a dead letter; it is the
+sentence a reader who does not reach the amendment will apply.
+
+The bound is exact. What is withdrawn is the _wait_, not the _burden_. D3 is untouched: the
+reachability burden still sits with any citation of bench-compare output, and an unreachability
+statement discharges the bench-evidence requirement only by being checkable, which is what the
+pinning rule in step 1 is for. A PR whose statement does not pin, or whose pins have moved, has
+not discharged anything and is back where the old bullet left it.
 
 ### D3-A: the reach predicate has two granularities, and file-level reach only opens the second
 
@@ -343,10 +389,26 @@ executes? Discharged only by naming, for every changed hunk in every reached fil
 benched path cannot observe it. Three forms are admissible:
 
 - the hunk adds an item and modifies none, with the added item shown to be absent from the
-  bench's import and call surface;
+  bench's import and call surface — **and, where the added item introduces contents of its own,
+  those contents discharged under this same list, recursively**;
 - the hunk is behind a `cfg` the bench build does not enable, with the bench build's resolved
   feature set stated rather than assumed;
 - the hunk changes only text the compiler discards, shown by the diff itself.
+
+**Form 1 is a test on behaviour, not on tokens, and it is recursive for a reason.** A module
+declaration is two words in a diff and an arbitrary quantity of code behind them. Read
+lexically, `pub mod x;` adds one item, modifies none, and appears nowhere in the bench's import
+list, so it discharges — while `x` may contain a `#[global_allocator]`, a `#[no_mangle]` or
+`#[export_name]` symbol, a linker or codegen attribute, a `static` with an initializer, a trait
+`impl` on a type the bench already uses, or a macro the bench's dependencies expand. Every one of
+those changes what the benched binary does without appearing at the bench's import surface at
+all, because their effect is by construction not by reference. The absent-from-the-import-surface
+check is necessary and is nowhere near sufficient: it is an allowlist over the names a diff
+mentions, and the risk lives in what the named thing contains.
+
+So an item addition discharges only when its contents are enumerated and each is itself
+discharged. If the contents are not read, Form 1 is not available and the PR runs the A/B. This
+is deliberately the expensive reading: the cheap one is indistinguishable from not looking.
 
 Anything else fails step 2 and the PR runs the A/B. Not admissible at either step: an argument
 that a change is small, cold, or obviously harmless. That is the reading D3 exists to prevent,
@@ -363,19 +425,35 @@ the A/B instead of arguing about it.
 Step 1: reached, through `crates/embed/src/lib.rs`, and no other file in the surface.
 
 Step 2: the change to that file is two lines, `#[cfg(feature = "native")]` and `pub mod drift;`,
-inserted between existing module declarations. No existing item is modified. The bench's only
-reference into this file's surface is the `EmbeddingModel` re-export at `:34`, which the diff
-does not touch, and `mod model;` is likewise untouched. This discharges under the first form.
+inserted between existing module declarations. No existing item is modified. The bench's three
+import paths into this crate resolve through **four** root-level declarations, and all four are
+checked rather than only the one named in an earlier version of this section:
+`use lattice_embed::EmbeddingModel` resolves through the re-export at `:34`, which in turn
+depends on the private `mod model;` at `:22`; `use lattice_embed::service::{…}` resolves through
+`pub mod service;` at `:23`; and `use lattice_embed::simd::{…}` resolves through `pub mod simd;`
+at `:24`. The diff modifies none of the four. Counting the re-export alone understates the
+root-module surface the bench depends on, and a change to `:22`, `:23` or `:24` would be
+invisible to a check that looked only at `:34`.
+
+**That is as far as the declaration gets it, and it is not far enough.** Under Form 1 as
+corrected above, an item addition discharges only when the added item's contents are themselves
+enumerated and discharged. `drift`'s contents are not read here, so Form 1 is unavailable and
+step 2 is undischarged. An earlier version of this example concluded the opposite — it read the
+two-line hunk lexically, found the added name absent from the bench's import surface, and
+discharged. That conclusion was the lexical hole, demonstrated on the one PR the predicate had
+to decide.
 
 Step 3: `native` is in `lattice-embed`'s default feature set, so the added module does compile
-into the bench build. The claim is that no benched symbol changed. It is not a claim that the
-emitted binary is identical.
+into the bench build. Even had step 2 discharged, the claim available would be that no benched
+symbol changed, never that the emitted binary is identical.
 
-Disposition: PR #1289 runs the A/B regardless. It is the only reached PR in the current
-population, and running one comparison is cheaper than establishing that its step 3 residual
-does not matter. That is an operational call about a population of one, and it is recorded
-separately from the predicate so that a later reader does not mistake it for the predicate
-producing a different answer than it does.
+Disposition: PR #1289 runs the A/B. Under the corrected Form 1 that is what the predicate
+requires rather than an operational preference, which is a stronger footing than the earlier
+version of this section had: it previously reached the same disposition by judgement, on the
+grounds that one comparison is cheaper than arguing about a residual in a population of one. Same
+outcome, different authority. Where the predicate and a convenience argument agree, the
+predicate is what gets recorded, because the convenience argument does not survive a population
+of twenty.
 
 ### D5: direction for the target and trigger sets
 
@@ -403,8 +481,16 @@ All reads are at `origin/main` at `e842a892d950f3d3b2687eaf6cc573e0587785a7` unl
 named, and use `git ls-tree` rather than `git ls-files` where the question is about a ref rather
 than about a checkout.
 
+An earlier version of this block asserted that method and then listed one command that did not
+follow it: a bare `grep` over two bench files, which reads whatever the working tree happens to
+hold. A stated ref discipline is not evidence that the commands beneath it observe the ref, and a
+single checkout-relative read inside a ref-qualified list is invisible precisely because the
+surrounding commands are correct. Every read below is now ref-qualified in the command itself, so
+the discipline is checkable from the commands rather than from the sentence introducing them.
+
     # bench imports, both default targets
-    grep -n '^use ' crates/inference/benches/elementwise_cpu_bench.rs crates/embed/benches/simd.rs
+    git show <ref>:crates/inference/benches/elementwise_cpu_bench.rs | grep -n '^use '
+    git show <ref>:crates/embed/benches/simd.rs                     | grep -n '^use '
 
     # surface file counts
     git ls-tree -r --name-only origin/main -- crates/inference/src/forward/cpu/ | grep -c '\.rs$'
@@ -418,24 +504,64 @@ than about a checkout.
     # trigger set
     git ls-tree -r --name-only origin/main -- crates/inference/ crates/embed/ crates/fann/ | wc -l
 
-    # open-PR join
+    # open-PR join — BOTH name fields, see below
     gh pr list --state open --limit 100 --json number
-    gh api "repos/<slug>/pulls/<n>/files?per_page=300" --jq '.[].filename'
+    gh api "repos/<slug>/pulls/<n>/files?per_page=300" --jq '.[] | .filename, .previous_filename'
 
-The classification predicate is an anchored alternation with a trailing separator on every
-directory prefix and an end anchor on every exact path:
+**The join reads both name fields, and the first draft of it did not.** GitHub represents a
+rename with a new `filename` and an old `previous_filename`, so a projection of `.[].filename`
+alone reports only where a file landed and never where it came from. This repository contains a
+real instance: PR #1038 carries
+`{"filename": "crates/tune/src/train_support.rs", "previous_filename":
+"crates/tune/src/bin/train_common/mod.rs", "status": "renamed"}`. A diff that renamed a file
+_out of_ the reachable surface, or renamed a crate root _into_ a path the surface does not list
+and then changed it, would touch the surface at its old name while the join saw only the
+unmatched new one. Step 1 would answer "no" and step 2 would never be owed. The failure is
+silent and runs in the permissive direction, which is the direction this record already names as
+the one nobody investigates.
 
-    ^(crates/inference/src/forward/cpu/|crates/embed/src/simd/|crates/embed/src/service/|crates/embed/src/lib\.rs$|crates/embed/src/model\.rs$)
+Two consequences follow. Deletions and renames are classified on **both** names. And a diff that
+changes a crate's `[lib] path`, or otherwise moves a crate root, is a **mandatory step-1 reach**
+regardless of what the surface list says, until the new root has been derived into the surface —
+because the surface names crate roots by path, and a moved root makes every one of those entries
+stale in a way no path comparison can detect.
 
-Both arms were run in the same invocation before any count was taken. Must-match:
-`crates/inference/src/forward/cpu/softmax.rs`, `crates/embed/src/simd/dot.rs`,
-`crates/embed/src/lib.rs`, `crates/embed/src/model.rs`. Must-not-match:
-`crates/inference/src/forward/cpu_f16.rs`, which is the prefix error this record already
+The classification predicate is a path-prefix test plus an exact-path set, evaluated as string
+operations rather than as a regular expression:
+
+    reached(p) := p.startswith("crates/inference/src/forward/cpu/")
+               or p.startswith("crates/embed/src/simd/")
+               or p.startswith("crates/embed/src/service/")
+               or p == "crates/embed/src/lib.rs"
+               or p == "crates/embed/src/model.rs"
+
+An earlier form of this predicate was a single anchored alternation in which the two exact paths
+carried a `$` anchor and the three directories carried a trailing separator. That form is
+correct under an engine where `$` matches only at end of string, and the record did not say
+which engine. Stating the predicate as prefix tests and equality tests removes the dependency
+rather than documenting it: **the two exact entries are equality, not suffix matching**, and the
+three directory entries match only at a path boundary.
+
+All nine control arms were evaluated in one invocation, against the tracked file list at
+`e842a892d950f3d3b2687eaf6cc573e0587785a7`, before any count was taken. Must-match:
+`crates/inference/src/forward/cpu/softmax.rs`, `crates/embed/src/simd/dot_product.rs`,
+`crates/embed/src/service/mod.rs`, `crates/embed/src/lib.rs`, `crates/embed/src/model.rs`.
+Must-not-match: `crates/inference/src/forward/cpu_f16.rs`, the prefix error this record already
 discloses and which a missing trailing separator reintroduces;
-`crates/embed/src/model_loader.rs`, which is the same error in the new exact-path entries;
 `crates/inference/src/attention/softmax_row.rs`, which must stay out because the surface is
-direct rather than transitive; and `crates/fann/src/lib.rs`. All eight arms returned their
-expected values.
+direct rather than transitive; `crates/fann/src/lib.rs`; and `crates/embed/src/model.rs.bak`,
+**which is synthetic and is labelled as such** — no such file exists in the repository, and it
+is present only to test that the two exact entries reject a suffix extension.
+
+Every must-match arm is additionally asserted to be a **tracked path at that ref**, in the same
+invocation. An earlier form of these controls named `crates/embed/src/simd/dot.rs` and
+`crates/embed/src/model_loader.rs`, neither of which exists in this repository — the real file is
+`dot_product.rs` — and presented both as repository paths. Those arms exercised the predicate
+against strings and returned the expected answers, so the stated result was not false; what was
+false was the implication that the predicate had been checked against the files it claims to
+classify. A must-match arm on a path that does not exist tests a regular expression, not a
+surface. Eight arms in two directions read as thorough, which is exactly why nobody re-derived
+them.
 
 ### Direction of error for this amendment
 


### PR DESCRIPTION
ADR-087 established that the bench-compare gate triggers on a far larger file set than its two
default targets can reach, and made reachability the burden on any citation of bench output.
That reachable surface is now being used as the predicate that decides whether a PR owes bench
evidence at all, so it has to be right. Re-deriving it found that it was not.

## What this corrects

**The surface omitted two directly imported files.** ADR-087's own prose names three things the
embed `simd` bench imports: `lattice_embed::simd`, `lattice_embed::service`, and
`EmbeddingModel`. The surface it derives in the next sentence covers the first two and drops the
third. `EmbeddingModel` is imported at `crates/embed/benches/simd.rs:9`, constructed at `:52`,
defined at `crates/embed/src/model.rs:70`, and re-exported at `crates/embed/src/lib.rs:34`.
Neither file matched the classification predicate.

**Two numerals do not reproduce under the commands they are attributed to.** The declared bench
target count is 30 rather than 31, at ADR-087's own date, under both available readings. The
trigger set is 473 files today and **465 at `63a50832e3`, the ref ADR-087 names for its own
measurements at line 13**, against a stated 452. The unreproduced gap is 13.

**Counts refreshed.** The embed side of the surface is 15 files rather than 14 because
`crates/embed/src/simd/manhattan.rs` landed after ADR-087 was written. The original count was
correct on its date.

**The open-pull-request join was blind to renames.** It projected `.[].filename`, which reports
where a file landed and never where it came from. This repository contains a real instance: PR
#1038 renames `crates/tune/src/bin/train_common/mod.rs` to `crates/tune/src/train_support.rs`.
A diff renaming a crate root into a path the surface does not list, then changing it, would
touch the surface at its old name while the join saw only the unmatched new one, so step 1 would
answer "no" and step 2 would never be owed. Names are now classified on both `filename` and
`previous_filename`, and a crate-root move is a mandatory step-1 reach until the new root is
derived into the surface.

**The Consequences bullet holding an unreached PR to wait on the instrument is withdrawn.** It
and the new statement path gave opposite dispositions to the same population, with nothing
saying which governs. What is withdrawn is the wait, not the burden: D3 is untouched and a
statement discharges only by pinning what it was evaluated against.

## What this does not change

Measured over the population recorded in `docs/adr/ADR-087-amendment-1-population-snapshot.md`,
which pins the cutoff, every open pull request number and each head OID: 35 open, of which 26
trigger the rule, zero are reached under the surface as originally written, and one is reached
under the corrected surface (#1289, through `crates/embed/src/lib.rs` alone). Those counts
already carry the rename fix and are unchanged by it. The Problem 3 conclusion survives its own
evidence being corrected.

The counts are stated against a committed snapshot rather than a date because a date does not
identify a population that changes hourly.

The omission understated reach, which is the direction that supports ADR-087's conclusion.
ADR-087's closing section names that direction as the one in which errors are not investigated.

One item is explicitly *not* a correction: `crates/inference/src/forward/cpu/softmax.rs:44`
reaches `crates/inference/src/attention/softmax_row.rs` transitively, and that file's absence is
ADR-087's disclosed file-level-and-direct scope working as disclosed. It is recorded so the next
reader does not re-derive whether it was missed.

## What this adds

**D3-A** states that the surface is file-level while the judgement it feeds is not. A positive
file-level answer opens a symbol-level step with a closed list of three admissible discharges,
and a residual statement is required even when that step succeeds.

Form 1 of that list is **recursive**, and this is the substantive change. Read lexically,
`pub mod x;` adds one item, modifies none, and appears nowhere in the bench's import list, so it
discharges — while `x` may contain a global allocator, an exported symbol, a linker attribute, a
static initializer, a trait `impl` on a benched type, or a macro. Each changes the benched binary
without appearing at the import surface, because the effect is by construction rather than by
reference. An item addition therefore discharges only when its contents are enumerated and each
is itself discharged. PR #1289 is worked through the predicate as an example and lands on the
A/B by the predicate rather than by an operational preference.

**D5** sets the direction for the target and trigger sets. It records that `lattice-fann`
declares a feature-gated bench target (`router_online`, `required-features = ["online-router"]`)
whose bench imports fann source directly, so fann is a widen case rather than a trigger to
remove. `BENCHES_EMBED` is a bare assignment at `scripts/lib/bench-compare-impl.sh:413`, so
widening the embed side is a code change rather than a configuration change.

## Evidence

Every count carries the command that produced it, ref-qualified **in the command itself** rather
than by a sentence introducing the block, and using `git ls-tree` rather than `git ls-files`
where the question is about a ref.

The classification predicate is stated as path-prefix tests plus an exact-path set, evaluated as
string operations rather than as a regular expression, so the two exact entries are equality
tests and do not depend on unstated matcher semantics for `$`.

Nine control arms run in one invocation before any count is taken, and **every must-match arm is
additionally asserted to be a tracked path at the surface ref**. That assertion is new: two
earlier arms named `crates/embed/src/simd/dot.rs` and `crates/embed/src/model_loader.rs`, neither
of which exists in this repository — the real file is `dot_product.rs` — and presented both as
repository paths. Those arms exercised the predicate against strings and returned the expected
answers, so the stated result was not false; what was false was the implication that the
predicate had been checked against the files it classifies. The one synthetic decoy is now
labelled synthetic.

## bench-compare disposition

Documentation only. No file under `crates/inference/`, `crates/embed/`, or `crates/fann/` is
touched, so the rule does not trigger.