### PR TITLE
docs: correct the crates.io publish-verification recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,26 @@ Publish order follows the internal dependency DAG (deps before dependents): fann
 2. Update release notes file (rename if needed); add a "Note on v<broken>" section explaining the yank
 3. Tag + GH release + `make publish`
 4. `for c in lattice-inference lattice-fann lattice-transport lattice-embed lattice-tune; do cargo yank --version <broken> "$c"; done`
-5. Verify: `curl -s https://crates.io/api/v1/crates/<crate>` should show `latest_unyanked=<new>`, `yanked=[<broken>]`
+5. Verify against the registry. crates.io rejects API requests that do not identify the caller, returning HTTP 403 with a JSON error object rather than crate data, so the request needs a `User-Agent` and the check needs to distinguish an error object from an absent version — a bare `curl` fails in a way that reads like "this version was never published".
+
+   ```bash
+   UA="lattice-release-check (you@example.com)"   # any identifying string with contact info
+   for c in lattice-inference lattice-fann lattice-transport lattice-embed lattice-tune; do
+     curl -s -H "User-Agent: $UA" "https://crates.io/api/v1/crates/$c" | python3 -c "
+   import sys, json
+   d = json.load(sys.stdin)
+   if 'errors' in d:                      # 403 or other API refusal — NOT an answer
+       raise SystemExit('FAILED READ: ' + d['errors'][0].get('detail', ''))
+   yanked = [v['num'] for v in d['versions'] if v['yanked']]
+   print(d['crate']['name'], 'max_stable=' + d['crate']['max_stable_version'], 'yanked=' + str(yanked))
+   "
+   done
+   ```
+
+   Expect `max_stable=<new>` on every crate and `<broken>` present in `yanked`. The fields are
+   `max_stable_version` / `max_version` / `newest_version` on the crate object and a per-version
+   `yanked` boolean in the `versions` array; the crate object carries no `latest_unyanked`. Run the same
+   command against a crate you know is published (`serde`) whenever the result is empty or
+   uniform across all five, so a refused request cannot be mistaken for a missing release.
 
 Done in v0.2.3 (yanked broken 0.2.2 which shipped with the RoPE bug). New `cargo add` users get the fix; existing pinned users get a yank warning on next `cargo update`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,7 +198,11 @@ Publish order follows the internal dependency DAG (deps before dependents): fann
 
    ```bash
    UA="lattice-release-check (you@example.com)"   # any identifying string with contact info
-   for c in lattice-inference lattice-fann lattice-transport lattice-embed lattice-tune; do
+   # serde is the control and is first on purpose: it is always published, so reaching a lattice
+   # line at all proves the registry accepted the request shape. The subshell keeps the abort
+   # from closing an interactive terminal.
+   (
+   for c in serde lattice-inference lattice-fann lattice-transport lattice-embed lattice-tune; do
      curl -s -H "User-Agent: $UA" "https://crates.io/api/v1/crates/$c" | python3 -c "
    import sys, json
    d = json.load(sys.stdin)
@@ -206,14 +210,20 @@ Publish order follows the internal dependency DAG (deps before dependents): fann
        raise SystemExit('FAILED READ: ' + d['errors'][0].get('detail', ''))
    yanked = [v['num'] for v in d['versions'] if v['yanked']]
    print(d['crate']['name'], 'max_stable=' + d['crate']['max_stable_version'], 'yanked=' + str(yanked))
-   "
+   " || exit 1
    done
+   )
    ```
 
-   Expect `max_stable=<new>` on every crate and `<broken>` present in `yanked`. The fields are
-   `max_stable_version` / `max_version` / `newest_version` on the crate object and a per-version
-   `yanked` boolean in the `versions` array; the crate object carries no `latest_unyanked`. Run the same
-   command against a crate you know is published (`serde`) whenever the result is empty or
-   uniform across all five, so a refused request cannot be mistaken for a missing release.
+   Expect a `serde` line first, then `max_stable=<new>` on every lattice crate with `<broken>`
+   present in `yanked`. The fields are `max_stable_version` / `max_version` / `newest_version` on
+   the crate object and a per-version `yanked` boolean in the `versions` array; the crate object
+   carries no `latest_unyanked`.
+
+   The control runs inside the loop rather than being described beside it, because the failure it
+   guards against does not look like a failure. A refused request returns an error object, and code
+   scanning that object for a version finds none, so a refusal is rendered as an absence and reads
+   as "this release was never published" — wrong in the reassuring direction. A control that the
+   reader is told to run when something looks wrong never runs, because nothing looks wrong.
 
 Done in v0.2.3 (yanked broken 0.2.2 which shipped with the RoPE bug). New `cargo add` users get the fix; existing pinned users get a yank warning on next `cargo update`.


### PR DESCRIPTION
## What

Corrects the crates.io publish-verification step in `CLAUDE.md`. As written it could not verify a publish, and it failed in a way that resembles a real answer.

## Why

Two independent defects in step 5 of the bump-and-yank procedure:

1. **crates.io refuses unidentified API requests.** A bare `curl` returns HTTP 403 with a JSON error object instead of crate data. A reader (or script) scanning that response for a version field finds none, which reads as "this release was never published". A refusal is rendered as an absence, and the wrong reading is the reassuring one.

2. **The field it named does not exist.** The step told the reader to look for `latest_unyanked`. The crate object carries `max_stable_version`, `max_version`, `newest_version`, and `default_version`; yank state lives in a per-version `yanked` boolean inside the `versions` array.

## What changed

The step now carries a working command: a `User-Agent`, an explicit check that treats an `errors` object as a failed read rather than as data, and a loop over all five published crates.

The known-good control (`serde`) runs **inside** the loop rather than being described next to it. The first revision of this change said to re-run against a known-published crate whenever the result looked empty or uniform, which cannot fire — nothing looks wrong, so that control never runs. Querying `serde` first in the same invocation means a refusal aborts before any lattice crate is reported. The loop runs in a subshell so the abort does not close an interactive terminal.

## Verification

Both paths were executed against the fenced block as it reads in this PR, extracted from the file rather than retyped:

- **As documented:** prints a `serde` line followed by all five lattice crates, exits 0.
- **With the `User-Agent` removed:** prints `FAILED READ` with the registry's own message, exits 1, and emits **no** lattice lines — so a refusal cannot be reported as a missing release.

## Scope

Documentation only. No crate source, `Cargo.toml`, or workflow is touched, so the bench-compare disposition requirement does not apply to this diff — no changed line reaches `crates/inference/`, `crates/embed/`, or `crates/fann/`.
