### PR TITLE
fix(bench): scope Criterion output roots per bench target and refuse foreign groups

### DIFF
--- a/scripts/lib/bench-compare-impl.sh
+++ b/scripts/lib/bench-compare-impl.sh
@@ -418,14 +418,66 @@ BENCH_BASELINE_NAME="compare-base"
 # Keep Criterion evidence target-qualified without giving up Cargo's shared
 # compilation target. CRITERION_HOME controls only Criterion's report/baseline
 # tree; Cargo continues to use each worktree's normal target directory.
+#
+# Root paths are keyed by BENCH TARGET, not just by crate: BENCHES_INFERENCE
+# is caller-overridable (BENCHES_EMBED is a fixed "simd" today, keyed the same
+# way for consistency should that change), so two runs that pick different
+# targets must never share a directory — Criterion's own report tree keys by
+# group/function only, and two different bench targets can and do declare
+# same-named or different groups into what would otherwise be one shared
+# directory. A target name reaches the filesystem as a path component here,
+# so it is sanitized first: anything outside [A-Za-z0-9._-] becomes '_', and
+# a name that sanitizes to nothing refuses rather than silently keying every
+# such target into the same empty-string directory.
+sanitize_target_component() {
+  local raw="$1" clean
+  clean="$(printf '%s' "$raw" | tr -c 'A-Za-z0-9._-' '_')"
+  if [ -z "$clean" ]; then
+    echo "bench-compare: bench target name '$raw' sanitizes to an empty path" \
+         "component — refusing." >&2
+    exit 2
+  fi
+  printf '%s' "$clean"
+}
+
 BENCH_CRITERION_ROOT="$REPO/.cache/bench-compare-criterion"
