### PR TITLE
fix(embed): use pure-Rust blake3 to drop C toolchain dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rayon = "1.10"
 
 # Crypto / Hashing
 sha2 = "0.10"
-blake3 = "1.5"
+blake3 = { version = "1.5", default-features = false, features = ["std", "pure"] }
 
 # Database (optional, for caching)
 rusqlite = { version = "0.35", features = ["bundled"] }


### PR DESCRIPTION
## Summary
lattice-embed's mandatory `blake3` dependency used default features, which select the NEON C-intrinsics build on little-endian AArch64, so AArch64 cross-builds fail without a C compiler even under `--no-default-features`. Switch the workspace dependency to `default-features = false, features = ["std", "pure"]`, selecting the portable Rust implementation on every target. Hash output is identical between blake3's pure and SIMD/C paths. `Cargo.lock` is unchanged (same resolved blake3 1.8.5; feature selection only).

Red/green check:
```
CC_aarch64_unknown_linux_gnu=/usr/bin/false \
  cargo check -p lattice-embed --no-default-features \
  --target aarch64-unknown-linux-gnu --locked
```
fails on `c/blake3_neon.c` before this change and passes after it. Full `cargo test -p lattice-embed`: 325 passed, 0 failed. `cargo clippy --workspace -- -D warnings` clean.

## bench-compare disposition
Structural waiver, manifest-change burden: this is a dependency-feature change, so the question is whether any declared bench target executes blake3. blake3 is compiled only into `lattice-embed` (sole `blake3 = { workspace = true }` consumer), so the search population is embed's five declared bench targets (`simd_bench`, `simd`, `embeddings`, `simsimd_comparison`, `simd_opt_bench`). The only bench code path into blake3-bearing code is `cached_embedding_delegate` in `benches/simd.rs`, which constructs `CachedEmbeddingService::new(_, 0)`; with capacity 0 `cache_and_embed` takes the disabled-cache fast path (`crates/embed/src/service/cached.rs:117-123`) and returns before `compute_key` runs, so no bench group executes blake3. Residual risk: production cache-key hashing on AArch64 moves from the NEON C path to pure Rust and no bench measures that path — the change is unmeasured, not known-neutral; the portability guarantee is the accepted trade.

Fixes #1299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Scope note (added after independent dependency-graph review)
The `pure` feature narrows the claim as follows: on the failing AArch64 cross-build path it suppresses blake3's NEON C compile branch (the fix this PR targets), but blake3's build script still declares `cc` as a build-dependency and still probes for a C compiler on x86 before selecting Rust intrinsics — so this is "avoid blake3 C compilation on the affected AArch64 path", not a repository-wide no-C-toolchain guarantee (the default embed graph also reaches `ring`). On x86 the `pure` feature also switches blake3 from its asm/AVX-512-capable backend to Rust SSE2/SSE4.1/AVX2 intrinsics; no benchmark of that path was run here, so no magnitude is claimed — the embed cache hash path is process-local keying where a slower hash costs latency, not correctness.
