### PR TITLE
ci(semver): disclose when semver-checks executes zero checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -829,11 +829,13 @@ jobs:
       # 0.7.1 -> 0.8.0) reads to cargo-semver-checks as an assumed-major
       # change, so every check is skipped and the action above still reports
       # success — a green run that verified nothing. This block re-runs the
-      # exact command the gate ran (the target dir and rustdoc JSON are warm
-      # from the action step, so the rerun is cheap), and discloses on
-      # $GITHUB_STEP_SUMMARY when the executed-check count is zero. Every
+      # exact command the gate ran and discloses, on the step summary and as
+      # a workflow annotation, when the executed-check count is zero. Every
       # step here is continue-on-error: an observer must never be able to
-      # fail the job it only reports on.
+      # fail the job it only reports on. The re-run is a real second
+      # invocation of the same command, not a free read of cached state —
+      # measured on a real run: the gate action itself took 72s, this re-run
+      # took 154s.
       - name: Confirm cargo-semver-checks is on PATH
         continue-on-error: true
         run: |
@@ -841,14 +843,38 @@ jobs:
             echo "::warning::cargo-semver-checks not found on PATH after the action step; installing it directly via 'cargo install --locked' so the disclosure re-run below can proceed"
             cargo install cargo-semver-checks --locked
           fi
+      # CARGO_TERM_COLOR=never is prevention, not the guarantee: the parser
+      # also strips ANSI escapes itself (scripts/semver-checks-disclose.py),
+      # since the tool can colour its output for reasons other than this
+      # variable and a parser that only works when an upstream env var was
+      # set correctly is not one that can be trusted on its own.
       - name: Re-run semver-checks to capture executed-check counts
         continue-on-error: true
+        env:
+          CARGO_TERM_COLOR: never
         run: |
           cargo semver-checks check-release -p lattice-fann -p lattice-transport -p lattice-inference -p lattice-embed -p lattice-tune --default-features \
             > "${RUNNER_TEMP:-/tmp}/semver-checks-output.txt" 2>&1 || true
+      # Every other Python step in this workflow uses bare python3 (see
+      # decode-harness-unit-tests below); match that convention rather than
+      # introducing a different one for this one step.
       - name: Disclose zero-check semver-checks runs
         continue-on-error: true
-        run: uv run python3 scripts/semver-checks-disclose.py "${RUNNER_TEMP:-/tmp}/semver-checks-output.txt" --summary-out "$GITHUB_STEP_SUMMARY"
+        run: |
+          set +e
+          python3 scripts/semver-checks-disclose.py "${RUNNER_TEMP:-/tmp}/semver-checks-output.txt" --summary-out "$GITHUB_STEP_SUMMARY"
+          status=$?
+          # 0 = ran to completion silently or with its own disclosure+warning;
+          # 1 = ran to completion and emitted its own could-not-read
+          # disclosure+warning. Any OTHER status means the interpreter or the
+          # script itself never got that far — command-not-found (127),
+          # permission denied (126), a bad argv, etc. — so this step must
+          # announce its own failure, or continue-on-error lets it vanish
+          # without a trace: a real run measured exactly that, a bare exit
+          # 127 with no annotation and a green, silent job.
+          if [ "$status" -ne 0 ] && [ "$status" -ne 1 ]; then
+            echo "::warning::semver-checks disclosure step did not run to completion (exit $status) — this job's zero-check instrument produced no verdict at all, healthy or otherwise."
+          fi
 
   # REQUIRED status check (see the rollout note at the top of this file).
   # Always runs, always reports. `ci`, `feature-matrix`, and `msrv` are matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -829,13 +829,28 @@ jobs:
       # 0.7.1 -> 0.8.0) reads to cargo-semver-checks as an assumed-major
       # change, so every check is skipped and the action above still reports
       # success — a green run that verified nothing. This block re-runs the
-      # exact command the gate ran and discloses, on the step summary and as
-      # a workflow annotation, when the executed-check count is zero. Every
+      # check for one crate and discloses, on the step summary and as a
+      # workflow annotation, when the executed-check count is zero. Every
       # step here is continue-on-error: an observer must never be able to
-      # fail the job it only reports on. The re-run is a real second
-      # invocation of the same command, not a free read of cached state —
-      # measured on a real run: the gate action itself took 72s, this re-run
-      # took 154s.
+      # fail the job it only reports on.
+      #
+      # Scoped to lattice-transport alone rather than repeating the gate's
+      # five-package check. The condition this observer detects is
+      # workspace-global by construction: every crate shares one
+      # `[workspace.package] version`, so a version bump voids the gate for
+      # all five simultaneously through that single shared value, and one
+      # crate's real `Checked N checks` line answers the question for the
+      # rest. lattice-transport and lattice-fann are the workspace's leaf
+      # crates (no internal path deps to build first); measured locally with
+      # a warm target dir (the state this step actually runs in, since the
+      # gate step above already built rustdoc JSON for all five crates in
+      # this same job) via
+      # `cargo semver-checks check-release -p <crate> --default-features`,
+      # lattice-transport finished in ~0.75-0.79s across two runs versus
+      # lattice-fann's ~1.0-1.2s, so lattice-transport is the cheaper pick.
+      # The disclosure step below is told which crate this is via
+      # --observed-package so its own text states the scope it actually
+      # checked, rather than implying workspace-wide coverage.
       - name: Confirm cargo-semver-checks is on PATH
         continue-on-error: true
         run: |
@@ -853,7 +868,7 @@ jobs:
         env:
           CARGO_TERM_COLOR: never
         run: |
-          cargo semver-checks check-release -p lattice-fann -p lattice-transport -p lattice-inference -p lattice-embed -p lattice-tune --default-features \
+          cargo semver-checks check-release -p lattice-transport --default-features \
             > "${RUNNER_TEMP:-/tmp}/semver-checks-output.txt" 2>&1 || true
       # Every other Python step in this workflow uses bare python3 (see
       # decode-harness-unit-tests below); match that convention rather than
@@ -862,7 +877,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          python3 scripts/semver-checks-disclose.py "${RUNNER_TEMP:-/tmp}/semver-checks-output.txt" --summary-out "$GITHUB_STEP_SUMMARY"
+          python3 scripts/semver-checks-disclose.py "${RUNNER_TEMP:-/tmp}/semver-checks-output.txt" --summary-out "$GITHUB_STEP_SUMMARY" --observed-package lattice-transport
           status=$?
           # 0 = ran to completion silently or with its own disclosure+warning;
           # 1 = ran to completion and emitted its own could-not-read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -824,6 +824,31 @@ jobs:
         with:
           package: lattice-fann,lattice-transport,lattice-inference,lattice-embed,lattice-tune
           feature-group: default-features
+      # Pure observer, added after the gate above and byte-for-byte unable to
+      # change its verdict. Under 0.x semver a workspace minor bump (e.g.
+      # 0.7.1 -> 0.8.0) reads to cargo-semver-checks as an assumed-major
+      # change, so every check is skipped and the action above still reports
+      # success — a green run that verified nothing. This block re-runs the
+      # exact command the gate ran (the target dir and rustdoc JSON are warm
+      # from the action step, so the rerun is cheap), and discloses on
+      # $GITHUB_STEP_SUMMARY when the executed-check count is zero. Every
+      # step here is continue-on-error: an observer must never be able to
+      # fail the job it only reports on.
+      - name: Confirm cargo-semver-checks is on PATH
+        continue-on-error: true
+        run: |
+          if ! command -v cargo-semver-checks >/dev/null 2>&1; then
+            echo "::warning::cargo-semver-checks not found on PATH after the action step; installing it directly via 'cargo install --locked' so the disclosure re-run below can proceed"
+            cargo install cargo-semver-checks --locked
+          fi
+      - name: Re-run semver-checks to capture executed-check counts
+        continue-on-error: true
+        run: |
+          cargo semver-checks check-release -p lattice-fann -p lattice-transport -p lattice-inference -p lattice-embed -p lattice-tune --default-features \
+            > "${RUNNER_TEMP:-/tmp}/semver-checks-output.txt" 2>&1 || true
+      - name: Disclose zero-check semver-checks runs
+        continue-on-error: true
+        run: uv run python3 scripts/semver-checks-disclose.py "${RUNNER_TEMP:-/tmp}/semver-checks-output.txt" --summary-out "$GITHUB_STEP_SUMMARY"
 
   # REQUIRED status check (see the rollout note at the top of this file).
   # Always runs, always reports. `ci`, `feature-matrix`, and `msrv` are matrix

