### PR TITLE
fix(bench): resolve criterion baseline IDs from benchmark metadata

### DIFF
--- a/scripts/bench-gate.sh
+++ b/scripts/bench-gate.sh
@@ -35,25 +35,49 @@ baseline=".cache/perf-baselines/$arch"
         exit 1
     }
 
+# Build a full_id -> directory_name map from the stored baseline metadata.
+# Criterion's directory_name differs from full_id for three-level IDs such as
+# group/function/value (e.g. tier_prepared_query/int8_query_per_call/1000 is
+# stored at tier_prepared_query/int8_query_per_call_1000). Reconstructing the
+# path by string manipulation silently dropped those baselines; deriving the
+# mapping from criterion's own benchmark.json avoids re-implementing its naming
+# rule and makes the script resilient to future criterion changes.
+baseline_id_map="$root/baseline-id-map.json"
+find "$baseline" -type f -name benchmark.json -print0 |
+    xargs -0 jq -s 'map({(.full_id): .directory_name}) | add' \
+        >"$baseline_id_map"
+
+copy_baseline_for_target() {
+    local bench_list="$1"
+    local target_root="$2"
+    local skipped=0
+    local bench
+    while IFS= read -r bench; do
+        [[ -n "$bench" ]] || continue
+        local dir
+        dir=$(jq -r --arg id "$bench" '.[$id] // empty' "$baseline_id_map")
+        if [[ -z "$dir" ]]; then
+            echo "bench-gate: skipping $bench: no stored baseline"
+            skipped=$((skipped + 1))
+            continue
+        fi
+        mkdir -p "$target_root/$(dirname "$dir")"
+        cp -R "$baseline/$dir" "$target_root/$dir"
+    done <"$bench_list"
+    echo "bench-gate: $target_root skipped $skipped benchmarks"
+}
+
 cargo bench -p lattice-inference --bench elementwise_cpu_bench -- --list \
     >"$root/inference-bench-list"
 sed -n 's/: benchmark$//p' "$root/inference-bench-list" \
     >"$root/inference-bench-ids"
-while IFS= read -r bench; do
-    [[ -d "$baseline/$bench" ]] || continue
-    mkdir -p "$inference_root/$(dirname "$bench")"
-    cp -R "$baseline/$bench" "$inference_root/$bench"
-done <"$root/inference-bench-ids"
+copy_baseline_for_target "$root/inference-bench-ids" "$inference_root"
 
 cargo bench -p lattice-embed --bench simd -- --list \
     >"$root/embed-bench-list"
 sed -n 's/: benchmark$//p' "$root/embed-bench-list" \
     >"$root/embed-bench-ids"
-while IFS= read -r bench; do
-    [[ -d "$baseline/$bench" ]] || continue
-    mkdir -p "$embed_root/$(dirname "$bench")"
-    cp -R "$baseline/$bench" "$embed_root/$bench"
-done <"$root/embed-bench-ids"
+copy_baseline_for_target "$root/embed-bench-ids" "$embed_root"
 
 bench_quiet_checkpoint "bench-gate: before measurements"
 CRITERION_HOME="$inference_root" cargo bench \


### PR DESCRIPTION
`scripts/bench-gate.sh` seeds each target's `CRITERION_HOME` by reading the benchmark IDs a bench binary declares (`cargo bench -- --list`) and copying the matching stored baseline out of the `perf-baselines` branch. It located each one by treating the ID as a filesystem path.

A Criterion benchmark ID is not a filesystem path. `--list` prints Criterion's `full_id`; the directory Criterion writes is its `directory_name`. For a two-level ID (`group/value`) the two are identical, which is why this held for most of the suite. For a three-level ID (`group/function/value`) Criterion joins the function and the value with an underscore: `full_id` `tier_prepared_query/int8_query_per_call/1000` is stored at `tier_prepared_query/int8_query_per_call_1000`.

So `[[ -d "$baseline/$bench" ]]` could never match a three-level ID, and the loop's `|| continue` dropped it with no output. The `tier_prepared_query` group in `crates/embed/benches/simd.rs` declares six such IDs, and both published arches carry six underscore-spelled directories each.

## Change

Build a `full_id -> directory_name` map by walking the stored `benchmark.json` metadata in the baseline tree, then look each declared ID up in that map. The naming rule is read out of Criterion's own output rather than re-implemented in the shell, so a future change to how Criterion joins those components cannot silently reintroduce this.

Genuinely missing baselines — a newly added benchmark with nothing published yet — are still skipped, but each one is now named and a per-target skip count is printed. The silent skip is what let this survive: an honest skip that prints nothing is indistinguishable from full coverage.

Pass/fail policy is unchanged. Whether a missing baseline should fail the gate is a separate question and is not decided here.

Both target loops are converted; they were independent copies of the same logic.

## Verification

Fixture trees with the underscore-spelled directories and their `benchmark.json` files, exercising the copy logic directly:

- Patched: 3 of 3 inference IDs resolved, 6 of 13 embed IDs resolved (the six three-level ones), the remaining 7 skipped and named — the fixture deliberately omits their baselines.
- Reverted to the previous `[[ -d ... ]]` test against the same fixture: 0 of 13 embed IDs resolved, all 13 skipped, the six three-level IDs among them.
- One fabricated ID with no stored baseline is reported by name, the skip count increments, and the loop continues rather than aborting.
- `bash -n scripts/bench-gate.sh` passes; `tests/test_bench_targets.py` and `tests/test_bench_measurement_supervision.py` pass (68 tests, 169 subtests).

An empty baseline tree resolves nothing and reports every ID as skipped, which is visible rather than silent.

## Reach

This script's only caller is `make bench-gate`. No workflow invokes it, and `arch` resolves to `aarch64-darwin` on an Apple silicon machine while `perf-baselines` publishes only `aarch64-linux` and `x86_64-linux` — so the script currently exits at its `no baseline for $arch` guard before reaching this code. The defect is real and the fix is correct, but it is latent until either a darwin baseline is published or the gate runs on a Linux host. Filed as a separate question rather than resolved here.

No code under `crates/inference/src/` or `crates/embed/src/` is touched, so no bench-compare A/B disposition applies. No timed measurement was run.