-BASE_INFERENCE_CRITERION_ROOT="$BENCH_CRITERION_ROOT/base/inference/criterion"
-BASE_EMBED_CRITERION_ROOT="$BENCH_CRITERION_ROOT/base/embed/criterion"
-INFERENCE_CRITERION_ROOT="$BENCH_CRITERION_ROOT/head/inference/criterion"
-EMBED_CRITERION_ROOT="$BENCH_CRITERION_ROOT/head/embed/criterion"
-mkdir -p \
-  "$BASE_INFERENCE_CRITERION_ROOT" "$BASE_EMBED_CRITERION_ROOT" \
-  "$INFERENCE_CRITERION_ROOT" "$EMBED_CRITERION_ROOT"
+BENCHES_INFERENCE_KEY="$(sanitize_target_component "$BENCHES_INFERENCE")"
+BENCHES_EMBED_KEY="$(sanitize_target_component "$BENCHES_EMBED")"
+BASE_INFERENCE_CRITERION_ROOT="$BENCH_CRITERION_ROOT/base/inference/$BENCHES_INFERENCE_KEY/criterion"
+BASE_EMBED_CRITERION_ROOT="$BENCH_CRITERION_ROOT/base/embed/$BENCHES_EMBED_KEY/criterion"
+INFERENCE_CRITERION_ROOT="$BENCH_CRITERION_ROOT/head/inference/$BENCHES_INFERENCE_KEY/criterion"
+EMBED_CRITERION_ROOT="$BENCH_CRITERION_ROOT/head/embed/$BENCHES_EMBED_KEY/criterion"
+
+# Each arm's root is wiped immediately before the phase that populates it, not
+# just created if absent: keying stops two DIFFERENT targets from sharing a
+# directory, but says nothing about a group a PRIOR run under the same key
+# left behind (renamed, removed, or from before this fix shipped). An `rm -rf`
+# whose argument came back empty or unmoored is the exact failure this repo's
+# rules exist to prevent, so the path is asserted non-empty and confined under
+# $BENCH_CRITERION_ROOT before anything is removed; both are already
+# guaranteed by sanitize_target_component and the fixed prefix construction
+# above, this is the second, independent check at the point of deletion.
+clear_criterion_root() {
+  local root="$1"
+  if [ -z "$root" ]; then
+    echo "bench-compare: internal error — empty Criterion root path passed to" \
+         "clear_criterion_root; refusing to remove anything." >&2
+    exit 2
+  fi
+  case "$root" in
+    "$BENCH_CRITERION_ROOT"/*) ;;
+    *)
+      echo "bench-compare: internal error — '$root' is not under the expected" \
+           "Criterion cache root '$BENCH_CRITERION_ROOT'; refusing to remove it." >&2
+      exit 2
+      ;;
+  esac
+  rm -rf -- "$root"
+  mkdir -p -- "$root"
+}
+
+clear_criterion_root "$BASE_INFERENCE_CRITERION_ROOT"
+clear_criterion_root "$BASE_EMBED_CRITERION_ROOT"
 if [ "$FAIL_ON_REGRESSION" = "1" ]; then
   python3 "$GATE_SCRIPT" "$BASE_INFERENCE_CRITERION_ROOT" \
     --baseline-name "$BENCH_BASELINE_NAME" --prepare-baseline-copy
@@ -563,6 +615,12 @@ prepare_target_root() {
   fi
 }
 
+# Wiped here, immediately before the head phase populates them (base-arm
+# baseline copy, then head's own run) — same rationale as the base-side clear
+# above, applied to the head-side roots at the point the head phase begins.
+clear_criterion_root "$INFERENCE_CRITERION_ROOT"
+clear_criterion_root "$EMBED_CRITERION_ROOT"
+
 prepare_target_root \
   "lattice-inference:$BENCHES_INFERENCE" \
   "$BASE_INFERENCE_CRITERION_ROOT" "$INFERENCE_CRITERION_ROOT"
@@ -665,12 +723,115 @@ echo "$QUIET_SAMPLES" | sed 's/^/    /'
 echo "  machine state:"
 echo "$MACHINE_STATE_SAMPLES" | sed 's/^/    /'
 
+# --- Reconcile reported groups against the bench target's declared groups ---
+# Path-keying and the clears above stop a stray group from surviving into a
+# target's root by construction. This is the independent check at the point
+# of reporting: it does not trust that construction, it verifies the outcome.
+# Before the gate reads a root, compare the Criterion groups actually present
+# in it (the first path component of every change/estimates.json — exactly
+# what perf-bench-gate.py's find_change_files/parse_bench walk to build the
+# report) against the groups the target's bench SOURCE declares. A group
+# present but undeclared refuses the run rather than being reported: this is
+# the third state the run can end in — not pass, not a confirmed regression,
+# but "the instrument's output does not match its subject."
+#
+# Declared groups are read by grepping the bench source for literal
+# `benchmark_group("...")` arguments — lexical, not semantic. This misses:
+#   - a group name built at runtime (format!, a variable, a match arm)
+#     instead of written as a string literal;
+#   - a benchmark registered directly via `c.bench_function(...)` with no
+#     enclosing group, which gets its own top-level directory named after the
+#     function rather than a declared group name.
+# Neither pattern occurs today in elementwise_cpu_bench.rs, f16_convert_bench
+# .rs, or embed's simd.rs: every group.bench_function/group.bench_with_input
+# call in those three files sits inside a benchmark_group(...) block, and a
+# bare `c.bench_function` (not `group.bench_function`) does not appear in any
+# of them (checked by grep over the three files during this fix). A future
+# bench target using either pattern needs this derivation extended — until
+# then, a group registered that way is invisible to this guard, so it is a
+# lower bound on what gets caught, not a proof that nothing can slip past it.
+bench_source_for_target() {
+  local head_dir="$1" crate_dir="$2" bench_name="$3"
+  local benches_dir candidate base_resolved resolved
+  benches_dir="$head_dir/crates/$crate_dir/benches"
+  candidate="$benches_dir/$bench_name.rs"
+  if [ ! -d "$benches_dir" ] || [ ! -f "$candidate" ]; then
+    echo "bench-compare: expected bench source '$candidate' does not exist —" \
+         "refusing to reconcile without a declared-group source." >&2
+    exit 2
+  fi
+  if ! base_resolved="$(cd "$benches_dir" && pwd -P)"; then
+    echo "bench-compare: cannot resolve '$benches_dir' — refusing." >&2
+    exit 2
+  fi
+  resolved="$base_resolved/$(basename "$candidate")"
+  case "$resolved" in
+    "$base_resolved"/*) ;;
+    *)
+      echo "bench-compare: bench source '$candidate' resolves outside" \
+           "'$base_resolved' — refusing." >&2
+      exit 2
+      ;;
+  esac
+  printf '%s' "$resolved"
+}
+
+declared_groups_from_source() {
+  local bench_source="$1"
+  command grep -oE 'benchmark_group\("[^"]+"\)' "$bench_source" \
+    | command sed -E 's/^benchmark_group\("(.*)"\)$/\1/' \
+    | LC_ALL=C sort -u
+}
+
+reconcile_criterion_groups() {
+  local target="$1" criterion_root="$2" bench_source="$3"
+  local declared actual stray
+
+  declared="$(declared_groups_from_source "$bench_source")"
+  if [ -z "$declared" ]; then
+    echo "bench-compare: $target: found zero declared Criterion groups in" \
+         "$bench_source — refusing. An empty declared set would let every" \
+         "reported group pass unreconciled, which is worse than not" \
+         "reconciling at all." >&2
+    exit 2
+  fi
+
+  if [ ! -d "$criterion_root" ]; then
+    return 0
+  fi
+
+  actual="$(
+    find "$criterion_root" -type f -path '*/change/estimates.json' -print 2>/dev/null \
+      | while IFS= read -r f; do
+          rel="${f#"$criterion_root"/}"
+          printf '%s\n' "${rel%%/*}"
+        done \
+      | LC_ALL=C sort -u
+  )"
+  if [ -z "$actual" ]; then
+    return 0
+  fi
+
+  stray="$(comm -23 <(printf '%s\n' "$actual") <(printf '%s\n' "$declared"))"
+  if [ -n "$stray" ]; then
+    echo "bench-compare: $target: $criterion_root reports group(s) this" \
+         "target does not declare — refusing to certify this report." >&2
+    echo "  undeclared group(s) found:" >&2
+    printf '%s\n' "$stray" | sed 's/^/    - /' >&2
+    echo "  declared groups (from $bench_source):" >&2
+    printf '%s\n' "$declared" | sed 's/^/    - /' >&2
+    exit 2
+  fi
+}
+
 echo ""
 echo "=== Target-qualified gate reports ==="
 GATE_RC=0
 run_target_gate() {
-  local target="$1" criterion_root="$2"
+  local target="$1" criterion_root="$2" bench_source="$3"
   local gate_rc=0 policy_rc=0 policy_invalid=0
+
+  reconcile_criterion_groups "$target" "$criterion_root" "$bench_source"
   local gate_args=(
     --baseline-name compare-base
     --target "$target"
@@ -725,9 +886,11 @@ run_target_gate() {
 }
 
 run_target_gate \
-  "lattice-inference:$BENCHES_INFERENCE" "$INFERENCE_CRITERION_ROOT"
+  "lattice-inference:$BENCHES_INFERENCE" "$INFERENCE_CRITERION_ROOT" \
+  "$(bench_source_for_target "$HEAD_DIR" "inference" "$BENCHES_INFERENCE")"
 run_target_gate \
-  "lattice-embed:$BENCHES_EMBED" "$EMBED_CRITERION_ROOT"
+  "lattice-embed:$BENCHES_EMBED" "$EMBED_CRITERION_ROOT" \
+  "$(bench_source_for_target "$HEAD_DIR" "embed" "$BENCHES_EMBED")"
 
 if [ "$FAIL_ON_REGRESSION" = "1" ] && [ "$GATE_RC" -ne 0 ]; then
   # Exit 1 is a confirmed regression; exit 2 is a broken measurement contract;

--- a/tests/test_bench_compare_measurement.py
+++ b/tests/test_bench_compare_measurement.py
@@ -287,7 +287,24 @@ def _run(
             'name = "criterion"\n'
             'version = "0.5.1"\n'
         )
-        subprocess.run([*GIT, "-C", str(root), "add", "-f", "Cargo.lock"], check=True)
+        # The default bench targets' declared-group derivation reads
+        # crates/<crate>/benches/<target>.rs from the checked-out worktree, so
+        # the fixture needs stub sources declaring the same groups the stub
+        # cargo fixtures above write results for (rms_norm, simd_dot_product).
+        # Every test defaults to BENCHES_INFERENCE=elementwise_cpu_bench and
+        # BENCHES_EMBED=simd (none override them), so one fixed pair covers
+        # the whole file.
+        inference_benches = root / "crates" / "inference" / "benches"
+        inference_benches.mkdir(parents=True)
+        (inference_benches / "elementwise_cpu_bench.rs").write_text(
+            'let mut group = c.benchmark_group("rms_norm");\n'
+        )
+        embed_benches = root / "crates" / "embed" / "benches"
+        embed_benches.mkdir(parents=True)
+        (embed_benches / "simd.rs").write_text(
+            'let mut group = c.benchmark_group("simd_dot_product");\n'
+        )
+        subprocess.run([*GIT, "-C", str(root), "add", "-f", "Cargo.lock", "crates"], check=True)
         for i in range(2):
             (root / f"f{i}.txt").write_text(str(i))
             subprocess.run([*GIT, "-C", str(root), "add", "-A"], check=True)
@@ -609,9 +626,13 @@ class BenchCompareMeasurementGuard(unittest.TestCase):
         enforcing run exits 0 instead of 2.
         """
         def seed_stale_change(root):
+            # Path is target-keyed (lattice#bench-criterion-root-per-target):
+            # BENCHES_INFERENCE defaults to elementwise_cpu_bench, so that is
+            # the segment between the crate and "criterion" here.
             bench = (
                 root / ".cache" / "bench-compare-criterion" / "head" /
-                "inference" / "criterion" / "rms_norm" / "4096"
+                "inference" / "elementwise_cpu_bench" / "criterion" /
+                "rms_norm" / "4096"
             )
             (bench / "new").mkdir(parents=True)
             (bench / "change").mkdir()
@@ -639,34 +660,47 @@ class BenchCompareMeasurementGuard(unittest.TestCase):
             "  - lattice-inference:elementwise_cpu_bench: rms_norm/4096",
             result.stdout,
         )
-        self.assertIn("removed 2 stale head artifact directories", result.stdout)
+        # The per-target root is now wiped wholesale before the head phase
+        # (lattice#bench-criterion-root-per-target), so the selective
+        # clear_selected_head_artifacts prune this message reports on always
+        # finds the root already empty here — the seeded stale artifact
+        # never survives to be found. The invariant this test guards (a stale
+        # same-path comparison cannot satisfy head completeness) is proven by
+        # the exit-2 assertion above, which fires because the real head stub
+        # genuinely never measured rms_norm/4096 in this run, independent of
+        # whichever mechanism cleared any prior data.
+        self.assertIn("removed 0 stale head artifact directories", result.stdout)
 
     def test_stale_unrelated_selected_baseline_is_pruned_before_copy(self):
         """A prior alternate-target baseline must not join today's base set.
 
-        Mutation-sensitive: remove the --prepare-baseline-copy call and the
-        stale compare-base artifact remains selected. The later head cleanup
-        removes its old comparison, so completeness false-fails old_group/42
-        even though every benchmark in today's fresh base set ran on HEAD.
-
-        The pruned baseline dir's `new/`/`change/` siblings must go with it
-        (mutation-sensitive on their own: leaving them behind resurrects
-        old_group/42 as a phantom unbaselined head measurement via the
-        root-wide new/estimates.json inventory — see
-        ClearSelectedBaselineArtifactsSiblingPrune for the isolated repro).
-        A second, differently-named baseline snapshot sharing the same
-        Criterion root must survive untouched, proving the prune did not
-        widen past the exact selected baseline.
+        Pre-lattice#bench-criterion-root-per-target, this asserted that
+        clear_selected_baseline_artifacts selectively pruned only the exact
+        selected-baseline dir, leaving an unrelated differently-named
+        baseline snapshot in the same root untouched. That fix now wipes the
+        whole arm-and-target root before either phase writes into it
+        (bench-compare-impl.sh's clear_criterion_root), which is a stronger
+        guarantee: a bench-compare-owned per-target root holds nothing but
+        this run's own artifacts, so nothing sharing that root — selected
+        baseline or not — should outlive one invocation. Both stale seeds
+        below (old_group/42 and the differently-named manual-snapshot) are
+        gone by construction; this test now asserts that directly rather than
+        asserting the old selective-prune's "removed N" message, which always
+        reads 0 now that the wipe runs first.
         """
         old_group_dir = None
         unrelated_dir = None
 
         def seed_unrelated_run(root):
             nonlocal old_group_dir, unrelated_dir
-            bench = (
+            # Path is target-keyed: BENCHES_INFERENCE defaults to
+            # elementwise_cpu_bench, the segment between crate and
+            # "criterion".
+            target_root = (
                 root / ".cache" / "bench-compare-criterion" / "head" /
-                "inference" / "criterion" / "old_group" / "42"
+                "inference" / "elementwise_cpu_bench" / "criterion"
             )
+            bench = target_root / "old_group" / "42"
             old_group_dir = bench
             (bench / "compare-base").mkdir(parents=True)
             (bench / "new").mkdir()
@@ -683,14 +717,11 @@ class BenchCompareMeasurementGuard(unittest.TestCase):
             )
 
             # A different target's persistent, differently-named baseline
-            # snapshot in the same criterion root. It has no new/change, so
-            # it cannot trip the head-ids coverage check either way; it is
-            # here purely to prove clear_selected_baseline_artifacts does not
-            # widen its deletion past the exact selected baseline name.
-            other = (
-                root / ".cache" / "bench-compare-criterion" / "head" /
-                "inference" / "criterion" / "other_group" / "7"
-            )
+            # snapshot sharing the same criterion root before this run wipes
+            # it. It has no new/change, so it cannot trip the head-ids
+            # coverage check either way; it is here to prove the wipe is
+            # total rather than scoped to the selected baseline name.
+            other = target_root / "other_group" / "7"
             unrelated_dir = other / "manual-snapshot"
             unrelated_dir.mkdir(parents=True)
             (unrelated_dir / "estimates.json").write_text(
@@ -718,21 +749,22 @@ class BenchCompareMeasurementGuard(unittest.TestCase):
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
         )
         self.assertIn(
-            "removed 1 stale selected-baseline artifact directory before fresh base copy",
+            "removed 0 stale selected-baseline artifact directories before fresh base copy",
             result.stdout,
         )
         self.assertNotIn("old_group/42", result.stdout)
         self.assertFalse(
             snapshot["old_group_new_exists"],
-            "stale old_group/42/new must be pruned along with its baseline dir",
+            "stale old_group/42/new must not survive the arm-and-target root wipe",
         )
         self.assertFalse(
             snapshot["old_group_change_exists"],
-            "stale old_group/42/change must be pruned along with its baseline dir",
+            "stale old_group/42/change must not survive the arm-and-target root wipe",
         )
-        self.assertTrue(
+        self.assertFalse(
             snapshot["unrelated_exists"],
-            "an unrelated target's differently-named baseline snapshot must survive the prune",
+            "a differently-named baseline snapshot must not survive the arm-and-target "
+            "root wipe either — the wipe is total, not scoped to the selected baseline",
         )
 
     def test_enforcing_mode_refuses_a_partial_baseline_copy(self):
@@ -768,6 +800,11 @@ class BenchCompareMeasurementGuard(unittest.TestCase):
         member or includes `<unset>`, reproducing the shared namespace behind
         #1090. The stub emits only its inherited CRITERION_HOME; no benchmark
         implementation is duplicated here.
+
+        Roots are keyed by bench TARGET as well as by crate (lattice#bench-
+        criterion-root-per-target): every root's path includes the exact
+        target name as its own path component, not just the crate name, so
+        two different targets under the same crate can never collide.
         """
         result = _run(
             [], stub_cargo=STALE_CHANGE_CARGO, emit_criterion_home=True
@@ -782,8 +819,67 @@ class BenchCompareMeasurementGuard(unittest.TestCase):
             f"expected isolated base/head roots per target, saw {roots}\n"
             f"stdout:\n{result.stdout}")
         self.assertNotIn("<unset>", roots)
-        self.assertTrue(any("/inference/criterion" in path for path in roots), roots)
-        self.assertTrue(any("/embed/criterion" in path for path in roots), roots)
+        self.assertTrue(
+            any("/inference/elementwise_cpu_bench/criterion" in path for path in roots),
+            roots,
+        )
+        self.assertTrue(
+            any("/embed/simd/criterion" in path for path in roots), roots
+        )
+
+    def test_different_bench_targets_get_different_criterion_roots(self):
+        """The actual defect: two runs choosing different BENCHES_INFERENCE
+        values must never write into the same Criterion root.
+
+        Mutation-sensitive: drop the target-name path segment (key the root by
+        crate alone, as the pre-fix script did) and both invocations report
+        the same criterion-home path.
+        """
+        def add_f16_convert_bench_source(root):
+            # STALE_CHANGE_CARGO picks its fabricated group name (rms_norm)
+            # from the CRATE in argv, not the --bench target, so the fixture
+            # source declares the same group name regardless of target — this
+            # test asserts path distinctness, not group-content reconciliation
+            # (that is covered separately by the reconciliation tests below).
+            # The file must be committed, not just written: bench-compare
+            # reads it from a `git worktree add --detach` checkout of HEAD,
+            # which only contains tracked, committed content.
+            path = root / "crates" / "inference" / "benches" / "f16_convert_bench.rs"
+            path.write_text('let mut group = c.benchmark_group("rms_norm");\n')
+            subprocess.run([*GIT, "-C", str(root), "add", "-f", str(path)], check=True)
+            subprocess.run(
+                [*GIT, "-C", str(root), "commit", "-qm", "add f16_convert_bench fixture"],
+                check=True,
+                env={
+                    **os.environ,
+                    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+                    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+                },
+            )
+
+        first = _run(
+            [], stub_cargo=STALE_CHANGE_CARGO, emit_criterion_home=True
+        )
+        self.assertEqual(first.returncode, 0, first.stderr)
+        second = _run(
+            [],
+            stub_cargo=STALE_CHANGE_CARGO,
+            emit_criterion_home=True,
+            extra_env={"BENCHES_INFERENCE": "f16_convert_bench"},
+            setup=add_f16_convert_bench_source,
+        )
+        self.assertEqual(second.returncode, 0, second.stderr)
+        first_roots = set(re.findall(r"criterion-home=(\S+)", first.stdout))
+        second_roots = set(re.findall(r"criterion-home=(\S+)", second.stdout))
+        inference_first = {p for p in first_roots if "/inference/" in p}
+        inference_second = {p for p in second_roots if "/inference/" in p}
+        self.assertTrue(inference_first, first.stdout)
+        self.assertTrue(inference_second, second.stdout)
+        self.assertFalse(
+            inference_first & inference_second,
+            f"different BENCHES_INFERENCE values shared a root: "
+            f"{inference_first} vs {inference_second}",
+        )
 
 
 class _FailOnEmptyTestProgram(unittest.TestProgram):

--- a/tests/test_bench_locks.py
+++ b/tests/test_bench_locks.py
@@ -157,8 +157,21 @@ class _Sandbox:
             'name = "criterion"\n'
             'version = "0.5.1"\n'
         )
+        # Declared-group reconciliation reads crates/<crate>/benches/<target>.rs
+        # from the checked-out worktree; the default targets need a stub here
+        # or bench-compare-impl.sh refuses with no declared-group source.
+        inference_benches = self.root / "crates" / "inference" / "benches"
+        inference_benches.mkdir(parents=True)
+        (inference_benches / "elementwise_cpu_bench.rs").write_text(
+            'let mut group = c.benchmark_group("rms_norm");\n'
+        )
+        embed_benches = self.root / "crates" / "embed" / "benches"
+        embed_benches.mkdir(parents=True)
+        (embed_benches / "simd.rs").write_text(
+            'let mut group = c.benchmark_group("simd_dot_product");\n'
+        )
         subprocess.run(
-            [*GIT, "-C", str(self.root), "add", "-f", "Cargo.lock"],
+            [*GIT, "-C", str(self.root), "add", "-f", "Cargo.lock", "crates"],
             check=True,
         )
         for i in range(2):


### PR DESCRIPTION
## Summary

`bench-compare` built its Criterion output roots keyed by CRATE, not by bench target:

```
BASE_INFERENCE_CRITERION_ROOT="$BENCH_CRITERION_ROOT/base/inference/criterion"
INFERENCE_CRITERION_ROOT="$BENCH_CRITERION_ROOT/head/inference/criterion"
```

`BENCHES_INFERENCE` selects which target runs and is overridable, so two runs of
different targets wrote into the same directory, and nothing cleared it between runs.
`perf-bench-gate.py` then read the whole directory and attributed everything in it to
the target named for that run.

The effect is a report that carries another target's measurements under its own label.
Observed on a machine that ran `elementwise_cpu_bench` and then `f16_convert_bench`: the
report attributed to `f16_convert_bench` carried 18 measurements, 17 of which are
`elementwise_cpu_bench`'s groups, and three verdict rows were byte-identical to the
previous run's — same delta, same CI bounds, same nanoseconds, across a different head
and a different target. `perf-bench-gate.py:47` already states the invariant the code did
not implement: each bench target in its own Criterion output root.

## Changes

1. **Roots are keyed by target.** The bench target name is part of the path, sanitized
   before interpolation since it becomes a filesystem component.
2. **Each arm's root is cleared before that arm writes.** Keying fixes today's instance;
   clearing is what stops a renamed or removed group from lingering. The removal asserts
   its argument is non-empty and lies under the expected base directory first.
3. **Reconciliation, which is the part that closes the class.** After a run, the groups
   about to be reported are checked against the groups the named target actually declares.
   A group present in the root that the target does not declare produces a refusal, not a
   row. The derivation is lexical (it reads `benchmark_group("...")` out of the bench
   source), so it fails closed when it finds no declared groups at all rather than passing
   everything.

Path-keying fixes the instance. Reconciliation catches the class, and gives the third
state this needs: not pass, not fail, but "the output does not match its subject, so no
verdict is available."

## Verification

Nine checks, all executed:

- **Defect reproduced** structurally against a fabricated Criterion tree: 10 groups
  visible under one shared root after simulating two different targets.
- **Fix closes it**: driving the real `sanitize_target_component` / `clear_criterion_root`
  (extracted from the fixed script by line number, not reimplemented), the two roots are
  distinct and each reports exactly its own groups after both runs.
- **Reconciliation refuses** (must-fail arm): an undeclared group planted beside a
  declared one against the real `elementwise_cpu_bench.rs` exits 2 and names the offender.
- **It does not over-refuse**: a root holding 2 of 8 declared groups, simulating a
  `BENCH_GROUPS_INFERENCE` filter, exits 0. Without this arm, "refuse everything" would
  also satisfy the arm above.
- Reconciliation fails closed when its own declared-group derivation finds nothing;
  `clear_criterion_root` refuses an empty argument and any path outside the base.

Existing suites executed: `test_bench_locks.py` 35 tests OK, `test_bench_compare_measurement.py`
16 tests OK, plus `test_bench_disposition.py` (39), `test_bench_measurement_supervision.py`
(62), `test_perf_bench_gate_status.py` (9), `test_perf_postmerge_workflow.py` (5),
`test_bench_gate_math.py` (82), `test_bench_run_record.py` (87), all OK.
`cargo fmt --check` and `cargo clippy --workspace -- -D warnings` (the invocation in
`scripts/ci.sh:11`) clean.

**One behaviour change worth stating rather than leaving in a diff.**
`test_stale_unrelated_selected_baseline_is_pruned_before_copy` previously proved that a
differently-named baseline snapshot sharing the root survived the selective prune. Under
the full per-target wipe it no longer does, and that assertion is inverted accordingly.
This is a real narrowing of what the harness tolerates, not a message-string update:
bench-compare-owned per-target roots are now wiped in full on every run, so nothing
sharing such a root outlives one invocation.

A new test drives the real script twice with different `BENCHES_INFERENCE` values and
asserts the reported `criterion-home=` paths never intersect. That is the regression test
for the actual defect.

## bench-compare disposition

Not required: `.github/workflows/bench-evidence.yml:120` requires one only when a changed
path matches `^crates/(inference|embed|fann)/`. The changed paths are under `scripts/` and
`tests/`.

No benchmark numbers are quoted here, deliberately. Numbers produced by the harness before
this change cannot be attributed to their stated target.
