### PR TITLE
chore(release): prepare v0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lattice-embed"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "blake3",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "lattice-fann"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "approx",
  "bytemuck",
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "lattice-inference"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "approx",
  "axum",
@@ -1670,7 +1670,7 @@ dependencies = [
 
 [[package]]
 name = "lattice-transport"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "criterion",
  "proptest",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "lattice-tune"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arc-swap",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 # MSRV, verified end-to-end (workspace + deps) on 1.93.1 and guarded by the msrv CI
 # job (aarch64 macOS, f16,metal-gpu, --all-targets) so a newer-toolchain-only API

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -53,7 +53,7 @@ tracing = "0.1"
 # its own ureq/download stack to non-wasm targets, so a plain `--features wasm`
 # build stays download-free; edge/cross builds drop it with
 # `--no-default-features --features native`. See issue #1095.
-lattice-inference = { version = "0.7.1", path = "../inference", optional = true, default-features = false, features = [
+lattice-inference = { version = "0.7.2", path = "../inference", optional = true, default-features = false, features = [
     "std",
     "f16",
 ] }

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -95,7 +95,7 @@ bytemuck = { version = "1", features = ["derive"], optional = true }
 ort = { version = "2.0.0-rc.12", optional = true }
 tokenizers = { version = "0.22", optional = true, default-features = false, features = ["progressbar", "onig"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-lattice-fann = { version = "0.7.1", path = "../fann", optional = true }
+lattice-fann = { version = "0.7.2", path = "../fann", optional = true }
 
 # `fcntl(F_GETPATH)` for `weights/f32_weights.rs`'s `real_path_of_open_file`, which reports the
 # real path of an already-open shard descriptor for diagnostics and error text. Containment is

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -32,7 +32,7 @@ mixture = ["lattice-fann/online-router"]
 simulated-teacher = []
 
 [dependencies]
-lattice-fann = { version = "0.7.1", path = "../fann" }
+lattice-fann = { version = "0.7.2", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -53,7 +53,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook and training backward pass (optional — for LoRA adapter injection and gradients)
-lattice-inference = { version = "0.7.1", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.7.2", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -128,7 +128,10 @@ unchanged.
 lattice-inference = "0.7.2"
 ```
 
-No source changes are required, and no public API changed.
+No source changes are required. This release adds new public API, the pooled
+hidden-state embedding methods described above, and nothing that existed in 0.7.1
+was changed or removed. Existing code continues to compile against 0.7.2 without
+modification.
 
 Two behavioral notes, both cases where a load that succeeded on `0.7.1` can now return
 an error.

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -1,0 +1,48 @@
+# lattice v0.7.2
+
+Patch release. One change, in `lattice-inference`: two explicit input bounds on
+SafeTensors checkpoint header parsing.
+
+This is the first release in the `0.7` line that can refuse a checkpoint that an
+earlier version would have loaded. See Upgrading below for who is affected.
+
+## Changed: explicit bounds on checkpoint header parsing
+
+Loading a SafeTensors checkpoint begins by parsing a JSON header that describes the
+tensors in the file. Two properties of that parse were previously unbounded, and both
+are now bounded explicitly.
+
+**Header size.**
+As of this release, safetensors headers larger than 4 MiB are now rejected at load (previously unbounded).
+The cap is sized against what the parser retains while
+building its tensor table rather than against the header's own length, because the
+retained shape data is several times the size of the header text that produces it.
+Checkpoints produced by the common conversion tools carry headers in the range of a
+few hundred KiB to low single-digit MiB, so the cap sits well above normal files.
+
+**Nesting depth.**
+In this release, a missing recursion bound was added to the header parser.
+The routine that skips over JSON values recursed on every `{` and `[` it encountered
+without tracking how deep it had gone. It now carries an explicit depth counter,
+checked when entering each container and decremented on every exit path, with a limit
+of 32 levels. Real headers are two to three levels deep.
+
+Both limits are compile-time constants in `lattice-inference`, and both produce a
+descriptive load error naming the limit that was exceeded rather than failing later
+in the load.
+
+## Upgrading
+
+```toml
+lattice-inference = "0.7.2"
+```
+
+No source changes are required, and no public API changed.
+
+One behavioral note. If you load a checkpoint whose header exceeds either limit, the
+load now returns an error where `0.7.1` would have proceeded. A model with more
+tensors than usual, or one produced by a tool that writes unusually verbose metadata,
+is the case to check. The error names the limit and the observed value, so a file that
+trips it is easy to identify. If you have a legitimate checkpoint that exceeds 4 MiB
+of header, please open an issue with the header size, since that would tell us the cap
+is mis-sized for a real workload.

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -1,11 +1,16 @@
 # lattice v0.7.2
 
 Patch release, in `lattice-inference`. Two explicit input bounds on SafeTensors
-checkpoint header parsing, and a trust boundary on the no-copy mmap load path.
+checkpoint header parsing, a trust boundary on the no-copy mmap load path, a stable
+pooled hidden-state embedding API on the CPU and Metal forward paths, a bounded
+shutdown path for the Metal serve worker, a preflight budget check on the streaming
+generation path, and a faster token recheck path in grammar-constrained decoding.
 
 This is the first release in the `0.7` line that can refuse a checkpoint that an
-earlier version would have loaded, and it does so for two independent reasons. See
-Upgrading below for who is affected by each.
+earlier version would have loaded, and it does so for two independent reasons: an
+oversized or too deeply nested header, and a checkpoint or checkpoint directory
+outside the supported ownership boundary. See Upgrading below for who is affected by
+each.
 
 ## Changed: explicit bounds on checkpoint header parsing
 
@@ -44,9 +49,17 @@ mapping to catch a truncate-or-replace race.
 
 **Supported checkpoint ownership.** The gate accepts a checkpoint file, and every
 directory above it, only when it is owned by the uid running the process or by root,
-and is not group- or other-writable. On macOS it additionally rejects a file carrying
-an extended ACL that grants write access, directly or transitively, since an ACL can
-grant that invisibly to a file whose mode reads `0600`.
+and is not group- or other-writable, with one deliberate exception: a directory that
+is world-writable but also carries the sticky bit, the `/tmp` pattern, is accepted.
+The sticky bit restricts renaming or deleting an entry in that directory to the
+entry's own owner, the directory's owner, or root, which is exactly the
+rename-and-replace this check exists to prevent, so a foreign, unprivileged
+principal with write access to a sticky world-writable directory still cannot swap
+out a checkpoint file the file-level check has already confirmed is owned by the
+process uid or root. On macOS the gate additionally rejects a file, or a directory in
+its ancestor chain, that carries an extended ACL granting write access directly or
+transitively, since an ACL can grant that invisibly to a file or directory whose mode
+bits read locked down.
 
 Ownership is the boundary rather than the mode bits because an owner keeps control of
 a file regardless of its current permissions: a third-uid owner of a read-only file can
@@ -68,8 +81,46 @@ configuration switch.
 A refusal names the file's owner uid, the accepted uids, and the `chmod` and `chown`
 commands that make the file loadable.
 
-This gate is compiled only into macOS builds with the `metal-gpu` feature. Other
-builds do not include this path and are unaffected.
+This gate's own code compiles into every Unix build. The mmap load path that calls
+it is gated behind the `metal-gpu` feature, and that feature requires macOS to build,
+so a published build without `metal-gpu` never reaches this gate and is unaffected by
+it.
+
+## New: stable pooled hidden-state embedding API
+
+Adds `Qwen35Model::embed_tokens(tokens, pooling)` and `hidden_size()` on the CPU
+forward path, and matching `embed_tokens`/`hidden_size()` methods on the Metal
+forward path when built with the `metal-gpu` feature on macOS. Both return the
+pooled hidden state from the model's own weights, the last position's hidden state
+after the final RMSNorm and before the language-model head by default, so an
+application that already loads a model for generation does not need a separate
+embedding model to get a vector for the same text. `HiddenPooling::Mean` is also
+available on the CPU path. Mean pooling is not available on the Metal path and
+returns an error there instead of a wrong answer, because that path only normalizes
+the rows it is about to project to logits, and earlier chunks of a long prompt never
+reach that normalization. This is not a substitute for a purpose-trained embedding
+model such as `lattice-embed`, which will normally score better on retrieval tasks.
+
+## Changed: bounded shutdown for the Metal serve worker
+
+`lattice serve`'s Metal worker now drains its queue under a deadline on shutdown.
+Previously nothing bounded how long an in-flight GPU batch could keep the worker
+running past the point the server was asked to stop.
+
+## Changed: streaming generation now preflights request budget
+
+The streaming decode path now runs the same request-budget preflight the
+non-streaming path already ran, ahead of dispatch. Previously a streaming request
+could reach tensor materialization before its budget was checked; it is now rejected
+up front, the same way an over-budget non-streaming request already was.
+
+## Changed: faster token rechecks in grammar-constrained decoding
+
+Grammar-constrained decoding now rechecks a mask against each grammar state's own
+candidate token ids instead of scanning the full global union of grammar tokens on
+every call. A state whose local candidate list would exceed a fixed size budget
+still falls back to the previous global-union scan, so behavior and mask output are
+unchanged.
 
 ## Upgrading
 

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -1,10 +1,11 @@
 # lattice v0.7.2
 
-Patch release. One change, in `lattice-inference`: two explicit input bounds on
-SafeTensors checkpoint header parsing.
+Patch release, in `lattice-inference`. Two explicit input bounds on SafeTensors
+checkpoint header parsing, and a trust boundary on the no-copy mmap load path.
 
 This is the first release in the `0.7` line that can refuse a checkpoint that an
-earlier version would have loaded. See Upgrading below for who is affected.
+earlier version would have loaded, and it does so for two independent reasons. See
+Upgrading below for who is affected by each.
 
 ## Changed: explicit bounds on checkpoint header parsing
 
@@ -31,6 +32,45 @@ Both limits are compile-time constants in `lattice-inference`, and both produce 
 descriptive load error naming the limit that was exceeded rather than failing later
 in the load.
 
+## New: trust boundary on no-copy checkpoint mmap loads
+
+Q4 checkpoint tensors are mapped read-only and handed to the GPU without a copy. That
+means the file must not be writable by another principal for as long as the mapping is
+alive: a write landing after validation but before the GPU reads the mapped pages would
+bypass the shape and bounds checks entirely. Every Q4 mmap load now passes through a
+single gate that opens the file with `O_NONBLOCK|O_NOFOLLOW`, rejects a planted FIFO,
+device, directory, or symlinked final component, and re-stats the file descriptor after
+mapping to catch a truncate-or-replace race.
+
+**Supported checkpoint ownership.** The gate accepts a checkpoint file, and every
+directory above it, only when it is owned by the uid running the process or by root,
+and is not group- or other-writable. On macOS it additionally rejects a file carrying
+an extended ACL that grants write access, directly or transitively, since an ACL can
+grant that invisibly to a file whose mode reads `0600`.
+
+Ownership is the boundary rather than the mode bits because an owner keeps control of
+a file regardless of its current permissions: a third-uid owner of a read-only file can
+change the mode and rewrite it after the check has passed. Accepting read-only
+third-uid files would reduce the boundary to a point-in-time mode check, which is a
+race by construction.
+
+So one shared-deployment shape is supported and one is not:
+
+- **Supported**: a root-owned model directory read by a non-root service account.
+- **Not supported**: a dedicated non-root account owning the checkpoints while
+  inference runs as a different non-root user.
+
+The second is a reasonable operations pattern and is simply outside what this path
+supports today. If you need it, please open an issue describing the deployment; the
+refusal is deliberate and loosening it is a design decision rather than a
+configuration switch.
+
+A refusal names the file's owner uid, the accepted uids, and the `chmod` and `chown`
+commands that make the file loadable.
+
+This gate is compiled only into macOS builds with the `metal-gpu` feature. Other
+builds do not include this path and are unaffected.
+
 ## Upgrading
 
 ```toml
@@ -39,10 +79,18 @@ lattice-inference = "0.7.2"
 
 No source changes are required, and no public API changed.
 
-One behavioral note. If you load a checkpoint whose header exceeds either limit, the
-load now returns an error where `0.7.1` would have proceeded. A model with more
-tensors than usual, or one produced by a tool that writes unusually verbose metadata,
-is the case to check. The error names the limit and the observed value, so a file that
-trips it is easy to identify. If you have a legitimate checkpoint that exceeds 4 MiB
-of header, please open an issue with the header size, since that would tell us the cap
-is mis-sized for a real workload.
+Two behavioral notes, both cases where a load that succeeded on `0.7.1` can now return
+an error.
+
+**Header bounds.** If a checkpoint's header exceeds either limit, the load fails. A
+model with more tensors than usual, or one produced by a tool that writes unusually
+verbose metadata, is the case to check. The error names the limit and the observed
+value, so a file that trips it is easy to identify. If you have a legitimate checkpoint
+that exceeds 4 MiB of header, please open an issue with the header size, since that
+would tell us the cap is mis-sized for a real workload.
+
+**Checkpoint ownership**, on macOS `metal-gpu` builds only. If your checkpoints are
+owned by a uid that is neither root nor the user running inference, or sit under a
+group- or other-writable directory, Q4 loads now fail. The refusal names the offending
+owner and the commands to fix it. The supported and unsupported ownership shapes are
+listed in the section above.

--- a/docs/releases/v0.7.2.md
+++ b/docs/releases/v0.7.2.md
@@ -49,17 +49,17 @@ mapping to catch a truncate-or-replace race.
 
 **Supported checkpoint ownership.** The gate accepts a checkpoint file, and every
 directory above it, only when it is owned by the uid running the process or by root,
-and is not group- or other-writable, with one deliberate exception: a directory that
-is world-writable but also carries the sticky bit, the `/tmp` pattern, is accepted.
-The sticky bit restricts renaming or deleting an entry in that directory to the
-entry's own owner, the directory's owner, or root, which is exactly the
+and is not group- or other-writable, with one deliberate exception: a group- or
+other-writable directory that also carries the sticky bit, the `/tmp` pattern, is
+accepted. The sticky bit restricts renaming or deleting an entry in that directory
+to the entry's own owner, the directory's owner, or root, which is exactly the
 rename-and-replace this check exists to prevent, so a foreign, unprivileged
-principal with write access to a sticky world-writable directory still cannot swap
-out a checkpoint file the file-level check has already confirmed is owned by the
-process uid or root. On macOS the gate additionally rejects a file, or a directory in
-its ancestor chain, that carries an extended ACL granting write access directly or
-transitively, since an ACL can grant that invisibly to a file or directory whose mode
-bits read locked down.
+principal with write access to a sticky group- or other-writable directory still
+cannot swap out a checkpoint file the file-level check has already confirmed is
+owned by the process uid or root. On macOS the gate additionally rejects a file, or
+a directory in its ancestor chain, that carries an extended ACL granting write
+access directly or transitively, since an ACL can grant that invisibly to a file or
+directory whose mode bits read locked down.
 
 Ownership is the boundary rather than the mode bits because an owner keeps control of
 a file regardless of its current permissions: a third-uid owner of a read-only file can
@@ -145,6 +145,6 @@ would tell us the cap is mis-sized for a real workload.
 
 **Checkpoint ownership**, on macOS `metal-gpu` builds only. If your checkpoints are
 owned by a uid that is neither root nor the user running inference, or sit under a
-group- or other-writable directory, Q4 loads now fail. The refusal names the offending
-owner and the commands to fix it. The supported and unsupported ownership shapes are
-listed in the section above.
+writable directory that does not qualify for the sticky-bit exception described above,
+Q4 loads now fail. The refusal names the offending owner and the commands to fix it.
+The supported and unsupported ownership shapes are listed in the section above.


### PR DESCRIPTION
Release preparation for v0.7.2. Version bump plus release notes; no code changes.

Every change described in the notes is on `main`, so the notes describe the release as it will
actually ship.

## What is in the release

**Header bounds**, in `lattice-inference`: two explicit input bounds on SafeTensors checkpoint
header parsing.

- **Header size**, capped at 4 MiB. Sized against what the parser retains while building its
  tensor table rather than against the header's own length, since the retained shape data is
  several times the size of the header text producing it.
- **JSON container nesting depth**, capped at 32 levels. The value-skipping routine recursed on
  every `{` and `[` with no depth tracking.

Both were previously unbounded.

**Trust boundary on no-copy mmap loads.** Q4 checkpoint loads now pass through a single gate that
rejects a file or ancestor directory writable by another principal, rejects a planted FIFO,
device, directory, or symlinked final component, and re-stats the descriptor after mapping to
catch a truncate-or-replace race. A world-writable ancestor directory carrying the sticky bit is
accepted, and the notes explain why that is not a hole.

**Stable pooled hidden-state embedding API.** `Qwen35Model::embed_tokens(tokens, pooling)` and
`hidden_size()` on the CPU forward path, with matching methods on the Metal forward path under
the `metal-gpu` feature on macOS. This is additive public API. Nothing that existed in 0.7.1 was
changed or removed.

**Bounded shutdown for the Metal serve worker.** The worker now drains its queue under a deadline
on shutdown, where previously nothing bounded how long an in-flight batch could keep it running
past the stop request.

**Streaming generation preflights request budget.** The streaming decode path now runs the same
request-budget preflight the non-streaming path already ran, ahead of dispatch.

**Faster token rechecks in grammar-constrained decoding.** Mask rechecks scan each grammar state's
own candidate token ids instead of the full global union, with a size-budgeted fallback to the
previous global scan, so behaviour and mask output are unchanged.

## Contents of this PR

- Workspace version and the four internal path-dependency version fields, 0.7.1 to 0.7.2.
- `Cargo.lock`, updated with `cargo update --workspace` so only the five workspace members move.
  The diff is 5 lines; the 26 external dependencies are unchanged.
- `docs/releases/v0.7.2.md`.

## Bench-compare disposition: structural waiver, no A/B run

This PR touches `crates/inference/` and `crates/embed/`, so it owes a bench-compare table or a
stated waiver. The waiver applies here, and the argument does not depend on which bench targets
are reachable.

The complete set of changes under those two crates is:

```
crates/embed/Cargo.toml
crates/inference/Cargo.toml
```

and the entire diff of both files is two `version =` fields on path dependencies (`0.7.1` to
`0.7.2`). Across the whole PR, the number of changed `.rs` files is **0**, against a control of 6
changed files total, so the count is a real zero rather than a broken query. Local builds resolve
these dependencies through their `path` keys, so the `version` field does not even select
different code.

No Rust source changed, therefore every declared bench target compiles identical code at base and
at head. The usual reachability question does not arise, because the changed set contains no
compilable source for any target to reach.

**Residual risk, stated rather than implied.** The one path by which a version bump can reach
generated code is `CARGO_PKG_VERSION`, which would embed a different string constant anywhere that
macro is used. That is a string literal and cannot move a timing measurement. It is named here
because "identical effective source" would otherwise be an overstatement.

## Note for reviewers

Two of the changes in this release can refuse a checkpoint that `0.7.1` would have loaded, for
independent reasons, so the upgrading section covers each separately and the notes publish which
checkpoint-ownership shapes the mmap path supports rather than leaving them to be discovered on a
failed load.

Every claim in the notes was checked against `main` rather than against this branch, since a
branch cannot falsify a claim about what ships.

Publishing to crates.io is a separate step and is not part of this PR.
