### PR TITLE
feat(tune): wire GDN LoRA into train_micro_lora; scope alloc-test counters per-thread

### DIFF
--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -85,6 +85,11 @@ name = "layer23_golden_bridge"
 path = "tests/layer23_golden_bridge.rs"
 required-features = ["train-backward"]
 
+[[test]]
+name = "gdn_lora_wiring"
+path = "tests/gdn_lora_wiring.rs"
+required-features = ["train-backward"]
+
 [dev-dependencies]
 tempfile.workspace = true
 proptest.workspace = true

--- a/crates/tune/docs/lora-core.md
+++ b/crates/tune/docs/lora-core.md
@@ -467,9 +467,29 @@ After preflight, the trainer captures the frozen prefix activation entering
 `first_layer` and the matching RoPE tables. It checks every allocation product
 before creating A/B buffers. A is deterministically initialized from
 `U(-1/sqrt(hidden), +1/sqrt(hidden))`; B starts at zero, so the initial adapter
-does not perturb frozen-model output. The public surface allocates slots only
+does not perturb frozen-model output. `train_micro_lora` allocates slots only
 for GQA `q_proj` and `v_proj`; GDN layers run the preserved no-LoRA path so
 their backward derivatives still reach preceding GQA layers.
+
+`train_micro_lora_with_gdn(model, pairs, config, train_gdn)` is the same
+trainer with one added switch. With `train_gdn: false` it reproduces
+`train_micro_lora` exactly, including RNG stream position — GDN LoRA slot
+initialization must not consume from the shared RNG in that mode, or GQA A
+factors would diverge between the two entry points for identical inputs.
+With `train_gdn: true`, every GDN layer inside the trainable window
+(`config.first_layer..=last_layer`) also gets a slot: the five
+[`GdnLoraParams`](#gdnloraparams) projections are initialized (A random, B
+zero, same rationale as the GQA slots), trained through the same forward/
+backward/Adam loop via `apply_gdn_adam_updates`, and surfaced in the
+returned adapter's `target_modules` and layers. `train_micro_lora` has no
+config field for this switch — a separate function avoids a breaking
+addition to the publicly, exhaustively constructible `MicroLoraConfig`
+(`cargo-semver-checks`'s `constructible_struct_adds_field` gate covers this
+crate). GDN and GQA slots share the trainer's single `learning_rate`; #884's
+held-out NLL run flagged this as a leading suspect for the GDN arm's
+regression against the untrained baseline and marked the shared-LR recipe
+unvalidated pending a rerun with revised hyperparameters — wiring alone does
+not certify training quality.
 
 The library loop intentionally mirrors the training binary's private CPU
 forward/backward and Adam sequence. Its library implementation uses the

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -14,8 +14,8 @@ use lattice_inference::model::qwen35::Qwen35Model;
 use crate::error::{Result, TuneError};
 use crate::lora::train_core::{
     AdamConfig, Dims, GdnDims, GdnLoraParams, Head, LayerW, LoraParams, MixerKind, SeqCtx,
-    SlotLayout, TapeGeometry, TrainCtx, apply_adam_updates, forward_full, nll_and_grads, rand_fill,
-    shifted,
+    SlotLayout, TapeGeometry, TrainCtx, apply_adam_updates, apply_gdn_adam_updates, forward_full,
+    nll_and_grads, rand_fill, shifted,
 };
 use crate::lora::{AdamState, LoraAdapter, LoraConfig, LoraLayer};
 