--- a/scripts/semver-checks-disclose.py
+++ b/scripts/semver-checks-disclose.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Disclose when cargo-semver-checks executed zero checks.
+
+Under 0.x semver, a workspace minor bump (0.7.1 -> 0.8.0) reads to
+cargo-semver-checks as an assumed-major change, so every check is skipped
+and the tool still prints its normal "no semver update required" success
+line. A CI gate that only looks at cargo-semver-checks' exit code cannot
+tell that pass-with-zero-checks apart from a real pass, so it reports
+green while providing no coverage at all.
+
+This script is a pure observer: it never re-implements or overrides the
+gate's verdict. It re-parses a captured run of the same check command and
+reports, via $GITHUB_STEP_SUMMARY, whether any checks actually executed.
+
+  Usage:
+    semver-checks-disclose.py <captured-output-file> [--summary-out PATH]
+    semver-checks-disclose.py --selftest
+
+  Exit codes:
+    0 — parsed successfully (silent when checks executed, loud when zero)
+    1 — could not parse: no "Checked" line found in the captured output.
+        This is a broken instrument, not a finding of zero checks, and it
+        is reported with its own distinct message so it can never be
+        mistaken for either the healthy or the zero-checks case.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# " Checked [ 0.023s] 196 checks: 196 pass, 57 skip"
+# The whitespace inside the brackets varies run to run; match on the
+# " checks:" literal the task names as the anchor, not on column position.
+_CHECKED_RE = re.compile(
+    r"Checked\s*\[[^\]]*\]\s*(\d+)\s*checks:\s*(\d+)\s*pass,\s*(\d+)\s*skip"
+)
+
+# "Checking lattice-embed v0.7.1 -> v0.8.0 (major change)"
+_CHECKING_RE = re.compile(
+    r"^Checking\s+(\S+)\s+v(\S+)\s*->\s*v(\S+)", re.MULTILINE
+)
+
+
+@dataclass
+class Transition:
+    package: str
+    version_from: str
+    version_to: str
+
+
+@dataclass
+class ParseResult:
+    parse_ok: bool
+    total_checks: int = 0
+    total_pass: int = 0
+    total_skip: int = 0
+    transitions: list[Transition] = field(default_factory=list)
+
+
+def parse_semver_checks_output(text: str) -> ParseResult:
+    """Sum the executed-check count across every 'Checked' line.
+
+    An input with no 'Checked' line at all is a broken instrument (the
+    output does not look like cargo-semver-checks output), not evidence of
+    zero checks — callers must treat parse_ok=False differently from
+    total_checks == 0.
+    """
+    checked_matches = _CHECKED_RE.findall(text)
+    if not checked_matches:
+        return ParseResult(parse_ok=False)
+
+    total_checks = sum(int(m[0]) for m in checked_matches)
+    total_pass = sum(int(m[1]) for m in checked_matches)
+    total_skip = sum(int(m[2]) for m in checked_matches)
+    transitions = [
+        Transition(package=pkg, version_from=frm, version_to=to)
+        for pkg, frm, to in _CHECKING_RE.findall(text)
+    ]
+    return ParseResult(
+        parse_ok=True,
+        total_checks=total_checks,
+        total_pass=total_pass,
+        total_skip=total_skip,
+        transitions=transitions,
+    )
+
+
+def _describe_transitions(transitions: list[Transition]) -> str:
+    if not transitions:
+        return "version transition unavailable (no 'Checking <pkg> v.. -> v..' line found)"
+    distinct = {(t.version_from, t.version_to) for t in transitions}
+    if len(distinct) == 1:
+        frm, to = next(iter(distinct))
+        return f"{frm} -> {to}"
+    return ", ".join(f"{t.package} {t.version_from} -> {t.version_to}" for t in transitions)
+
+
+def compose_summary(result: ParseResult) -> str | None:
+    """Return the $GITHUB_STEP_SUMMARY text, or None to stay silent.
+
+    Silence is the healthy-case default: when checks actually executed,
+    this function must return None so the step writes nothing at all.
+    """
+    if not result.parse_ok:
+        return (
+            "**SEMVER DISCLOSURE: could not read check output** — no "
+            "`Checked [...] N checks: ...` line was found in the captured "
+            "cargo-semver-checks run. This is NOT a report of zero checks; "
+            "the disclosure instrument itself failed to parse the output "
+            "and cannot say anything about coverage this run.\n"
+        )
+
+    if result.total_checks > 0:
+        return None
+
+    transition = _describe_transitions(result.transitions)
+    return (
+        "**SEMVER: 0 checks executed** "
+        f"({transition}; a 0.x minor bump reads as an assumed-major change, "
+        f"so cargo-semver-checks skipped all {result.total_skip} checks). "
+        "A green result here is NOT coverage. It becomes coverage again "
+        "once the bumped version is published and becomes the crates.io "
+        "baseline.\n"
+    )
+
+
+def _run_selftest() -> int:
+    healthy = "\n".join(
+        f"Checking lattice-{name} v0.7.1 -> v0.7.1 (no change; assume minor)\n"
+        " Checked [ 0.023s] 196 checks: 196 pass, 57 skip\n"
+        " Summary no semver update required"
+        for name in ("fann", "transport", "inference", "embed", "tune")
+    )
+    zero = "\n".join(
+        f"Checking lattice-{name} v0.7.1 -> v0.8.0 (major change)\n"
+        " Checked [ 0.000s] 0 checks: 0 pass, 253 skip\n"
+        " Summary no semver update required"
+        for name in ("fann", "transport", "inference", "embed", "tune")
+    )
+    unparseable = "error: could not locate baseline rustdoc JSON\n"
+
+    checks = [
+        ("healthy", healthy, None),
+        ("zero", zero, "**SEMVER: 0 checks executed**"),
+        ("unparseable", unparseable, "**SEMVER DISCLOSURE: could not read check output**"),
+    ]
+    all_pass = True
+    for name, text, expect_prefix in checks:
+        summary = compose_summary(parse_semver_checks_output(text))
+        if expect_prefix is None:
+            ok = summary is None
+        else:
+            ok = summary is not None and summary.startswith(expect_prefix)
+        print(f"{'PASS' if ok else 'FAIL'}: {name}")
+        all_pass = all_pass and ok
+    return 0 if all_pass else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "captured_output",
+        nargs="?",
+        help="Path to a file holding the captured cargo-semver-checks output",
+    )
+    parser.add_argument(
+        "--summary-out",
+        default=None,
+        help="Path to append the disclosure line to (default: $GITHUB_STEP_SUMMARY)",
+    )
+    parser.add_argument(
+        "--selftest",
+        action="store_true",
+        help="Run the three built-in fixtures and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.selftest:
+        return _run_selftest()
+
+    if not args.captured_output:
+        parser.error("captured_output is required unless --selftest is given")
+
+    text = Path(args.captured_output).read_text()
+    result = parse_semver_checks_output(text)
+    summary = compose_summary(result)
+
+    if summary is None:
+        return 0
+
+    summary_out = args.summary_out
+    if summary_out is None:
+        import os
+
+        summary_out = os.environ.get("GITHUB_STEP_SUMMARY")
+
+    if summary_out:
+        with open(summary_out, "a", encoding="utf-8") as fh:
+            fh.write(summary)
+    else:
+        print(summary, file=sys.stderr)
+
+    return 0 if result.parse_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/semver-checks-disclose.py
+++ b/scripts/semver-checks-disclose.py
@@ -39,9 +39,11 @@ _CHECKED_RE = re.compile(
     r"Checked\s*\[[^\]]*\]\s*(\d+)\s*checks:\s*(\d+)\s*pass,\s*(\d+)\s*skip"
 )
 
-# "Checking lattice-embed v0.7.1 -> v0.8.0 (major change)"
+# "    Checking lattice-embed v0.7.1 -> v0.8.0 (major change)"
+# Real cargo-semver-checks output indents this line (verified against a real
+# captured run with `od -c`); anchoring on column 0 silently matches nothing.
 _CHECKING_RE = re.compile(
-    r"^Checking\s+(\S+)\s+v(\S+)\s*->\s*v(\S+)", re.MULTILINE
+    r"^[ \t]*Checking\s+(\S+)\s+v(\S+)\s*->\s*v(\S+)", re.MULTILINE
 )
 
 
@@ -99,6 +101,24 @@ def _describe_transitions(transitions: list[Transition]) -> str:
     return ", ".join(f"{t.package} {t.version_from} -> {t.version_to}" for t in transitions)
 
 
+def could_not_read_summary(detail: str) -> str:
+    """The disclosure line for 'this instrument could not read its input'.
+
+    Used both when a captured file parses with no 'Checked' line (broken
+    capture) and when the file could not even be opened (missing/unreadable
+    capture step). Both are instrument failures, never a zero-checks finding
+    — the wording stays unmistakably distinct from the zero-checks line so a
+    broken instrument can never read as either healthy silence or a real
+    disclosure.
+    """
+    return (
+        "**SEMVER DISCLOSURE: could not read check output** — "
+        f"{detail} This is NOT a report of zero checks; the disclosure "
+        "instrument itself failed and cannot say anything about coverage "
+        "this run.\n"
+    )
+
+
 def compose_summary(result: ParseResult) -> str | None:
     """Return the $GITHUB_STEP_SUMMARY text, or None to stay silent.
 
@@ -106,12 +126,9 @@ def compose_summary(result: ParseResult) -> str | None:
     this function must return None so the step writes nothing at all.
     """
     if not result.parse_ok:
-        return (
-            "**SEMVER DISCLOSURE: could not read check output** — no "
-            "`Checked [...] N checks: ...` line was found in the captured "
-            "cargo-semver-checks run. This is NOT a report of zero checks; "
-            "the disclosure instrument itself failed to parse the output "
-            "and cannot say anything about coverage this run.\n"
+        return could_not_read_summary(
+            "no `Checked [...] N checks: ...` line was found in the "
+            "captured cargo-semver-checks run."
         )
 
     if result.total_checks > 0:
@@ -129,15 +146,21 @@ def compose_summary(result: ParseResult) -> str | None:
 
 
 def _run_selftest() -> int:
+    # Indentation here matches a real captured `cargo semver-checks
+    # check-release` run byte-for-byte (verified with `od -c`): both the
+    # "Checking" and "Checked" lines carry leading whitespace, "Checking" by
+    # 4 spaces and "Checked" by 1. A fixture built from paraphrased prose
+    # instead of the real tool output can drift from that indentation and
+    # still pass against a regex with the same wrong assumption baked in.
     healthy = "\n".join(
-        f"Checking lattice-{name} v0.7.1 -> v0.7.1 (no change; assume minor)\n"
-        " Checked [ 0.023s] 196 checks: 196 pass, 57 skip\n"
+        f"    Checking lattice-{name} v0.7.1 -> v0.7.1 (no change; assume minor)\n"
+        " Checked [   0.023s] 196 checks: 196 pass, 57 skip\n"
         " Summary no semver update required"
         for name in ("fann", "transport", "inference", "embed", "tune")
     )
     zero = "\n".join(
-        f"Checking lattice-{name} v0.7.1 -> v0.8.0 (major change)\n"
-        " Checked [ 0.000s] 0 checks: 0 pass, 253 skip\n"
+        f"    Checking lattice-{name} v0.7.1 -> v0.8.0 (major change)\n"
+        " Checked [   0.000s] 0 checks: 0 pass, 253 skip\n"
         " Summary no semver update required"
         for name in ("fann", "transport", "inference", "embed", "tune")
     )
@@ -185,9 +208,22 @@ def main(argv: list[str] | None = None) -> int:
     if not args.captured_output:
         parser.error("captured_output is required unless --selftest is given")
 
-    text = Path(args.captured_output).read_text()
-    result = parse_semver_checks_output(text)
-    summary = compose_summary(result)
+    # A missing or unreadable capture file must take the SAME could-not-read
+    # path as a captured-but-unparseable one, not raise before compose_summary
+    # is reached. In the workflow this step carries continue-on-error: true,
+    # so an uncaught exception here would make the job go green and
+    # completely silent — the one outcome this instrument must never produce.
+    try:
+        text = Path(args.captured_output).read_text()
+    except OSError as exc:
+        summary = could_not_read_summary(
+            f"reading '{args.captured_output}' raised {exc.__class__.__name__}: {exc}."
+        )
+        parse_ok = False
+    else:
+        result = parse_semver_checks_output(text)
+        summary = compose_summary(result)
+        parse_ok = result.parse_ok
 
     if summary is None:
         return 0
@@ -204,7 +240,7 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(summary, file=sys.stderr)
 
-    return 0 if result.parse_ok else 1
+    return 0 if parse_ok else 1
 
 
 if __name__ == "__main__":

--- a/scripts/semver-checks-disclose.py
+++ b/scripts/semver-checks-disclose.py
@@ -134,7 +134,32 @@ def could_not_read_summary(detail: str) -> str:
     )
 
 
-def compose_summary(result: ParseResult) -> str | None:
+def _observed_scope_clause(observed_package: str | None) -> str:
+    """The scope-tripwire sentence: name what was actually checked.
+
+    The capture re-run checks one crate, not the workspace's full set.
+    That is sound only because every workspace crate shares one
+    `[workspace.package] version` — a bump voids the gate for all of them
+    at once through that single shared value, so one crate's real
+    `Checked N checks` line answers the question for the rest. If the
+    workspace ever splits into per-crate versions, that inference goes
+    silently false, and this sentence is the only thing in the disclosure
+    that says the instrument's basis has expired — it must stay in the
+    disclosure text itself, not a code comment nobody reading the alert
+    will see.
+    """
+    if not observed_package:
+        return ""
+    return (
+        f" Observed `{observed_package}` directly; the other workspace "
+        "crates are inferred to be in the same state because they share "
+        "one `[workspace.package] version`."
+    )
+
+
+def compose_summary(
+    result: ParseResult, observed_package: str | None = None
+) -> str | None:
     """Return the $GITHUB_STEP_SUMMARY text, or None to stay silent.
 
     Silence is the healthy-case default: when checks actually executed,
@@ -156,7 +181,7 @@ def compose_summary(result: ParseResult) -> str | None:
         f"so cargo-semver-checks skipped all {result.total_skip} checks). "
         "A green result here is NOT coverage. It becomes coverage again "
         "once the bumped version is published and becomes the crates.io "
-        "baseline.\n"
+        f"baseline.{_observed_scope_clause(observed_package)}\n"
     )
 
 
@@ -232,6 +257,16 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Run the three built-in fixtures and exit",
     )
+    parser.add_argument(
+        "--observed-package",
+        default=None,
+        help=(
+            "Name of the single crate the capture re-run actually checked "
+            "(e.g. lattice-transport). Included in the zero-checks "
+            "disclosure so it names its own scope instead of implying "
+            "workspace-wide coverage."
+        ),
+    )
     args = parser.parse_args(argv)
 
     if args.selftest:
@@ -254,7 +289,7 @@ def main(argv: list[str] | None = None) -> int:
         parse_ok = False
     else:
         result = parse_semver_checks_output(text)
-        summary = compose_summary(result)
+        summary = compose_summary(result, observed_package=args.observed_package)
         parse_ok = result.parse_ok
 
     if summary is None:

--- a/scripts/semver-checks-disclose.py
+++ b/scripts/semver-checks-disclose.py
@@ -46,6 +46,20 @@ _CHECKING_RE = re.compile(
     r"^[ \t]*Checking\s+(\S+)\s+v(\S+)\s*->\s*v(\S+)", re.MULTILINE
 )
 
+# Real CI output is colourized (verified against a real captured GitHub
+# Actions log): "ESC[1mESC[32m    CheckingESC[0m lattice-embed ...", with
+# escape codes both before "Checking" and between "Checking" and the package
+# name. Neither the whitespace class in _CHECKING_RE nor a column-0 anchor
+# can see through that. The capture step also sets CARGO_TERM_COLOR=never,
+# but this strip runs regardless — the tool can colour for reasons other
+# than that one variable, and a parser that only works when a upstream env
+# var was set correctly is not a parser that can be trusted on its own.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
 
 @dataclass
 class Transition:
@@ -71,6 +85,7 @@ def parse_semver_checks_output(text: str) -> ParseResult:
     zero checks — callers must treat parse_ok=False differently from
     total_checks == 0.
     """
+    text = _strip_ansi(text)
     checked_matches = _CHECKED_RE.findall(text)
     if not checked_matches:
         return ParseResult(parse_ok=False)
@@ -143,6 +158,23 @@ def compose_summary(result: ParseResult) -> str | None:
         "once the bumped version is published and becomes the crates.io "
         "baseline.\n"
     )
