### PR TITLE
docs(releases): correct v0.8.0 public API claim

### DIFF
--- a/docs/releases/v0.8.0.md
+++ b/docs/releases/v0.8.0.md
@@ -1,24 +1,11 @@
 # lattice v0.8.0
 
 Minor release. The `/v1/chat/completions` contract shared by both HTTP binaries now accepts
-an inline image on a user message and routes it through the Metal multimodal path, and one
-Metal vision entry point leaves the public API.
+an inline image on a user message and routes it through the Metal multimodal path.
 
-The version bump is a minor rather than a patch because of that second item: a previously
-public function is no longer public. Everything else in this release is additive.
-
-## Breaking changes
-
-`qwen35_vit_forward_metal` is no longer part of the public API. It was re-exported from
-`crates/inference`'s vision module and is now crate-internal, renamed
-`qwen35_vit_forward_metal_with_cancel` and carrying an additional cancellation callback so a
-vision forward pass can be interrupted rather than run to completion after its request is
-gone.
-
-Callers outside the crate had no way to supply that callback, and the pre-existing entry
-point offered no way to cancel, so the two could not be reconciled by keeping both. There is
-no in-tree replacement for external callers: driving the Metal ViT directly is no longer a
-supported surface, and vision work is reached through the serve path described below.
+The version bump is a minor rather than a patch because the release adds a capability. The
+public API is unchanged: nothing was removed, renamed, or given a different signature, and
+no source change is required to upgrade.
 
 ## New: inline image content parts on chat completions
 
@@ -50,6 +37,11 @@ client never receives a response that quietly ignored the image it sent.
 
 ## Fixes and internal changes
 
+- The Metal vision forward pass is now cancellation-aware internally, so a vision forward
+  can be interrupted rather than run to completion after the request that asked for it is
+  gone. This is an internal change: serving calls a crate-private cancellation-aware entry
+  point, while the public `qwen35_vit_forward_metal` keeps its path and signature and
+  delegates to that sibling without ever requesting cancellation.
 - The crates.io publish-verification recipe in `CLAUDE.md` was corrected. The registry
   rejects API requests that do not identify the caller, and the previous recipe's failure
   mode rendered that refusal as an absent version, which reads as "this release was never
@@ -63,10 +55,7 @@ client never receives a response that quietly ignored the image it sent.
 
 ## Upgrading
 
-Most callers upgrade with no change. Two cases need attention.
-
-If you call `qwen35_vit_forward_metal` from outside `lattice-inference`, that call no longer
-compiles. There is no drop-in replacement; use the serve path.
+Every caller upgrades with no source change.
 
 If you send `/v1/chat/completions` requests built by a client that emits OpenAI-style content
 part arrays, requests that previously carried image parts and were ignored or rejected


### PR DESCRIPTION
The v0.8.0 release notes stated that `qwen35_vit_forward_metal` left the public API and that
external calls to it no longer compile. Both statements are wrong.

Verified against the published `lattice-inference` 0.8.0 crate from crates.io, which is the
artifact a user actually installs:

- The export chain is intact: `pub mod vision` to `pub mod qwen35_vit_metal` to an ungated
  `pub fn qwen35_vit_forward_metal`.
- The declaration is character-for-character identical to 0.7.2's:
  `pub fn qwen35_vit_forward_metal(weights: &Qwen35VisionWeights, cfg: &VisionModelConfig, pixel_values: &[f32], grid: GridThw) -> Result<Vec<f32>, VisionError>`
- What changed is internal: the function now delegates to a crate-private
  `qwen35_vit_forward_metal_with_cancel` and passes a closure that never cancels.

So there is no breaking change in 0.8.0. The minor version is still correct, because the
release adds a capability.

This PR removes the breaking-changes section, states plainly that the public API is unchanged,
and records the cancellation work under internal changes. The remaining claims in the notes
(the 48,000-byte decoded cap, the two accepted media types, the five refusal codes, and the
stream/logprobs refusals) were each re-checked against the same published crate and hold, with
a negative control confirming the check can fail.

No GitHub release exists for v0.8.0 yet, so the corrected text is what will be published as
the release body.