@@ -236,6 +236,39 @@ pub fn train_micro_lora(
     pairs: &[TrainingPair],
     config: &MicroLoraConfig,
 ) -> Result<LoraAdapter> {
+    train_micro_lora_impl(model, pairs, config, false)
+}
+
+/// Train GQA `q_proj`/`v_proj` LoRA weights, and — when `train_gdn` is
+/// `true` — also train the five GDN LoRA projections (`in_proj_qkv`,
+/// `in_proj_z`, `in_proj_b`, `in_proj_a`, `out_proj`) on GatedDeltaNet
+/// layers inside the trainable window (`config.first_layer..=last_layer`).
+/// With `train_gdn: false` this reproduces [`train_micro_lora`]'s
+/// GQA-only, GDN-frozen behavior exactly.
+///
+/// A separate function rather than a new [`MicroLoraConfig`] field:
+/// `MicroLoraConfig` is publicly, exhaustively constructible and
+/// `cargo-semver-checks`' `constructible_struct_adds_field` gate covers
+/// `lattice-tune`, so adding a field to it would be a breaking change
+/// without an available major-version bump this cycle (the same
+/// constraint that kept `min_p` off `SamplingConfig`/`GenerateConfig` in
+/// `lattice-inference`).
+/// See [`docs/lora-core.md`](../../docs/lora-core.md#train_micro_lora) for the tape, limits, and implementation rationale.
+pub fn train_micro_lora_with_gdn(
+    model: &Qwen35Model,
+    pairs: &[TrainingPair],
+    config: &MicroLoraConfig,
+    train_gdn: bool,
+) -> Result<LoraAdapter> {
+    train_micro_lora_impl(model, pairs, config, train_gdn)
+}
+
+fn train_micro_lora_impl(
+    model: &Qwen35Model,
+    pairs: &[TrainingPair],
+    config: &MicroLoraConfig,
+    train_gdn: bool,
+) -> Result<LoraAdapter> {
     // Validate caller-controlled bounds before model access or allocation.
     let vocab_size = model.config().vocab_size;
     let num_hidden_layers = model.config().num_hidden_layers;
@@ -290,6 +323,7 @@ pub fn train_micro_lora(
     let top_layer = num_hidden_layers - 1;
     let mut layers: Vec<LayerW> = Vec::new();
     let mut slot_layers: Vec<usize> = Vec::new();
+    let mut gdn_slot_layers: Vec<usize> = Vec::new();
     for layer_idx in materialized_layer_range(first_layer, top_layer) {
         let trainable = layer_idx <= trainable_last;
         if let Some((w_q, w_k, w_v, w_o, q_norm, k_norm, pre, post, gate, up, down)) =
@@ -319,6 +353,13 @@ pub fn train_micro_lora(
                 lora_slot,
             });
         } else if let Some((gdn, pre, post, gate, up, down)) = model.gdn_layer_weights(layer_idx) {
+            let lora_slot = if train_gdn && trainable {
+                let slot = gdn_slot_layers.len();
+                gdn_slot_layers.push(layer_idx);
+                Some(slot)
+            } else {
+                None
+            };
             layers.push(LayerW {
                 kind: MixerKind::Gdn,
                 w_q: &[],
@@ -333,7 +374,7 @@ pub fn train_micro_lora(
                 w_gate: gate,
                 w_up: up,
                 w_down: down,
-                lora_slot: None,
+                lora_slot,
             });
         } else {
             return Err(TuneError::Validation(format!(
@@ -347,6 +388,7 @@ pub fn train_micro_lora(
             "no GQA layers in the configured range — nothing to train".to_string(),
         ));
     }
+    let num_gdn_slots = gdn_slot_layers.len();
 
     // Capture frozen-prefix state and RoPE tables after input validation.
     let mut caches: Vec<SeqCtx> = Vec::with_capacity(pairs.len());
@@ -409,13 +451,26 @@ pub fn train_micro_lora(
         })
         .collect();
 
+    // Initialize GDN A uniformly and B to zero (same rationale as the GQA
+    // loras above: the initial adapter is a no-op), continuing the same rng
+    // stream position rather than reseeding it, matching train_grad_full's
+    // zero_b_gdn_loras call convention.
+    let mut gdn_loras: Vec<GdnLoraParams> = (0..num_gdn_slots)
+        .map(|_| {
+            GdnLoraParams::shaped(
+                rank,
+                dims.hidden,
+                &gdn_dims,
+                |n| rand_fill(&mut rng, n, init_amp),
+                |n| vec![0.0; n],
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+
     let mut adam = AdamState::new();
     let (beta1, beta2, eps_adam) = (0.9f32, 0.999f32, 1e-8f32);
     let lr = config.learning_rate;
 
-    // This public entry point trains GQA slots only; GDN stays on the frozen path.
-    let gdn_loras: Vec<GdnLoraParams> = Vec::new();
-    let gdn_slot_layers: Vec<usize> = Vec::new();
     let train_ctx = TrainCtx::try_new(
         TapeGeometry::new(&dims, &gdn_dims, &cfg),
         rank,
@@ -426,10 +481,10 @@ pub fn train_micro_lora(
     for step in 1..=config.steps {
         let ctx = &caches[(step - 1) % caches.len()];
         let fwd = forward_full(ctx, &layers, &loras, &gdn_loras, &head, &train_ctx)?;
-        let (_nll, _n, grads, _gdn_grads) =
-            nll_and_grads(&fwd, &layers, &loras, &head, &train_ctx)?;
+        let (_nll, _n, grads, gdn_grads) = nll_and_grads(&fwd, &layers, &loras, &head, &train_ctx)?;
 
         apply_adam_updates(&mut adam, &mut loras, &grads, &train_ctx);
+        apply_gdn_adam_updates(&mut adam, &mut gdn_loras, &gdn_grads, &train_ctx);
     }
 
     // Assemble LoraAdapter from trained slot params.
@@ -456,10 +511,77 @@ pub fn train_micro_lora(
             },
         );
     }
+    let mut target_modules = vec!["q_proj".to_string(), "v_proj".to_string()];
+    if num_gdn_slots > 0 {
+        target_modules.extend([
+            "in_proj_qkv".to_string(),
+            "in_proj_z".to_string(),
+            "in_proj_b".to_string(),
+            "in_proj_a".to_string(),
+            "out_proj".to_string(),
+        ]);
+        for (s, &li) in gdn_slot_layers.iter().enumerate() {
+            let g = &gdn_loras[s];
+            adapter_layers.insert(
+                (li, "in_proj_qkv".to_string()),
+                LoraLayer {
+                    a: g.a_qkv.clone(),
+                    b: g.b_qkv.clone(),
+                    d_in: dims.hidden,
+                    d_out: gdn_dims.qkv_dim,
+                    rank,
+                },
+            );
+            adapter_layers.insert(
+                (li, "in_proj_z".to_string()),
+                LoraLayer {
+                    a: g.a_z.clone(),
+                    b: g.b_z.clone(),
+                    d_in: dims.hidden,
+                    d_out: gdn_dims.output_dim,
+                    rank,
+                },
+            );
+            adapter_layers.insert(
+                (li, "in_proj_b".to_string()),
+                LoraLayer {
+                    a: g.a_b.clone(),
+                    b: g.b_b.clone(),
+                    d_in: dims.hidden,
+                    // beta is projected per VALUE head (matches the shipping
+                    // gdn_fused forward and the f16 weight loader), not per
+                    // key head (#792).
+                    d_out: gdn_dims.value_heads,
+                    rank,
+                },
+            );
+            adapter_layers.insert(
+                (li, "in_proj_a".to_string()),
+                LoraLayer {
+                    a: g.a_a.clone(),
+                    b: g.b_a.clone(),
+                    d_in: dims.hidden,
+                    // alpha is likewise projected per VALUE head.
+                    d_out: gdn_dims.value_heads,
+                    rank,
+                },
+            );
+            adapter_layers.insert(
+                (li, "out_proj".to_string()),
+                LoraLayer {
+                    a: g.a_out.clone(),
+                    b: g.b_out.clone(),
+                    d_in: gdn_dims.output_dim,
+                    d_out: dims.hidden,
+                    rank,
+                },
+            );
+        }
+    }
     let lora_config = LoraConfig {
         rank,
         alpha,
-        target_modules: vec!["q_proj".to_string(), "v_proj".to_string()],
+        target_modules,
     };
     LoraAdapter::new(lora_config, adapter_layers)
 }

--- a/crates/tune/tests/gdn_lora_wiring.rs
+++ b/crates/tune/tests/gdn_lora_wiring.rs
@@ -1,0 +1,187 @@
+//! Functional smoke test for issue #884: `train_micro_lora_with_gdn` must
+//! actually populate GDN LoRA slots (the pre-fix code left `GdnLoraParams`
+//! permanently empty — see `crates/tune/src/lora/train.rs`), and
+//! `train_micro_lora`/`train_micro_lora_with_gdn(.., train_gdn: false)` must
+//! remain byte-identical to the pre-#884 GQA-only behavior.
+//!
+//! Not run in CI: requires a real Qwen3.5-0.8B checkpoint on disk at
+//! `$HOME/.lattice/models/qwen3.5-0.8b` (or `LATTICE_MODEL_DIR`), matching
+//! the existing convention in `bench_backward_737.rs`.
+use std::path::PathBuf;
+
+use lattice_inference::model::qwen35::Qwen35Model;
+use lattice_tune::lora::train::{
+    MicroLoraConfig, TrainingPair, train_micro_lora, train_micro_lora_with_gdn,
+};
+
+fn model_dir() -> PathBuf {
+    std::env::var("LATTICE_MODEL_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            std::env::var("HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(".lattice")
+                .join("models")
+                .join("qwen3.5-0.8b")
+        })
+}
+
+/// Deterministic xorshift64 token generator (mirrors `bench_backward_737.rs`).
+fn synth_pairs(vocab: usize, n_pairs: usize, seq_len: usize) -> Vec<TrainingPair> {
+    let mut state: u64 = 0x1234_5678_9abc_def1;
+    let mut next = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    (0..n_pairs)
+        .map(|_| {
+            let tokens: Vec<u32> = (0..seq_len)
+                .map(|_| (next() % vocab as u64) as u32)
+                .collect();
+            TrainingPair {
+                tokens,
+                completion_start: seq_len / 2,
+            }
+        })
+        .collect()
+}
+
+fn gdn_config() -> MicroLoraConfig {
+    MicroLoraConfig {
+        rank: 4,
+        alpha: 8.0,
+        // Spans layers 19..=23: GQA(19), GDN(20,21,22), GQA(23) on the
+        // Qwen3.5-0.8B [linear,linear,linear,full] hybrid layout — the same
+        // window `bench_backward_737.rs` uses to exercise every mixer kind.
+        first_layer: 19,
+        last_layer: Some(23),
+        steps: 1,
+        learning_rate: 1e-3,
+        max_seq_len: 64,
+    }
+}
+
+const GDN_MODULES: [&str; 5] = [
+    "in_proj_qkv",
+    "in_proj_z",
+    "in_proj_b",
+    "in_proj_a",
+    "out_proj",
+];
+
+#[test]
+#[ignore = "requires a real Qwen3.5-0.8B checkpoint on disk; run explicitly for #884 verification"]
+fn train_gdn_false_matches_train_micro_lora_exactly() {
+    let model = Qwen35Model::from_safetensors(&model_dir())
+        .unwrap_or_else(|e| panic!("failed to load model: {e}"));
+    let vocab = model.config().vocab_size;
+    let pairs = synth_pairs(vocab, 2, 48);
+    let config = gdn_config();
+
+    let baseline = train_micro_lora(&model, &pairs, &config).expect("train_micro_lora");
+    let opted_out = train_micro_lora_with_gdn(&model, &pairs, &config, false)
+        .expect("train_micro_lora_with_gdn(false)");
+
+    assert_eq!(
+        baseline.config().target_modules,
+        opted_out.config().target_modules,
+        "train_gdn=false must keep the GQA-only target_modules list"
+    );
+    for module in GDN_MODULES {
+        assert!(
+            !baseline.has_adapter(20, module) && !opted_out.has_adapter(20, module),
+            "neither path should carry a GDN adapter when train_gdn is off"
+        );
+    }
+    for ((layer, module), layer_w) in baseline.layers() {
+        let other = opted_out
+            .layers()
+            .get(&(*layer, module.clone()))
+            .unwrap_or_else(|| panic!("opted_out adapter missing ({layer}, {module})"));
+        assert_eq!(
+            layer_w.a, other.a,
+            "layer {layer} module {module}: A factors diverged between train_micro_lora and \
+             train_micro_lora_with_gdn(.., false) — GDN init must not perturb the GQA rng stream"
+        );
+        assert_eq!(
+            layer_w.b, other.b,
+            "layer {layer} module {module}: B factors diverged between train_micro_lora and \
+             train_micro_lora_with_gdn(.., false)"
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires a real Qwen3.5-0.8B checkpoint on disk; run explicitly for #884 verification"]
+fn train_gdn_true_populates_and_trains_all_five_gdn_modules() {
+    let model = Qwen35Model::from_safetensors(&model_dir())
+        .unwrap_or_else(|e| panic!("failed to load model: {e}"));
+    let vocab = model.config().vocab_size;
+    let pairs = synth_pairs(vocab, 2, 48);
+    let config = gdn_config();
+
+    let adapter = train_micro_lora_with_gdn(&model, &pairs, &config, true)
+        .expect("train_micro_lora_with_gdn(true)");
+
+    for module in ["q_proj", "v_proj"] {
+        assert!(
+            adapter
+                .config()
+                .target_modules
+                .contains(&module.to_string())
+        );
+    }
+    for module in GDN_MODULES {
+        assert!(
+            adapter
+                .config()
+                .target_modules
+                .contains(&module.to_string()),
+            "target_modules missing {module}"
+        );
+        for gdn_layer in [20usize, 21, 22] {
+            assert!(
+                adapter.has_adapter(gdn_layer, module),
+                "adapter missing ({gdn_layer}, {module})"
+            );
+        }
+    }
+    // GQA layers must not pick up GDN modules, and layer 19/23 (GQA) must
+    // not carry GDN adapters.
+    for gqa_layer in [19usize, 23] {
+        for module in GDN_MODULES {
+            assert!(
+                !adapter.has_adapter(gqa_layer, module),
+                "GQA layer {gqa_layer} must not carry GDN module {module}"
+            );
+        }
+    }
+
+    // B factors start at zero; after >=1 Adam step with a nonzero gradient
+    // at least one GDN slot's B array must have moved off zero — otherwise
+    // this test would pass vacuously even if gradients/updates were wired
+    // to a no-op.
+    let mut any_nonzero_b = false;
+    for gdn_layer in [20usize, 21, 22] {
+        for module in GDN_MODULES {
+            let layer_w = adapter
+                .layers()
+                .get(&(gdn_layer, module.to_string()))
+                .expect("checked has_adapter above");
+            if layer_w.b.iter().any(|&v| v != 0.0) {
+                any_nonzero_b = true;
+            }
+            assert!(
+                layer_w.a.iter().all(|v| v.is_finite()) && layer_w.b.iter().all(|v| v.is_finite()),
+                "layer {gdn_layer} module {module}: non-finite LoRA factor after training"
+            );
+        }
+    }
+    assert!(
+        any_nonzero_b,
+        "no GDN B factor moved off zero after training — GDN gradients/Adam updates are not wired"
+    );
+}

--- a/crates/tune/tests/lora_apply_no_alloc.rs
+++ b/crates/tune/tests/lora_apply_no_alloc.rs
@@ -7,24 +7,35 @@
 //! from other integration tests, which run as separate processes) and
 //! asserts zero allocation-call deltas across both the missing-adapter fast
 //! path and the matched, rank-driven path.
+//!
+//! Counters are thread-local (#1272): the test body runs on a harness-spawned
+//! thread while other harness threads (result reporting, output capture,
+//! timing) remain live and may allocate during the measured window. A
+//! process-wide counter attributes that unrelated activity to
+//! `LoraAdapter::apply`, producing an intermittent nonzero delta with no
+//! code change — the same commit both failed and passed in CI. Scoping the
+//! counters to the measuring thread removes that cross-thread noise instead
+//! of tolerating it with a fudge-factor threshold.
 
 use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use lattice_tune::lora::{LoraAdapter, LoraConfig, LoraLayer};
 
 struct CountingAlloc;
 
-static ALLOC_CALLS: AtomicU64 = AtomicU64::new(0);
-static DEALLOC_CALLS: AtomicU64 = AtomicU64::new(0);
+thread_local! {
+    static ALLOC_CALLS: Cell<u64> = const { Cell::new(0) };
+    static DEALLOC_CALLS: Cell<u64> = const { Cell::new(0) };
+}
 
 #[global_allocator]
 static GLOBAL: CountingAlloc = CountingAlloc;
 
 unsafe impl GlobalAlloc for CountingAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        ALLOC_CALLS.with(|c| c.set(c.get() + 1));
         // SAFETY: `System` imposes the same contract on `alloc` that this
         // impl's caller has already satisfied, and `layout` reaches it
         // unchanged. Counting is side-effect free with respect to that
@@ -34,7 +45,7 @@ unsafe impl GlobalAlloc for CountingAlloc {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        DEALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        DEALLOC_CALLS.with(|c| c.set(c.get() + 1));
         // SAFETY: every pointer this allocator hands out comes from `System`,
         // so a `ptr`/`layout` pair the caller validly passes here is one
         // `System` allocated under that same layout. Both are forwarded
@@ -43,7 +54,7 @@ unsafe impl GlobalAlloc for CountingAlloc {
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        ALLOC_CALLS.with(|c| c.set(c.get() + 1));
         // SAFETY: same forwarding invariant as `dealloc` for `ptr`/`layout`,
         // and `new_size` is passed through untouched for `System` to validate
         // against its own contract.
@@ -52,11 +63,11 @@ unsafe impl GlobalAlloc for CountingAlloc {
 }
 
 fn alloc_calls() -> u64 {
-    ALLOC_CALLS.load(Ordering::Relaxed)
+    ALLOC_CALLS.with(Cell::get)
 }
 
 fn dealloc_calls() -> u64 {
-    DEALLOC_CALLS.load(Ordering::Relaxed)
+    DEALLOC_CALLS.with(Cell::get)
 }
 
 fn make_adapter() -> LoraAdapter {


### PR DESCRIPTION
## Summary
Two commits, both `crates/tune` only:

1. **GDN LoRA wiring (#884, first checkbox)**: `train_micro_lora` gains a `train_micro_lora_with_gdn` entry point wiring the already-landed GDN LoRA machinery (`GdnLoraParams::shaped`, `apply_gdn_adam_updates`) into the public training surface, following the same init policy as the known-good private driver (A random `U(-1/sqrt(hidden), ...)`, B zero, shared rng stream). A `required-features = ["train-backward"]` entry gates the new integration test so default builds stay green. Docs extended with the shared-learning-rate caveat from the prior failed NLL run, so the next training-quality attempt starts with that context. This PR makes the capability reachable; it does not claim a training-quality result — the held-out NLL acceptance and ADR-079 update remain open, so #884 stays open.
2. **Per-thread alloc counters (#1272)**: `lora_apply_no_alloc`'s counting allocator used process-wide `AtomicU64` statics, attributing harness-thread allocations (reporting, capture, timing) to the measured window — an intermittent nonzero delta with no code change. Switched to `thread_local!` `Cell<u64>` counters scoped to the measuring thread; the assertion still requires an exact zero delta (no tolerance introduced). Mutation-checked: a seeded allocation in the measured loop still fails the test (24576 detected), reverted, then 5x clean runs.

## Validation
`cargo test -p lattice-tune` (default and `--features train-backward`): 344+ passed, 0 failed, re-run on this branch's exact base. `cargo clippy -p lattice-tune --all-targets -- -D warnings` clean. `cargo fmt --check` clean. No `crates/inference`/`crates/embed`/`crates/fann` paths touched, so no bench-compare disposition applies.

Refs #884
Fixes #1272

🤖 Generated with [Claude Code](https://claude.com/claude-code)