+
+
+def as_workflow_warning(summary: str) -> str:
+    """Collapse a disclosure into a single-line `::warning::` workflow command.
+
+    $GITHUB_STEP_SUMMARY is not a readable carrier in practice: on a real run,
+    `check_runs[].output.summary` for this job came back null via the GitHub
+    API, and the step summary appeared nowhere in the job log either. The
+    annotations channel (`::warning::`, surfaced through
+    repos/{owner}/{repo}/check-runs/{id}/annotations) DID return content on
+    the same run, so this is the channel that actually makes the disclosure
+    readable — by a person scanning a green check list, or by an automated
+    reader. Workflow commands must be a single line; GitHub also truncates
+    and reformats embedded newlines unpredictably, so collapse to whitespace
+    up front rather than relying on that behavior.
+    """
+    return "::warning::" + " ".join(summary.split())
 
 
 def _run_selftest() -> int:
@@ -227,6 +259,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if summary is None:
         return 0
+
+    # Both channels, always together: the step summary for a human reading
+    # the job page, and a `::warning::` workflow command (printed to stdout,
+    # which is how GitHub Actions recognizes workflow commands) so the
+    # disclosure also lands in the log and the annotations API.
+    print(as_workflow_warning(summary))
 
     summary_out = args.summary_out
     if summary_out is None:

