### PR TITLE
fix(bench): require and resolve a supported interpreter at harness entry

### DIFF
--- a/scripts/bench-command.sh
+++ b/scripts/bench-command.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
+source "$REPO/scripts/lib/bench-python.sh"
 HELPER="$REPO/scripts/lib/bench_supervision.py"
 LABEL=""
 MODE="ordinary"
@@ -32,7 +33,8 @@ if [[ -z "$LABEL" || $# -eq 0 ]]; then
     exit 2
 fi
 
+PYTHON_BIN="$(bench_require_python3 "bench-command.sh")" || exit 1
 if [[ "$MODE" == "durable" ]]; then
-    exec python3 "$HELPER" run --label "$LABEL" --quiet -- "$@"
+    exec "$PYTHON_BIN" "$HELPER" run --label "$LABEL" --quiet -- "$@"
 fi
-exec python3 "$HELPER" run --label "$LABEL" -- "$@"
+exec "$PYTHON_BIN" "$HELPER" run --label "$LABEL" -- "$@"

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -25,7 +25,9 @@
 # with only a fabricated status file is refused at the handoff sample.
 set -euo pipefail
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
-exec python3 "$REPO/scripts/lib/bench_supervision.py" run \
+source "$REPO/scripts/lib/bench-python.sh"
+PYTHON_BIN="$(bench_require_python3 "bench-compare.sh")" || exit 1
+exec "$PYTHON_BIN" "$REPO/scripts/lib/bench_supervision.py" run \
   --label "bench-compare" \
   --entrypoint \
   -- "$REPO/scripts/lib/bench-compare-impl.sh" "$@"

--- a/scripts/bench_quality_selftest.sh
+++ b/scripts/bench_quality_selftest.sh
@@ -15,6 +15,7 @@ mkdir -p "$SB/scripts/lib" "$SB/docs/bench_results" "$SB/target/release" \
 cp "$SRC" "$SB/scripts/bench_quality.sh"
 if ! cp \
   "$SRC_ROOT/scripts/lib/bench-supervision.sh" \
+  "$SRC_ROOT/scripts/lib/bench-python.sh" \
   "$SRC_ROOT/scripts/lib/bench_supervision.py" \
   "$SRC_ROOT/scripts/lib/bench-locks.py" \
   "$SB/scripts/lib/"; then

--- a/scripts/bench_wasm_simd.mjs
+++ b/scripts/bench_wasm_simd.mjs
@@ -43,6 +43,28 @@ const REPO = path.resolve(HERE, '..');
 const SUPERVISION = path.join(REPO, 'scripts', 'lib', 'bench_supervision.py');
 const SUPERVISOR_FD = Number(process.env.LATTICE_BENCH_SUPERVISOR_FD ?? '');
 
+// Resolve a Python interpreter that satisfies the bench harness's version
+// floor (scripts/lib/bench_supervision.py: 3.11+) instead of trusting
+// whichever `python3` happens to be first on PATH -- macOS ships
+// /usr/bin/python3 at 3.9, which is too old.
+function resolvePython3() {
+  for (const candidate of ['python3.13', 'python3.12', 'python3.11', 'python3']) {
+    const probe = spawnSync(
+      candidate,
+      ['-c', 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)'],
+      { stdio: 'ignore' },
+    );
+    if (!probe.error && probe.status === 0) return candidate;
+  }
+  console.error(
+    'bench_wasm_simd: no Python >= 3.11 found on PATH (tried python3.13, ' +
+      'python3.12, python3.11, python3); install one (e.g. ' +
+      '`brew install python@3.12`) and ensure it is reachable.',
+  );
+  process.exit(1);
+}
+const PYTHON3 = resolvePython3();
+
 function supervisionStdio() {
   const stdio = ['inherit', 'inherit', 'inherit'];
   if (!Number.isInteger(SUPERVISOR_FD) || SUPERVISOR_FD < 3) return stdio;
@@ -53,7 +75,7 @@ function supervisionStdio() {
 
 if (!process.env.LATTICE_BENCH_LOCK_STATUS) {
   const child = spawnSync(
-    'python3',
+    PYTHON3,
     [
       SUPERVISION,
       'run',
@@ -74,7 +96,7 @@ if (!process.env.LATTICE_BENCH_LOCK_STATUS) {
   process.exit(child.status ?? 2);
 }
 
-const receipt = spawnSync('python3', [SUPERVISION, 'verify', '--require-quiet'], {
+const receipt = spawnSync(PYTHON3, [SUPERVISION, 'verify', '--require-quiet'], {
   // Node closes non-stdio descriptors by default. Preserve the non-lock
   // liveness pipe only for this cooperative handoff sample.
   stdio: supervisionStdio(),
@@ -259,7 +281,7 @@ for (const dim of ARGS.dims) {
   }
 }
 
-const completed = spawnSync('python3', [SUPERVISION, 'verify'], {
+const completed = spawnSync(PYTHON3, [SUPERVISION, 'verify'], {
   stdio: supervisionStdio(),
   env: {
     ...process.env,

--- a/scripts/lib/bench-python.sh
+++ b/scripts/lib/bench-python.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Resolve a Python interpreter that satisfies the bench harness's version
+# floor (scripts/lib/bench_supervision.py, scripts/perf-bench-gate.py,
+# scripts/lib/machine-state-probe.py: 3.11+), instead of trusting whichever
+# `python3` happens to be first on PATH. macOS ships /usr/bin/python3 at
+# 3.9, and PATH order putting it ahead of a newer interpreter is a normal,
+# not exotic, caller environment.
+#
+# Prints the resolved interpreter's path on stdout and returns 0, or prints
+# nothing and returns 1 if no candidate on PATH satisfies the floor.
+bench_resolve_python3() {
+    local candidate resolved
+    for candidate in python3.13 python3.12 python3.11 python3; do
+        resolved="$(command -v "$candidate" 2>/dev/null)" || continue
+        if "$resolved" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)' 2>/dev/null; then
+            printf '%s\n' "$resolved"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Resolves via bench_resolve_python3 or exits 1 with a message naming the
+# requirement, what was found, and how to get a suitable interpreter.
+# Usage: PYTHON_BIN="$(bench_require_python3 "$0")"
+bench_require_python3() {
+    local caller="${1:-$0}" resolved
+    if resolved="$(bench_resolve_python3)"; then
+        printf '%s\n' "$resolved"
+        return 0
+    fi
+    {
+        echo "$caller: no Python >= 3.11 found on PATH (tried python3.13, python3.12, python3.11, python3)."
+        echo "$caller: found on PATH: $(command -v python3 2>/dev/null || echo 'none') ($(command -v python3 >/dev/null 2>&1 && "$(command -v python3)" --version 2>&1 || echo 'n/a'))"
+        echo "$caller: install a newer interpreter, e.g. \`brew install python@3.12\`, and ensure it's reachable."
+    } >&2
+    return 1
+}

--- a/scripts/lib/bench-supervision.sh
+++ b/scripts/lib/bench-supervision.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/bench-python.sh"
+
 bench_close_supervisor_witness() {
     local fd="${LATTICE_BENCH_SUPERVISOR_FD:-}"
 
@@ -15,22 +17,23 @@ bench_supervise_entry() {
     local measurement="$3"
     shift 3
 
-    local repo helper
+    local repo helper python_bin
     repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
     helper="$repo/scripts/lib/bench_supervision.py"
+    python_bin="$(bench_require_python3 "${0##*/}")" || exit 1
 
     if [[ -z "${LATTICE_BENCH_LOCK_STATUS:-}" ]]; then
         if [[ "$mode" == "durable" ]]; then
-            exec python3 "$helper" run --label "$label" --quiet --entrypoint -- "$0" "$@"
+            exec "$python_bin" "$helper" run --label "$label" --quiet --entrypoint -- "$0" "$@"
         fi
-        exec python3 "$helper" run --label "$label" --entrypoint -- "$0" "$@"
+        exec "$python_bin" "$helper" run --label "$label" --entrypoint -- "$0" "$@"
     fi
     if [[ "$mode" == "durable" ]]; then
-        if ! python3 "$helper" verify --require-quiet; then
+        if ! "$python_bin" "$helper" verify --require-quiet; then
             exit 2
         fi
     else
-        if ! python3 "$helper" verify; then
+        if ! "$python_bin" "$helper" verify; then
             exit 2
         fi
     fi
@@ -54,7 +57,7 @@ bench_supervise_entry() {
     if [[ "$restore_errexit" -eq 1 ]]; then
         set -e
     fi
-    if ! python3 "$helper" verify; then
+    if ! "$python_bin" "$helper" verify; then
         return 2
     fi
     return "$measurement_rc"

--- a/scripts/lib/bench_supervision.py
+++ b/scripts/lib/bench_supervision.py
@@ -11,6 +11,27 @@ caller-supplied state and does not authenticate a deliberate same-user caller.
 
 from __future__ import annotations
 
+import sys
+
+# 3.10 covers this module's own zip(..., strict=True) (PEP 618), but the
+# measurement scripts this supervisor hands off to (scripts/perf-bench-gate.py,
+# scripts/lib/machine-state-probe.py) already require 3.11 (`datetime.UTC`,
+# PEP 604 checked at their own entry). Floor here at the graph's actual
+# requirement so a 3.10 interpreter fails fast at this entry point instead of
+# passing here and crashing two steps later inside the measurement body.
+_MIN_PYTHON = (3, 11)
+if sys.version_info < _MIN_PYTHON:
+    sys.stderr.write(
+        "bench-supervision: requires Python >= "
+        f"{'.'.join(str(part) for part in _MIN_PYTHON)} "
+        "(this harness and the measurement scripts it hands off to use "
+        "zip(..., strict=True) and datetime.UTC); found "
+        f"{sys.version.split()[0]} at {sys.executable}. "
+        "Install a newer interpreter (e.g. `brew install python@3.12`) and "
+        "point the caller at it explicitly rather than relying on PATH.\n"
+    )
+    sys.exit(1)
+
 import argparse
 import fcntl
 import os
@@ -19,7 +40,6 @@ import runpy
 import select
 import stat
 import subprocess
-import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]

--- a/tests/test_bench_measurement_supervision.py
+++ b/tests/test_bench_measurement_supervision.py
@@ -994,8 +994,17 @@ class InventoryContract(unittest.TestCase):
         ):
             with self.subTest(path=path):
                 source = (REPO / path).read_text()
+                # The interpreter may be a literal `python3` or a resolved
+                # interpreter variable (e.g. `"$python_bin"` from
+                # bench-python.sh's version-floor resolver) -- either way,
+                # the helper's `verify` subcommand must be re-invoked.
                 self.assertGreaterEqual(
-                    len(re.findall(r'python3 "[^"]+" verify', source)), 2
+                    len(
+                        re.findall(
+                            r'(?:python3|"\$[A-Za-z_]+") "[^"]+" verify', source
+                        )
+                    ),
+                    2,
                 )
                 self.assertNotIn("verify-retained", source)
 
@@ -1008,7 +1017,12 @@ class _SupervisorSandbox:
         self.root = Path(self.tmp.name) / "repo"
         lib = self.root / "scripts" / "lib"
         lib.mkdir(parents=True)
-        for name in ("bench_supervision.py", "bench-locks.py", "quiet-probe.py"):
+        for name in (
+            "bench_supervision.py",
+            "bench-locks.py",
+            "quiet-probe.py",
+            "bench-python.sh",
+        ):
             shutil.copy2(REPO / "scripts" / "lib" / name, lib / name)
         shutil.copy2(
             REPO / "scripts" / "lib" / "bench-supervision.sh",
@@ -2299,6 +2313,10 @@ class BenchCompareDirectInvocationRefusal(unittest.TestCase):
         shutil.copy2(
             REPO / "scripts" / "lib" / "bench_supervision.py",
             lib / "bench_supervision.py",
+        )
+        shutil.copy2(
+            REPO / "scripts" / "lib" / "bench-python.sh",
+            lib / "bench-python.sh",
         )
         self.bench_lock = Path(tmp) / "bench-window.lock"
         self.gpu_lock = Path(tmp) / "metal-gpu.lock"


### PR DESCRIPTION
## Summary

The bench harness entry points `exec`'d whatever `python3` was first on `PATH`. On a
machine where that resolves to the macOS system interpreter (3.9.x), the harness never
starts: `scripts/lib/bench_supervision.py` uses `zip(..., strict=True)` (3.10+) and dies
with a `TypeError` raised from inside `zip()`.

**The direction here is fail-closed, and that is why it never produced a false green.** A
harness that crashes before it measures anything emits no numbers, passes no gate, and
updates no baseline. This is not a correctness incident and no previously reported
measurement is called into question by it. What the crash does is misattribute its own
cause: a `TypeError` from a standard-library call reads as a broken script, so the
actual, one-line-fixable condition (the interpreter does not meet the harness's
requirement) is the one thing the error message does not say.

## The floor is 3.11, not 3.10

The failing call needs 3.10, but the version floor is set at 3.11, because the module
graph this entry point pulls in already requires it: `scripts/perf-bench-gate.py` and
`scripts/lib/machine-state-probe.py` both carry their own explicit 3.11 self-guards
(`from datetime import UTC`). Flooring at 3.10 would satisfy the crashing call site and
still leave the harness unable to complete a run. The constant carries a comment
recording that reasoning so the next reader inherits it rather than re-deriving it.

## Changes

- **Version floor at entry.** `scripts/lib/bench_supervision.py` checks
  `sys.version_info` before any other import, and refuses with a message naming the
  requirement, what was found, and how to obtain a suitable interpreter.
- **Explicit interpreter resolution.** New `scripts/lib/bench-python.sh` searches
  `python3.13`, `python3.12`, `python3.11`, `python3` on `PATH` and verifies each
  candidate's own `sys.version_info` rather than trusting its name, returning the first
  that clears the floor. A binary named `python3.11` that is not 3.11 does not pass.
- **Wired into the entry points whose silent failure is mistaken for a passing gate:**
  `scripts/bench-compare.sh`, `scripts/bench-command.sh`, the shared
  `bench_supervise_entry` / `bench_quiet_checkpoint` in `scripts/lib/bench-supervision.sh`
  (which cascades to `bench-ci.sh`, `bench-gate.sh`, `bench_quality.sh`,
  `bench_decode_slopefit.sh`, and `e2e-parity-local.sh`'s handoff step without editing
  them), and `scripts/bench_wasm_simd.mjs`'s three `python3` spawns.

## Scope boundary, stated rather than implied

`python3` invocations were enumerated across the harness with
`grep -rlE 'python3?\b' scripts Makefile` (47 files). The following are left with a bare
`python3` call, deliberately:

- `scripts/perf-bench-gate.py` and `scripts/lib/machine-state-probe.py` already carry
  their own 3.11 guards, so they refuse clearly on their own.
- `scripts/bench-host-id.py`, `scripts/lib/perf_governor.py` and `scripts/quiet-probe.py`
  do not require 3.11 and run correctly under an older interpreter.
- `e2e-parity-local.sh`'s own final `exec` is out of scope here;
  `scripts/e2e_parity_check.py` does not require 3.11 either.

No threshold, lock, governor, or statistical logic is touched. This changes which
interpreter runs the harness, not what the harness measures or how it judges a result.

## Verification

Both arms executed against real interpreters, not simulated:

- **Too-old arm**: run under `/usr/bin/python3` (3.9.6). Before the change, the harness
  crashed inside `zip()`. After the change, it refuses cleanly with a message naming the
  requirement (3.11) and what was found (3.9.6).
- **Supported arm**: run under a resolved 3.12. The guard passes and execution proceeds
  into the supervision logic proper, where it stops on an unrelated, deliberately
  mismatched lock path (`bench-supervision: lock receipt names /tmp/fake1; expected
  /tmp/lion-bench-window.lock; refusing to measure`). That second refusal is the point of
  the arm: it shows the new check admits a valid interpreter rather than refusing
  everything, since a guard that rejects all inputs also passes the first arm.
- `tests/test_bench_measurement_supervision.py` executed, with fixture file lists updated
  for the new resolver and one regex broadened from the old literal `python3 "..." verify`
  call shape to also accept the resolved-variable form.

## bench-compare disposition

Not required for this change, per the gate's own predicate rather than by assertion:
`.github/workflows/bench-evidence.yml:120` requires a disposition only when a changed
path matches `^crates/(inference|embed|fann)/`. The changed paths here are under
`scripts/` and `tests/` only.

No benchmark was run for this PR and none is claimed. Running one would also have been
the wrong evidence: the change alters which interpreter starts the harness, so a timing
number would measure the machine, not the diff.
