### PR TITLE
docs: add v0.8.0 release notes

### DIFF
--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,0 +1,75 @@
+# lattice v0.8.0
+
+Minor release. The `/v1/chat/completions` contract shared by both HTTP binaries now accepts
+an inline image on a user message and routes it through the Metal multimodal path, and one
+Metal vision entry point leaves the public API.
+
+The version bump is a minor rather than a patch because of that second item: a previously
+public function is no longer public. Everything else in this release is additive.
+
+## Breaking changes
+
+`qwen35_vit_forward_metal` is no longer part of the public API. It was re-exported from
+`crates/inference`'s vision module and is now crate-internal, renamed
+`qwen35_vit_forward_metal_with_cancel` and carrying an additional cancellation callback so a
+vision forward pass can be interrupted rather than run to completion after its request is
+gone.
+
+Callers outside the crate had no way to supply that callback, and the pre-existing entry
+point offered no way to cancel, so the two could not be reconciled by keeping both. There is
+no in-tree replacement for external callers: driving the Metal ViT directly is no longer a
+supported surface, and vision work is reached through the serve path described below.
+
+## New: inline image content parts on chat completions
+
+A user message may now carry one image part alongside its text, supplied as a `data:` URI.
+`image/png` and `image/jpeg` are decoded; the decoded payload is capped at 48,000 bytes
+(`MAX_DECODED_IMAGE_BYTES`), with the base64 length bounded correspondingly so an oversized
+request is refused before it is decoded rather than after.
+
+Admitted images go through the same multimodal path the engine already used: a vision weight
+inventory preflight that checks the exact fp16 or Q4 tensors the model needs, lazy loading of
+those weights, bounded preprocessing, the Metal ViT, the CPU merger, prompt-position
+construction, and multimodal decode. A model without vision weights is not silently degraded
+to text.
+
+Everything outside that narrow shape fails closed with a 400 and an explicit code rather than
+being partially honoured:
+
+- `unsupported_image_url_scheme` — a remote URL rather than a `data:` URI. The server does
+  not fetch images.
+- `invalid_image_role` — an image on a message that is not a user message.
+- `multiple_images_unsupported` — more than one image part on a request.
+- `vision_unsupported` — a text-only model.
+- `invalid_image` — a payload that is not decodable as a supported format, or exceeds the
+  size cap.
+
+Two request options are refused in combination with an image rather than being silently
+dropped: `stream: true`, and `logprobs`. In both cases the image request is rejected, so a
+client never receives a response that quietly ignored the image it sent.
+
+## Fixes and internal changes
+
+- The crates.io publish-verification recipe in `CLAUDE.md` was corrected. The registry
+  rejects API requests that do not identify the caller, and the previous recipe's failure
+  mode rendered that refusal as an absent version, which reads as "this release was never
+  published". The corrected recipe sends a `User-Agent`, distinguishes an error object from a
+  missing version, and runs a control crate first so a refusal cannot be mistaken for an
+  answer.
+- The CI semver gate now discloses when it executes zero checks. Previously a run that
+  skipped every check and a run that passed every check both reported that no semver update
+  was required and both exited zero, so a version bump could switch the gate off across the
+  repository without any signal. The gate now reports the executed-check count.
+
+## Upgrading
+
+Most callers upgrade with no change. Two cases need attention.
+
+If you call `qwen35_vit_forward_metal` from outside `lattice-inference`, that call no longer
+compiles. There is no drop-in replacement; use the serve path.
+
+If you send `/v1/chat/completions` requests built by a client that emits OpenAI-style content
+part arrays, requests that previously carried image parts and were ignored or rejected
+generically will now either be served or refused with one of the specific codes above. That
+is a behaviour change on inputs that were already outside the previous contract, so it does
+not affect text-only traffic.


### PR DESCRIPTION
Adds `docs/releases/v0.8.0.md`, the release notes for the current workspace version. Docs only; no code changes.

`docs/releases/` currently stops at v0.7.2, so main declares 0.8.0 with no notes describing it. The three commits between v0.7.2 and main are the inline image content part support, the crates.io publish-verification recipe correction, and the semver-gate zero-check disclosure.

The notes lead with the breaking change, since that is what makes this a minor rather than a patch release under 0.x: `qwen35_vit_forward_metal` was a public re-export from the vision module and is now crate-internal, renamed `qwen35_vit_forward_metal_with_cancel` and taking a cancellation callback. External callers had no way to supply that callback, so there is no drop-in replacement, and the Upgrading section says so rather than implying one exists.

Claims in the notes were read from source rather than from PR descriptions:

- the 48,000-byte decoded cap and the derived base64 bound, `crates/inference/src/serve/contract.rs`
- the accepted media types `image/png` and `image/jpeg`, same file
- the fail-closed rejection codes `unsupported_image_url_scheme`, `invalid_image_role`, `multiple_images_unsupported`, `vision_unsupported`, `invalid_image`
- the refusal of `stream: true` and of `logprobs` in combination with an image, `contract.rs:494-498`. The `logprobs` half was found while verifying the streaming claim and is documented here for that reason.