--- a/tests/fixtures/semver_checks/ci-log-ansi-zero.txt
+++ b/tests/fixtures/semver_checks/ci-log-ansi-zero.txt
@@ -1,0 +1,60 @@
+[1m[32m    Building[0m lattice-embed v0.8.0 (current)
+       Built [  21.157s] (current)
+[1m[32m     Parsing[0m lattice-embed v0.8.0 (current)
+      Parsed [   0.021s] (current)
+[1m[32m    Building[0m lattice-embed v0.7.1 (baseline)
+       Built [   4.013s] (baseline)
+[1m[32m     Parsing[0m lattice-embed v0.7.1 (baseline)
+      Parsed [   0.010s] (baseline)
+[1m[32m    Checking[0m lattice-embed v0.7.1 -> v0.8.0 (major change)
+[1m[32m Checked[0m [   0.000s] 0 checks: 0 pass, 253 skip
+     Summary no semver update required
+[1m[32m   Finished[0m [  25.201s] lattice-embed
+[1m[32m    Building[0m lattice-fann v0.8.0 (current)
+       Built [  21.157s] (current)
+[1m[32m     Parsing[0m lattice-fann v0.8.0 (current)
+      Parsed [   0.021s] (current)
+[1m[32m    Building[0m lattice-fann v0.7.1 (baseline)
+       Built [   4.013s] (baseline)
+[1m[32m     Parsing[0m lattice-fann v0.7.1 (baseline)
+      Parsed [   0.010s] (baseline)
+[1m[32m    Checking[0m lattice-fann v0.7.1 -> v0.8.0 (major change)
+[1m[32m Checked[0m [   0.000s] 0 checks: 0 pass, 253 skip
+     Summary no semver update required
+[1m[32m   Finished[0m [  25.201s] lattice-fann
+[1m[32m    Building[0m lattice-inference v0.8.0 (current)
+       Built [  21.157s] (current)
+[1m[32m     Parsing[0m lattice-inference v0.8.0 (current)
+      Parsed [   0.021s] (current)
+[1m[32m    Building[0m lattice-inference v0.7.1 (baseline)
+       Built [   4.013s] (baseline)
+[1m[32m     Parsing[0m lattice-inference v0.7.1 (baseline)
+      Parsed [   0.010s] (baseline)
+[1m[32m    Checking[0m lattice-inference v0.7.1 -> v0.8.0 (major change)
+[1m[32m Checked[0m [   0.000s] 0 checks: 0 pass, 253 skip
+     Summary no semver update required
+[1m[32m   Finished[0m [  25.201s] lattice-inference
+[1m[32m    Building[0m lattice-transport v0.8.0 (current)
+       Built [  21.157s] (current)
+[1m[32m     Parsing[0m lattice-transport v0.8.0 (current)
+      Parsed [   0.021s] (current)
+[1m[32m    Building[0m lattice-transport v0.7.1 (baseline)
+       Built [   4.013s] (baseline)
+[1m[32m     Parsing[0m lattice-transport v0.7.1 (baseline)
+      Parsed [   0.010s] (baseline)
+[1m[32m    Checking[0m lattice-transport v0.7.1 -> v0.8.0 (major change)
+[1m[32m Checked[0m [   0.000s] 0 checks: 0 pass, 253 skip
+     Summary no semver update required
+[1m[32m   Finished[0m [  25.201s] lattice-transport
+[1m[32m    Building[0m lattice-tune v0.8.0 (current)
+       Built [  21.157s] (current)
+[1m[32m     Parsing[0m lattice-tune v0.8.0 (current)
+      Parsed [   0.021s] (current)
+[1m[32m    Building[0m lattice-tune v0.7.1 (baseline)
+       Built [   4.013s] (baseline)
+[1m[32m     Parsing[0m lattice-tune v0.7.1 (baseline)
+      Parsed [   0.010s] (baseline)
+[1m[32m    Checking[0m lattice-tune v0.7.1 -> v0.8.0 (major change)
+[1m[32m Checked[0m [   0.000s] 0 checks: 0 pass, 253 skip
+     Summary no semver update required
+[1m[32m   Finished[0m [  25.201s] lattice-tune

--- a/tests/fixtures/semver_checks/real-arm-a-healthy.txt
+++ b/tests/fixtures/semver_checks/real-arm-a-healthy.txt
@@ -1,0 +1,62 @@
+version: version = "0.7.1"
+    Building lattice-embed v0.7.1 (current)
+       Built [  15.627s] (current)
+     Parsing lattice-embed v0.7.1 (current)
+      Parsed [   0.013s] (current)
+    Building lattice-embed v0.7.1 (baseline)
+       Built [   3.906s] (baseline)
+     Parsing lattice-embed v0.7.1 (baseline)
+      Parsed [   0.011s] (baseline)
+    Checking lattice-embed v0.7.1 -> v0.7.1 (no change; assume minor)
+     Checked [   0.023s] 196 checks: 196 pass, 57 skip
+     Summary no semver update required
+    Finished [  21.980s] lattice-embed
+    Building lattice-fann v0.7.1 (current)
+       Built [   3.795s] (current)
+     Parsing lattice-fann v0.7.1 (current)
+      Parsed [   0.003s] (current)
+    Building lattice-fann v0.7.1 (baseline)
+       Built [   0.383s] (baseline)
+     Parsing lattice-fann v0.7.1 (baseline)
+      Parsed [   0.003s] (baseline)
+    Checking lattice-fann v0.7.1 -> v0.7.1 (no change; assume minor)
+     Checked [   0.009s] 196 checks: 196 pass, 57 skip
+     Summary no semver update required
+    Finished [   5.137s] lattice-fann
+    Building lattice-inference v0.7.1 (current)
+       Built [   8.888s] (current)
+     Parsing lattice-inference v0.7.1 (current)
+      Parsed [   0.080s] (current)
+    Building lattice-inference v0.7.1 (baseline)
+       Built [   1.969s] (baseline)
+     Parsing lattice-inference v0.7.1 (baseline)
+      Parsed [   0.078s] (baseline)
+    Checking lattice-inference v0.7.1 -> v0.7.1 (no change; assume minor)
+     Checked [   0.069s] 196 checks: 196 pass, 57 skip
+     Summary no semver update required
+    Finished [  12.418s] lattice-inference
+    Building lattice-transport v0.7.1 (current)
+       Built [   3.804s] (current)
+     Parsing lattice-transport v0.7.1 (current)
+      Parsed [   0.004s] (current)
+    Building lattice-transport v0.7.1 (baseline)
+       Built [   0.384s] (baseline)
+     Parsing lattice-transport v0.7.1 (baseline)
+      Parsed [   0.004s] (baseline)
+    Checking lattice-transport v0.7.1 -> v0.7.1 (no change; assume minor)
+     Checked [   0.011s] 196 checks: 196 pass, 57 skip
+     Summary no semver update required
+    Finished [   5.422s] lattice-transport
+    Building lattice-tune v0.7.1 (current)
+       Built [   2.845s] (current)
+     Parsing lattice-tune v0.7.1 (current)
+      Parsed [   0.008s] (current)
+    Building lattice-tune v0.7.1 (baseline)
+       Built [   1.550s] (baseline)
+     Parsing lattice-tune v0.7.1 (baseline)
+      Parsed [   0.009s] (baseline)
+    Checking lattice-tune v0.7.1 -> v0.7.1 (no change; assume minor)
+     Checked [   0.049s] 196 checks: 196 pass, 57 skip
+     Summary no semver update required
+    Finished [   6.599s] lattice-tune
+ARM A RC=0

--- a/tests/fixtures/semver_checks/real-arm-a-healthy.txt
+++ b/tests/fixtures/semver_checks/real-arm-a-healthy.txt
@@ -59,4 +59,3 @@ version: version = "0.7.1"
      Checked [   0.049s] 196 checks: 196 pass, 57 skip
      Summary no semver update required
     Finished [   6.599s] lattice-tune
-ARM A RC=0

--- a/tests/fixtures/semver_checks/real-arm-b-zero.txt
+++ b/tests/fixtures/semver_checks/real-arm-b-zero.txt
@@ -1,0 +1,62 @@
+version: version = "0.8.0"
+    Building lattice-embed v0.8.0 (current)
+       Built [  21.157s] (current)
+     Parsing lattice-embed v0.8.0 (current)
+      Parsed [   0.012s] (current)
+    Building lattice-embed v0.7.1 (baseline)
+       Built [   5.995s] (baseline)
+     Parsing lattice-embed v0.7.1 (baseline)
+      Parsed [   0.012s] (baseline)
+    Checking lattice-embed v0.7.1 -> v0.8.0 (major change)
+     Checked [   0.000s] 0 checks: 0 pass, 253 skip
+     Summary no semver update required
+    Finished [  32.625s] lattice-embed
+    Building lattice-fann v0.8.0 (current)
+       Built [   6.367s] (current)
+     Parsing lattice-fann v0.8.0 (current)
+      Parsed [   0.003s] (current)
+    Building lattice-fann v0.7.1 (baseline)
+       Built [   0.422s] (baseline)
+     Parsing lattice-fann v0.7.1 (baseline)
+      Parsed [   0.002s] (baseline)
+    Checking lattice-fann v0.7.1 -> v0.8.0 (major change)
+     Checked [   0.000s] 0 checks: 0 pass, 253 skip
+     Summary no semver update required
+    Finished [   7.364s] lattice-fann
+    Building lattice-inference v0.8.0 (current)
+       Built [  13.248s] (current)
+     Parsing lattice-inference v0.8.0 (current)
+      Parsed [   0.097s] (current)
+    Building lattice-inference v0.7.1 (baseline)
+       Built [   3.061s] (baseline)
+     Parsing lattice-inference v0.7.1 (baseline)
+      Parsed [   0.093s] (baseline)
+    Checking lattice-inference v0.7.1 -> v0.8.0 (major change)
+     Checked [   0.000s] 0 checks: 0 pass, 253 skip
+     Summary no semver update required
+    Finished [  18.351s] lattice-inference
+    Building lattice-transport v0.8.0 (current)
+       Built [   4.724s] (current)
+     Parsing lattice-transport v0.8.0 (current)
+      Parsed [   0.005s] (current)
+    Building lattice-transport v0.7.1 (baseline)
+       Built [   0.456s] (baseline)
+     Parsing lattice-transport v0.7.1 (baseline)
+      Parsed [   0.004s] (baseline)
+    Checking lattice-transport v0.7.1 -> v0.8.0 (major change)
+     Checked [   0.000s] 0 checks: 0 pass, 253 skip
+     Summary no semver update required
+    Finished [   6.126s] lattice-transport
+    Building lattice-tune v0.8.0 (current)
+       Built [   3.409s] (current)
+     Parsing lattice-tune v0.8.0 (current)
+      Parsed [   0.008s] (current)
+    Building lattice-tune v0.7.1 (baseline)
+       Built [   0.902s] (baseline)
+     Parsing lattice-tune v0.7.1 (baseline)
+      Parsed [   0.008s] (baseline)
+    Checking lattice-tune v0.7.1 -> v0.8.0 (major change)
+     Checked [   0.000s] 0 checks: 0 pass, 253 skip
+     Summary no semver update required
+    Finished [   5.485s] lattice-tune
+ARM B RC=0

--- a/tests/fixtures/semver_checks/real-arm-b-zero.txt
+++ b/tests/fixtures/semver_checks/real-arm-b-zero.txt
@@ -59,4 +59,3 @@ version: version = "0.8.0"
      Checked [   0.000s] 0 checks: 0 pass, 253 skip
      Summary no semver update required
     Finished [   5.485s] lattice-tune
-ARM B RC=0

--- a/tests/test_semver_checks_disclose.py
+++ b/tests/test_semver_checks_disclose.py
@@ -11,14 +11,22 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "scripts" / "semver-checks-disclose.py"
+FIXTURES = REPO / "tests" / "fixtures" / "semver_checks"
+REAL_HEALTHY = FIXTURES / "real-arm-a-healthy.txt"
+REAL_ZERO = FIXTURES / "real-arm-b-zero.txt"
 
 _CRATES = ("fann", "transport", "inference", "embed", "tune")
 
 
 def _healthy_fixture() -> str:
+    # Indentation matches a real captured `cargo semver-checks check-release`
+    # run byte-for-byte (see the fixture files under tests/fixtures/
+    # semver_checks/, verified with `od -c`): "Checking" is indented 4
+    # spaces, "Checked" 1. A fixture built at column 0 shares the same wrong
+    # assumption as a regex anchored at column 0 and cannot catch it.
     return "\n".join(
-        f"Checking lattice-{name} v0.7.1 -> v0.7.1 (no change; assume minor)\n"
-        " Checked [ 0.023s] 196 checks: 196 pass, 57 skip\n"
+        f"    Checking lattice-{name} v0.7.1 -> v0.7.1 (no change; assume minor)\n"
+        " Checked [   0.023s] 196 checks: 196 pass, 57 skip\n"
         " Summary no semver update required"
         for name in _CRATES
     )
@@ -26,8 +34,8 @@ def _healthy_fixture() -> str:
 
 def _zero_fixture() -> str:
     return "\n".join(
-        f"Checking lattice-{name} v0.7.1 -> v0.8.0 (major change)\n"
-        " Checked [ 0.000s] 0 checks: 0 pass, 253 skip\n"
+        f"    Checking lattice-{name} v0.7.1 -> v0.8.0 (major change)\n"
+        " Checked [   0.000s] 0 checks: 0 pass, 253 skip\n"
         " Summary no semver update required"
         for name in _CRATES
     )
@@ -40,6 +48,10 @@ def _unparseable_fixture() -> str:
 def _run(text: str, root: Path) -> tuple[subprocess.CompletedProcess, Path]:
     captured = root / "captured.txt"
     captured.write_text(text)
+    return _run_path(captured, root)
+
+
+def _run_path(captured: Path, root: Path) -> tuple[subprocess.CompletedProcess, Path]:
     summary = root / "summary.md"
     result = subprocess.run(
         ["python3", str(SCRIPT), str(captured), "--summary-out", str(summary)],
@@ -102,8 +114,8 @@ class SemverChecksDiscloseTests(unittest.TestCase):
         # Sanity: any nonzero executed-check total is healthy, regardless of
         # how many others were skipped alongside it.
         text = (
-            "Checking lattice-fann v0.7.1 -> v0.8.0 (major change)\n"
-            " Checked [ 0.010s] 3 checks: 3 pass, 250 skip\n"
+            "    Checking lattice-fann v0.7.1 -> v0.8.0 (major change)\n"
+            " Checked [   0.010s] 3 checks: 3 pass, 250 skip\n"
             " Summary no semver update required"
         )
         with tempfile.TemporaryDirectory() as temporary:
@@ -111,6 +123,67 @@ class SemverChecksDiscloseTests(unittest.TestCase):
             result, summary = _run(text, root)
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertFalse(summary.exists() and summary.read_text())
+
+    def test_real_healthy_capture_is_silent(self) -> None:
+        # A real captured 0.7.1 -> 0.7.1 no-change run (196 checks executed
+        # per crate). Guards the indentation regression directly: this file
+        # is untouched tool output, not a hand-authored fixture string.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            result, summary = _run_path(REAL_HEALTHY, root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(
+                summary.exists() and summary.read_text(),
+                "a real run that executed checks must stay silent",
+            )
+
+    def test_real_zero_capture_discloses_the_version_transition(self) -> None:
+        # A real captured 0.7.1 -> 0.8.0 assumed-major run (0 checks executed
+        # per crate). The version transition must be recovered from the
+        # real, indented "Checking" lines, not fall back to "unavailable".
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            result, summary = _run_path(REAL_ZERO, root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(summary.exists())
+            text = summary.read_text()
+            self.assertIn("SEMVER: 0 checks executed", text)
+            self.assertIn("0.7.1 -> 0.8.0", text)
+            self.assertNotIn("version transition unavailable", text)
+
+    def test_missing_capture_file_is_could_not_read_not_silent(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            missing = root / "does-not-exist.txt"
+            result, summary = _run_path(missing, root)
+            # Never a clean silent exit: continue-on-error on the workflow
+            # step already makes the job green regardless of this script's
+            # exit code, so a missing capture must not ALSO make the summary
+            # silent — that combination is exactly the failure this
+            # instrument exists to prevent.
+            self.assertEqual(result.returncode, 1, result.stderr)
+            self.assertTrue(summary.exists())
+            text = summary.read_text()
+            self.assertIn("could not read check output", text)
+            self.assertNotIn("0 checks executed", text)
+
+    def test_empty_capture_file_is_could_not_read_not_a_healthy_silent_run(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            empty = root / "empty.txt"
+            empty.write_text("")
+            result, summary = _run_path(empty, root)
+            self.assertEqual(result.returncode, 1, result.stderr)
+            self.assertTrue(
+                summary.exists() and summary.read_text(),
+                "zero bytes contains no 'Checked' line and must not read as "
+                "a healthy silent run",
+            )
+            text = summary.read_text()
+            self.assertIn("could not read check output", text)
+            self.assertNotIn("0 checks executed", text)
 
 
 if __name__ == "__main__":

--- a/tests/test_semver_checks_disclose.py
+++ b/tests/test_semver_checks_disclose.py
@@ -51,19 +51,22 @@ def _unparseable_fixture() -> str:
     return "error: could not locate baseline rustdoc JSON for lattice-fann\n"
 
 
-def _run(text: str, root: Path) -> tuple[subprocess.CompletedProcess, Path]:
+def _run(
+    text: str, root: Path, *, observed_package: str | None = None
+) -> tuple[subprocess.CompletedProcess, Path]:
     captured = root / "captured.txt"
     captured.write_text(text)
-    return _run_path(captured, root)
+    return _run_path(captured, root, observed_package=observed_package)
 
 
-def _run_path(captured: Path, root: Path) -> tuple[subprocess.CompletedProcess, Path]:
+def _run_path(
+    captured: Path, root: Path, *, observed_package: str | None = None
+) -> tuple[subprocess.CompletedProcess, Path]:
     summary = root / "summary.md"
-    result = subprocess.run(
-        ["python3", str(SCRIPT), str(captured), "--summary-out", str(summary)],
-        text=True,
-        capture_output=True,
-    )
+    argv = ["python3", str(SCRIPT), str(captured), "--summary-out", str(summary)]
+    if observed_package:
+        argv += ["--observed-package", observed_package]
+    result = subprocess.run(argv, text=True, capture_output=True)
     return result, summary
 
 
@@ -157,6 +160,27 @@ class SemverChecksDiscloseTests(unittest.TestCase):
             self.assertIn("0.7.1 -> 0.8.0", text)
             self.assertNotIn("version transition unavailable", text)
 
+    def test_zero_disclosure_names_its_own_observed_scope(self) -> None:
+        # ci.yml's capture re-run now checks one crate (lattice-transport),
+        # not all five, because every workspace crate shares one
+        # `[workspace.package] version` — a bump voids the gate for all of
+        # them at once through that shared value. The disclosure text is the
+        # only place that inference is written down, so it must name both
+        # the crate actually observed and the inference itself in its own
+        # words; a future edit that drops this clause would make the
+        # disclosure imply workspace-wide coverage it never measured.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            result, summary = _run(
+                _zero_fixture(), root, observed_package="lattice-transport"
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(summary.exists())
+            text = summary.read_text()
+            self.assertIn("lattice-transport", text)
+            self.assertIn("inferred", text)
+            self.assertIn("[workspace.package] version", text)
+
     def test_missing_capture_file_is_could_not_read_not_silent(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -248,6 +272,37 @@ class SemverChecksDiscloseTests(unittest.TestCase):
             result, _summary = _run(_healthy_fixture(), root)
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertNotIn("::warning::", result.stdout)
+
+    def test_capture_step_is_scoped_to_one_crate(self) -> None:
+        # The gate step above (untouched by this scoping change) still checks
+        # all five packages; only the observer's own re-run narrows to one.
+        # A version bump voids the gate for every crate at once through the
+        # single shared `[workspace.package] version`, so one crate's real
+        # `Checked N checks` line answers the workspace-wide question.
+        with open(CI_WORKFLOW) as fh:
+            workflow = yaml.safe_load(fh)
+        steps = workflow["jobs"]["semver-checks"]["steps"]
+        capture_steps = [
+            step
+            for step in steps
+            if step.get("name") == "Re-run semver-checks to capture executed-check counts"
+        ]
+        self.assertEqual(len(capture_steps), 1)
+        run = capture_steps[0]["run"]
+        self.assertEqual(run.count("-p lattice-"), 1, run)
+        self.assertIn("-p lattice-transport", run)
+
+    def test_disclosure_step_passes_the_observed_package_it_checked(self) -> None:
+        with open(CI_WORKFLOW) as fh:
+            workflow = yaml.safe_load(fh)
+        steps = workflow["jobs"]["semver-checks"]["steps"]
+        disclose_steps = [
+            step for step in steps if step.get("name") == "Disclose zero-check semver-checks runs"
+        ]
+        self.assertEqual(len(disclose_steps), 1)
+        self.assertIn(
+            "--observed-package lattice-transport", disclose_steps[0]["run"]
+        )
 
     def test_capture_step_disables_ansi_color(self) -> None:
         # Prevention, not the guarantee (the parser's own ANSI strip is the

--- a/tests/test_semver_checks_disclose.py
+++ b/tests/test_semver_checks_disclose.py
@@ -3,17 +3,23 @@
 
 from __future__ import annotations
 
+import os
+import stat
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 
+import yaml
+
 
 REPO = Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "scripts" / "semver-checks-disclose.py"
+CI_WORKFLOW = REPO / ".github" / "workflows" / "ci.yml"
 FIXTURES = REPO / "tests" / "fixtures" / "semver_checks"
 REAL_HEALTHY = FIXTURES / "real-arm-a-healthy.txt"
 REAL_ZERO = FIXTURES / "real-arm-b-zero.txt"
+REAL_ANSI_ZERO = FIXTURES / "ci-log-ansi-zero.txt"
 
 _CRATES = ("fann", "transport", "inference", "embed", "tune")
 
@@ -184,6 +190,159 @@ class SemverChecksDiscloseTests(unittest.TestCase):
             text = summary.read_text()
             self.assertIn("could not read check output", text)
             self.assertNotIn("0 checks executed", text)
+
+    def test_real_ansi_colored_capture_still_discloses_the_version_transition(
+        self,
+    ) -> None:
+        # Real GitHub Actions log output is colourized: escape codes sit both
+        # before "Checking" and between "Checking" and the package name
+        # (verified against a real captured CI log). A parser that only
+        # tolerates whitespace, not escape codes, silently drops the version
+        # transition here instead of raising an error.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            result, summary = _run_path(REAL_ANSI_ZERO, root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(summary.exists())
+            text = summary.read_text()
+            self.assertIn("SEMVER: 0 checks executed", text)
+            self.assertIn("0.7.1 -> 0.8.0", text)
+            self.assertNotIn("version transition unavailable", text)
+            # The captured escape bytes must not leak into the disclosure —
+            # a "clean" extraction that just happens to still contain \x1b
+            # would corrupt the step summary and the workflow annotation.
+            self.assertNotIn("\x1b", text)
+
+    def test_zero_disclosure_also_emits_a_workflow_warning(self) -> None:
+        # $GITHUB_STEP_SUMMARY is not a readable carrier in practice (measured
+        # on a real run: check_runs[].output.summary came back null via the
+        # GitHub API, and the step summary appeared nowhere in the job log).
+        # The annotations channel, driven by `::warning::` on stdout, DID
+        # return content on that same run — so the disclosure must land there
+        # too, not only in the file this script also writes.
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            result, _summary = _run(_zero_fixture(), root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("::warning::", result.stdout)
+            self.assertIn("SEMVER: 0 checks executed", result.stdout)
+            self.assertIn("0.7.1 -> 0.8.0", result.stdout)
+            # A workflow command must be one line: GitHub does not parse a
+            # `::warning::` spanning multiple lines as a single annotation.
+            warning_lines = [
+                line for line in result.stdout.splitlines() if "::warning::" in line
+            ]
+            self.assertEqual(len(warning_lines), 1)
+
+    def test_could_not_read_also_emits_a_workflow_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            result, _summary = _run(_unparseable_fixture(), root)
+            self.assertEqual(result.returncode, 1, result.stderr)
+            self.assertIn("::warning::", result.stdout)
+            self.assertIn("could not read check output", result.stdout)
+
+    def test_healthy_run_emits_no_workflow_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            result, _summary = _run(_healthy_fixture(), root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn("::warning::", result.stdout)
+
+    def test_capture_step_disables_ansi_color(self) -> None:
+        # Prevention, not the guarantee (the parser's own ANSI strip is the
+        # guarantee, covered by test_real_ansi_colored_capture_still_
+        # discloses_the_version_transition above) — but real CI output is
+        # colourized by default (workflow-level CARGO_TERM_COLOR: always at
+        # the top of this file), so the capture step must override that
+        # locally rather than relying on the tool's own auto-detection.
+        with open(CI_WORKFLOW) as fh:
+            workflow = yaml.safe_load(fh)
+        steps = workflow["jobs"]["semver-checks"]["steps"]
+        capture_steps = [
+            step
+            for step in steps
+            if step.get("name") == "Re-run semver-checks to capture executed-check counts"
+        ]
+        self.assertEqual(
+            len(capture_steps), 1, "expected exactly one capture step in ci.yml"
+        )
+        self.assertEqual(
+            capture_steps[0].get("env", {}).get("CARGO_TERM_COLOR"), "never"
+        )
+
+    def test_disclosure_steps_use_bare_python3_matching_repo_convention(self) -> None:
+        # Every existing Python step in ci.yml is bare `python3` (e.g.
+        # decode-harness-unit-tests below invokes `python3 tests/...`); this
+        # workflow never uses `uv` anywhere else. `uv run python3 ...` is
+        # command-not-found (exit 127) on a runner that never installed uv —
+        # exactly the failure a real run of this job measured. Assert the
+        # convention directly rather than only through the script-cannot-run
+        # simulation below, since a sandbox that happens to have uv installed
+        # locally can mask this defect by finding a real interpreter anyway.
+        with open(CI_WORKFLOW) as fh:
+            workflow = yaml.safe_load(fh)
+        steps = workflow["jobs"]["semver-checks"]["steps"]
+        for step in steps:
+            run = step.get("run", "")
+            if "semver-checks-disclose.py" not in run:
+                continue
+            self.assertNotIn(
+                "uv run", run, f"step {step.get('name')!r} must use bare python3"
+            )
+            self.assertIn("python3 scripts/semver-checks-disclose.py", run)
+
+    def test_disclosure_step_still_warns_when_the_script_cannot_run(self) -> None:
+        # Extracted from the live workflow rather than restated here: a copy
+        # of the shell logic proves only that the copy behaves, and the two
+        # drift silently. This grades the actual step ci.yml will run.
+        #
+        # continue-on-error on this step hides a nonzero step conclusion from
+        # the job, so a step that dies invisibly (command-not-found, a
+        # missing script, a bad interpreter) must announce that itself. This
+        # simulates exactly that: `python3` on PATH always exits 127, standing
+        # in for "the interpreter or script never ran at all" — the failure
+        # measured on a real run, where the job stayed green with no
+        # annotation at all.
+        with open(CI_WORKFLOW) as fh:
+            workflow = yaml.safe_load(fh)
+        steps = workflow["jobs"]["semver-checks"]["steps"]
+        disclose_steps = [
+            step for step in steps if step.get("name") == "Disclose zero-check semver-checks runs"
+        ]
+        self.assertEqual(
+            len(disclose_steps), 1, "expected exactly one disclosure step in ci.yml"
+        )
+        script = disclose_steps[0]["run"]
+        self.assertIn("::warning::", script)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            fake_python3 = fake_bin / "python3"
+            fake_python3.write_text("#!/bin/sh\nexit 127\n")
+            fake_python3.chmod(fake_python3.stat().st_mode | stat.S_IEXEC)
+
+            step_script = root / "step.sh"
+            step_script.write_text(script)
+
+            env = dict(os.environ)
+            env["PATH"] = f"{fake_bin}:{env['PATH']}"
+            env["RUNNER_TEMP"] = str(root)
+            result = subprocess.run(
+                ["bash", str(step_script)],
+                text=True,
+                capture_output=True,
+                env=env,
+                cwd=REPO,
+            )
+            self.assertIn(
+                "::warning::",
+                result.stdout,
+                f"a script that never ran must still self-report; stdout={result.stdout!r} stderr={result.stderr!r}",
+            )
+            self.assertIn("did not run to completion", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_semver_checks_disclose.py
+++ b/tests/test_semver_checks_disclose.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Contract tests for the semver-checks zero-check disclosure instrument."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts" / "semver-checks-disclose.py"
+
+_CRATES = ("fann", "transport", "inference", "embed", "tune")
+
+
+def _healthy_fixture() -> str:
+    return "\n".join(
+        f"Checking lattice-{name} v0.7.1 -> v0.7.1 (no change; assume minor)\n"
+        " Checked [ 0.023s] 196 checks: 196 pass, 57 skip\n"
+        " Summary no semver update required"
+        for name in _CRATES
+    )
+
+
+def _zero_fixture() -> str:
+    return "\n".join(
+        f"Checking lattice-{name} v0.7.1 -> v0.8.0 (major change)\n"
+        " Checked [ 0.000s] 0 checks: 0 pass, 253 skip\n"
+        " Summary no semver update required"
+        for name in _CRATES
+    )
+
+
+def _unparseable_fixture() -> str:
+    return "error: could not locate baseline rustdoc JSON for lattice-fann\n"
+
+
+def _run(text: str, root: Path) -> tuple[subprocess.CompletedProcess, Path]:
+    captured = root / "captured.txt"
+    captured.write_text(text)
+    summary = root / "summary.md"
+    result = subprocess.run(
+        ["python3", str(SCRIPT), str(captured), "--summary-out", str(summary)],
+        text=True,
+        capture_output=True,
+    )
+    return result, summary
+
+
+class SemverChecksDiscloseTests(unittest.TestCase):
+    def test_selftest(self) -> None:
+        result = subprocess.run(
+            ["python3", str(SCRIPT), "--selftest"],
+            text=True,
+            capture_output=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("PASS: healthy", result.stdout)
+        self.assertIn("PASS: zero", result.stdout)
+        self.assertIn("PASS: unparseable", result.stdout)
+
+    def test_healthy_run_is_silent(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            result, summary = _run(_healthy_fixture(), root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(
+                summary.exists() and summary.read_text(),
+                "healthy run must write nothing to the summary",
+            )
+
+    def test_zero_checks_writes_loud_disclosure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            result, summary = _run(_zero_fixture(), root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(summary.exists())
+            text = summary.read_text()
+            self.assertIn("SEMVER: 0 checks executed", text)
+            self.assertIn("0.7.1 -> 0.8.0", text)
+            # 253 skip appears on every one of the five Checked lines above;
+            # the disclosure must report the SUMMED skip count (5 * 253),
+            # not one crate's line, or it would understate what was skipped.
+            self.assertIn(str(253 * len(_CRATES)), text)
+
+    def test_unparseable_output_is_neither_silent_nor_a_zero_claim(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            result, summary = _run(_unparseable_fixture(), root)
+            # Non-zero: a broken instrument must not exit clean, but must
+            # not be able to fail the enclosing job either (that's the
+            # workflow step's job via continue-on-error, not this script's).
+            self.assertEqual(result.returncode, 1, result.stderr)
+            self.assertTrue(summary.exists())
+            text = summary.read_text()
+            self.assertIn("could not read check output", text)
+            self.assertNotIn("0 checks executed", text)
+
+    def test_partial_execution_stays_silent(self) -> None:
+        # Sanity: any nonzero executed-check total is healthy, regardless of
+        # how many others were skipped alongside it.
+        text = (
+            "Checking lattice-fann v0.7.1 -> v0.8.0 (major change)\n"
+            " Checked [ 0.010s] 3 checks: 3 pass, 250 skip\n"
+            " Summary no semver update required"
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            result, summary = _run(text, root)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(summary.exists() and summary.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`cargo semver-checks` prints `Summary no semver update required` and exits 0 in two situations that are not the same thing: when it executed hundreds of checks and found no breaking change, and when it executed **zero** checks and therefore found nothing. The second happens when the local version has moved ahead of the published baseline in a way the tool reads as an assumed-major change, at which point it skips every check. Both print the same summary line and both exit 0. Only the executed-check count distinguishes them.

That is not hypothetical here. This repository's workspace version is `0.8.0` while the published baseline is `0.7.1`, so the gate is currently in the second state for every crate. On this PR's own CI run, the gate action printed `Summary no semver update required` five times, once per crate, and the job went green having verified nothing.

## What this adds

Three steps in the `semver-checks` job, all `continue-on-error`, placed after the existing gate action. **The gate action itself is unchanged — zero lines removed.**

1. Confirm `cargo-semver-checks` is on `PATH`, installing it directly if the action did not leave it there.
2. Re-run the check for one crate, capturing real output to a file.
3. Parse that output and, when the executed-check count is zero, emit a disclosure to both the step summary and a workflow annotation.

An observer must never be able to fail the job it only reports on, hence `continue-on-error` throughout. The corollary is that it must also never be able to vanish silently, so the step emits its own warning if the script cannot be invoked at all.

## Scope of the re-run

The re-run checks `lattice-transport` alone rather than repeating the gate's five-package check. The condition being detected is workspace-global by construction: every crate declares `version.workspace = true`, so a version bump voids the gate for all five simultaneously through that single shared value, and one crate's real `Checked N checks` line answers the question for the rest.

`lattice-transport` and `lattice-fann` are the workspace's leaf crates. Measured with a warm target directory, which is the state this step runs in since the gate above already built rustdoc JSON for all five crates in the same job: `lattice-transport` finished in ~0.75-0.79s versus `lattice-fann`'s ~1.0-1.2s.

Because the observed set is now narrower than the workspace, the disclosure states its own scope in its own text: which crate it observed directly, and that the rest are inferred from the shared workspace version, with the inference stated as an inference. If the workspace ever moves to per-crate versions that inference becomes silently false, and this sentence is the only thing that tells a reader the instrument's basis has expired. It is asserted by a test so a later tidy-up cannot quietly drop it.

## Evidence from this PR's own run

The instrument is exercised end-to-end by its own change. From the completed `semver-checks` job, read back through the annotations API:

```
[warning] **SEMVER: 0 checks executed** (0.7.1 -> 0.8.0; a 0.x minor bump reads as an
assumed-major change, so cargo-semver-checks skipped all 254 checks). A green result here
is NOT coverage. It becomes coverage again once the bumped version is published and becomes
the crates.io baseline. Observed `lattice-transport` directly; the other workspace crates
are inferred to be in the same state because they share one `[workspace.package] version`.
```

The job's conclusion is `success`, which is the intended behaviour: the disclosure reports, it does not gate.

The annotation channel is used deliberately rather than the step summary alone. Measured on an earlier run of this branch: the check run's `output.summary` field reads `null` and the step summary does not appear in the job log, so a disclosure living only there cannot be read back by any automated check and is invisible to someone reading a green check list. The annotations endpoint does serve its content back. Both carriers are written; only one of them can be cited.

## Cost

The re-run is a real second invocation, not a free read of cached state. Measured on a full run of this branch when it checked all five crates: the gate action took 72s and the re-run took 154s. Narrowing to one crate is what that measurement bought.

## Tests

19 tests in `tests/test_semver_checks_disclose.py`, run by the same bare `python3` convention every other Python step in this workflow uses. Fixtures are verbatim captured tool output rather than hand-written approximations, including one carrying real ANSI colour codes, because output described in prose gets re-invented by whatever reads it.

Three of the tests guard the workflow file itself rather than the parser: that the capture step is scoped to one crate, that the disclosure step is told which crate that is, and that the disclosure text names the crate and the inference basis.

## Self-retiring

This disclosure fires only while the executed-check count is zero. Once the bumped version is published and becomes the crates.io baseline, the gate regains its reach, the count stops being zero, and the step goes silent on its own. Nothing needs to be removed.
