### PR TITLE
fix(inference): dead-code feature gating, tokenizer module cycle, guard order in MTP verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,17 @@ jobs:
       # which is why the guard runs on the isolated resolve instead. See #1095.
       - name: embed — f16 native dependency load guard (standalone, no workspace unification)
         run: cargo test -p lattice-embed --test f16_feature_load_guard
+      # `-p lattice-inference` in isolation, default features only, no `--features`
+      # flag. Neither the pre-commit hook's `--workspace --all-targets` nor this
+      # job's own `f16,metal-gpu` clippy step below can see what this catches:
+      # `--workspace` lets another member's feature unification pull `f16` into
+      # lattice-inference for free, and the metal-gpu step enables it explicitly.
+      # Both masked four real dead-code items (two unused test imports, an unused
+      # test helper, an unused test-only method) that only this isolated,
+      # default-feature, per-crate scope reports (#1276). Run it so that scope
+      # divergence — locally-green, CI-green, and still rotting — cannot recur.
+      - name: inference — default-feature clippy, isolated (no workspace unification)
+        run: cargo clippy -p lattice-inference --all-targets -- -D warnings
       # Metal kernels only exist on macOS; gate so Linux does not try to build them.
       - name: inference — metal-gpu (macOS only)
         if: runner.os == 'macOS'

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -4217,12 +4217,12 @@ mod inner {
             tokens: &[u32],
             start_pos: usize,
         ) -> Result<MetalVerifyOutput, crate::error::InferenceError> {
+            self.check_forward_range_capacity(start_pos, tokens.len(), true)?;
             if self.session.gdn_checkpoints.is_none() {
                 return Err(crate::error::InferenceError::Inference(
                     "GDN checkpoint pool required for verify_tokens_batched".into(),
                 ));
             }
-            self.check_forward_range_capacity(start_pos, tokens.len(), true)?;
             if let Some(ref mut p) = self.session.gdn_checkpoints {
                 p.active_base_seq_len = Some(start_pos);
                 p.mtp_base_seq_len = self.session.mtp.as_ref().map(|m| m.cache.seq_len);
@@ -4277,12 +4277,12 @@ mod inner {
                     "verify_batch: bad token count {n} (max {MTP_VERIFY_MAX_TOKENS})"
                 )));
             }
+            self.check_forward_range_capacity(start_pos, n, false)?;
             if self.session.gdn_checkpoints.is_none() {
                 return Err(crate::error::InferenceError::Inference(
                     "GDN checkpoint pool required for verify_tokens_batch_gemm".into(),
                 ));
             }
-            self.check_forward_range_capacity(start_pos, n, false)?;
 
             let cfg = self.engine.config.clone();
             let hidden = cfg.hidden_size;

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -514,7 +514,6 @@ mod inner {
     };
     use crate::attention::gdn::GatedDeltaNetState;
     use crate::attention::gdn_fused::GatedDeltaNetFusedScratch;
-    use crate::model::qwen35::detokenize::IncrementalDetokenizer;
     use crate::model::qwen35::stop_strings::StopStringMatcher;
     use crate::model::qwen35::{
         AttentionWeights, GenerationEntryContract, GenerationPlan, GenerationPreparation,
@@ -524,6 +523,7 @@ mod inner {
     use crate::stop_reason::StopReason;
     use crate::tokenizer::bpe::BpeTokenizer;
     use crate::tokenizer::common::Tokenizer;
+    use crate::tokenizer::detokenize::IncrementalDetokenizer;
     use crate::vision::multimodal::Qwen35VisionRequest;
     use crate::weights::q4_weights::quantize_row_q4_0;
     use metal::*;
@@ -9915,7 +9915,7 @@ mod inner {
     }
 
     fn decode_tokens(tokenizer: &BpeTokenizer, ids: &[u32]) -> String {
-        crate::model::qwen35::detokenize::decode_tokens(tokenizer, ids)
+        crate::tokenizer::detokenize::decode_tokens(tokenizer, ids)
     }
 
     // -----------------------------------------------------------------------
@@ -25737,7 +25737,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// `好` (`0xE5 0xA5 0xBD`), exactly as a real byte-level BPE vocab
         /// would encode it, so ids 30/31 decode to genuine CJK bytes if sampled.
         fn multibyte_vocab_tokenizer() -> crate::tokenizer::bpe::BpeTokenizer {
-            use crate::model::qwen35::detokenize::bytes_to_unicode;
+            use crate::tokenizer::detokenize::bytes_to_unicode;
             use std::collections::HashMap;
             let byte_encoder = bytes_to_unicode();
             let byte_level_token = |bytes: &[u8]| -> String {

--- a/crates/inference/src/model/gemma4_cache.rs
+++ b/crates/inference/src/model/gemma4_cache.rs
@@ -487,7 +487,7 @@ impl Gemma4KvCache {
     /// gate) by pointing a shared layer at the wrong same-type owner's slot
     /// and showing the forward output diverges, without touching the
     /// weight-loading config the model was built against.
-    #[cfg(test)]
+    #[cfg(all(test, feature = "f16"))]
     pub(crate) fn override_layer_slot_for_test(&mut self, layer: usize, slot: usize) {
         self.layer_kv_slot[layer] = slot;
     }

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -1,6 +1,5 @@
 //! Qwen3.5 generation, streaming generation, prefill/decode loops, stop-streamer utilities, and stop-token helpers.
 use super::cache::{ForwardScratch, KvCache};
-use super::detokenize::{IncrementalDetokenizer, decode_tokens};
 use super::model::Qwen35Model;
 use super::sampling::sample_token;
 use super::stop_strings::{
@@ -15,6 +14,7 @@ use crate::model::qwen35_config::{
 use crate::sampling::compute_step_logprobs;
 use crate::stop_reason::StopReason;
 use crate::tokenizer::common::Tokenizer;
+use crate::tokenizer::detokenize::{IncrementalDetokenizer, decode_tokens};
 
 /// Test-only toggle forcing the pre-delegation serial prefill path
 /// (`prefill_tokens`) instead of `prefill_tokens_batched_for_generate`.

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -11,7 +11,6 @@
 
 mod cache;
 mod debug;
-pub(crate) mod detokenize;
 mod embed;
 mod eval;
 mod forward;
@@ -48,8 +47,8 @@ pub mod test_support;
 pub use model::Qwen35Model;
 pub use weights::ModelWeights;
 
+pub(crate) use crate::tokenizer::detokenize::decode_tokens;
 pub(crate) use cache::{ForwardScratch, KvCache, resize};
-pub(crate) use detokenize::decode_tokens;
 // Re-exported so that quantized CPU generate helpers (cpu_q8, cpu_f16,
 // neon_forward) can share the same typed grammar-not-set guard without
 // duplicating the predicate or the error message (#397/#398).
@@ -101,7 +100,7 @@ pub(crate) use weights::{
 pub(crate) use weights::{MoeLayerWeights, MoeRouter, RoutedExperts, SharedExpert};
 
 #[cfg(test)]
-pub use detokenize::bytes_to_unicode;
+pub use crate::tokenizer::detokenize::bytes_to_unicode;
 // Needed by all generate paths (cpu_q8, cpu_f16, neon_forward)
 // and by tests. `pub(crate)` keeps it out of the public API surface.
 pub(crate) use generation::should_stop_token;

--- a/crates/inference/src/model/qwen35/stop_strings.rs
+++ b/crates/inference/src/model/qwen35/stop_strings.rs
@@ -550,8 +550,8 @@ mod tests {
     /// token 1's delta must be the complete "好", not mojibake or U+FFFD.
     #[test]
     fn token_level_split_cjk_codepoint_decodes_without_mojibake() {
-        use crate::model::qwen35::detokenize::{IncrementalDetokenizer, bytes_to_unicode};
         use crate::tokenizer::bpe::BpeTokenizer;
+        use crate::tokenizer::detokenize::{IncrementalDetokenizer, bytes_to_unicode};
         use std::collections::HashMap;
 
         let byte_encoder = bytes_to_unicode();
@@ -581,8 +581,8 @@ mod tests {
     /// never emitting a dropped/garbled tail for the preceding ASCII text.
     #[test]
     fn stop_streamer_matches_split_cjk_stop_string_no_dropped_tail() {
-        use crate::model::qwen35::detokenize::{IncrementalDetokenizer, bytes_to_unicode};
         use crate::tokenizer::bpe::BpeTokenizer;
+        use crate::tokenizer::detokenize::{IncrementalDetokenizer, bytes_to_unicode};
         use std::collections::HashMap;
 
         let byte_encoder = bytes_to_unicode();

--- a/crates/inference/src/tokenizer/bpe.rs
+++ b/crates/inference/src/tokenizer/bpe.rs
@@ -18,8 +18,8 @@ use std::path::Path;
 use std::sync::Arc;
 use tracing::warn;
 
-const DEFAULT_BPE_CACHE_CAPACITY: usize = 8_192;
-const DEFAULT_BPE_MAX_SEQ_LEN: usize = 4_096;
+pub(crate) const DEFAULT_BPE_CACHE_CAPACITY: usize = 8_192;
+pub(crate) const DEFAULT_BPE_MAX_SEQ_LEN: usize = 4_096;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PreTokenizeMode {
@@ -206,7 +206,7 @@ impl BpeTokenizer {
         )
     }
 
-    fn from_vocab_and_merges_with_config(
+    pub(crate) fn from_vocab_and_merges_with_config(
         vocab: HashMap<String, u32>,
         merges: Vec<(String, String)>,
         added_tokens: HashMap<String, u32>,
@@ -1718,83 +1718,6 @@ mod tests {
             .expect("matching vocab length");
         assert!(logits[100].is_finite());
         assert!(logits[101].is_finite());
-    }
-
-    #[test]
-    fn decode_and_incremental_detokenize_render_non_ascii_added_tokens() {
-        use crate::model::qwen35::detokenize::IncrementalDetokenizer;
-
-        let tokenizer = non_ascii_added_tokenizer();
-        assert_eq!(
-            tokenizer.token_bytes_for_id(100).as_deref(),
-            Some("好".as_bytes())
-        );
-        assert_eq!(
-            tokenizer.token_bytes_for_id(101).as_deref(),
-            Some("café".as_bytes())
-        );
-        assert_eq!(tokenizer.decode(&[100, 101]), Some("好café".to_string()));
-
-        let mut detok = IncrementalDetokenizer::new();
-        let mut text = String::new();
-        for id in [100, 101] {
-            text.push_str(&detok.push(&tokenizer, id));
-        }
-        text.push_str(&detok.finish());
-        assert_eq!(text, "好café");
-    }
-
-    #[test]
-    fn test_decode_renders_nonspecial_added_tokens() {
-        // Regression (qwen3.6-27b think-tag bug): added tokens with special=false
-        // (`</think>`, `<tool_call>`, FIM markers) live BEYOND the base vocab range,
-        // so before the fix `token_for_id` returned None and they decoded to the
-        // empty string — silently swallowed from the output stream even though the
-        // model sampled them correctly. They must now render as their literal text.
-        // special=true markers (im_end-style) must STILL be swallowed.
-        let mut vocab = HashMap::new();
-        for (s, i) in [("a", 0u32), ("b", 1), ("c", 2)] {
-            vocab.insert(s.to_string(), i);
-        }
-        // rendered_added = the special=false subset (content -> id), ids past base max.
-        let mut rendered = HashMap::new();
-        rendered.insert("</think>".to_string(), 100u32);
-        rendered.insert("<think>".to_string(), 101u32);
-        rendered.insert("<tool_call>".to_string(), 102u32);
-
-        let tokenizer = BpeTokenizer::from_vocab_and_merges_with_config(
-            vocab,
-            Vec::new(),
-            HashMap::new(),
-            rendered,
-            DEFAULT_BPE_CACHE_CAPACITY,
-            DEFAULT_BPE_MAX_SEQ_LEN,
-        )
-        .expect("construct tokenizer with rendered added tokens");
-
-        // special=false added tokens render verbatim (byte-level decode is identity
-        // for printable ASCII).
-        assert_eq!(tokenizer.decode(&[101]), Some("<think>".to_string()));
-        assert_eq!(tokenizer.decode(&[100]), Some("</think>".to_string()));
-        assert_eq!(tokenizer.decode(&[102]), Some("<tool_call>".to_string()));
-        // Mixed with base content tokens, in stream order.
-        assert_eq!(
-            tokenizer.decode(&[0, 1, 100, 2]),
-            Some("ab</think>c".to_string())
-        );
-        // An id present in neither base vocab nor the rendered set (e.g. a
-        // special=true marker) stays swallowed — token_for_id returns None.
-        assert_eq!(tokenizer.decode(&[200]), Some(String::new()));
-
-        // The incremental streaming detokenizer must agree byte-for-byte.
-        use crate::model::qwen35::detokenize::IncrementalDetokenizer;
-        let mut detok = IncrementalDetokenizer::new();
-        let mut out = String::new();
-        for id in [0u32, 100, 1] {
-            out.push_str(&detok.push(&tokenizer, id));
-        }
-        out.push_str(&detok.finish());
-        assert_eq!(out, "a</think>b");
     }
 
     #[test]

--- a/crates/inference/src/tokenizer/detokenize.rs
+++ b/crates/inference/src/tokenizer/detokenize.rs
@@ -197,6 +197,7 @@ pub fn bytes_to_unicode() -> Vec<char> {
 mod tests {
     use super::*;
     use crate::tokenizer::bpe::BpeTokenizer;
+    use crate::tokenizer::common::Tokenizer;
     use std::collections::HashMap;
 
     #[test]
@@ -411,5 +412,90 @@ mod tests {
         assert_eq!(streamed, reference);
         assert_eq!(detok.retained_byte_len(), 0);
         assert!(detok.retained_byte_capacity() <= DETOK_RETAINED_BYTE_CAPACITY);
+    }
+
+    fn non_ascii_added_tokenizer() -> BpeTokenizer {
+        let json = r#"{
+            "model":{"type":"BPE","vocab":{"a":0},"merges":[]},
+            "added_tokens":[
+                {"id":100,"content":"好","special":false},
+                {"id":101,"content":"café","special":false}
+            ]
+        }"#;
+        BpeTokenizer::from_tokenizer_json_str(json).unwrap()
+    }
+
+    #[test]
+    fn decode_and_incremental_detokenize_render_non_ascii_added_tokens() {
+        let tokenizer = non_ascii_added_tokenizer();
+        assert_eq!(
+            tokenizer.token_bytes_for_id(100).as_deref(),
+            Some("好".as_bytes())
+        );
+        assert_eq!(
+            tokenizer.token_bytes_for_id(101).as_deref(),
+            Some("café".as_bytes())
+        );
+        assert_eq!(tokenizer.decode(&[100, 101]), Some("好café".to_string()));
+
+        let mut detok = IncrementalDetokenizer::new();
+        let mut text = String::new();
+        for id in [100, 101] {
+            text.push_str(&detok.push(&tokenizer, id));
+        }
+        text.push_str(&detok.finish());
+        assert_eq!(text, "好café");
+    }
+
+    #[test]
+    fn test_decode_renders_nonspecial_added_tokens() {
+        // Regression (qwen3.6-27b think-tag bug): added tokens with special=false
+        // (`</think>`, `<tool_call>`, FIM markers) live BEYOND the base vocab range,
+        // so before the fix `token_for_id` returned None and they decoded to the
+        // empty string — silently swallowed from the output stream even though the
+        // model sampled them correctly. They must now render as their literal text.
+        // special=true markers (im_end-style) must STILL be swallowed.
+        let mut vocab = HashMap::new();
+        for (s, i) in [("a", 0u32), ("b", 1), ("c", 2)] {
+            vocab.insert(s.to_string(), i);
+        }
+        // rendered_added = the special=false subset (content -> id), ids past base max.
+        let mut rendered = HashMap::new();
+        rendered.insert("</think>".to_string(), 100u32);
+        rendered.insert("<think>".to_string(), 101u32);
+        rendered.insert("<tool_call>".to_string(), 102u32);
+
+        let tokenizer = BpeTokenizer::from_vocab_and_merges_with_config(
+            vocab,
+            Vec::new(),
+            HashMap::new(),
+            rendered,
+            crate::tokenizer::bpe::DEFAULT_BPE_CACHE_CAPACITY,
+            crate::tokenizer::bpe::DEFAULT_BPE_MAX_SEQ_LEN,
+        )
+        .expect("construct tokenizer with rendered added tokens");
+
+        // special=false added tokens render verbatim (byte-level decode is identity
+        // for printable ASCII).
+        assert_eq!(tokenizer.decode(&[101]), Some("<think>".to_string()));
+        assert_eq!(tokenizer.decode(&[100]), Some("</think>".to_string()));
+        assert_eq!(tokenizer.decode(&[102]), Some("<tool_call>".to_string()));
+        // Mixed with base content tokens, in stream order.
+        assert_eq!(
+            tokenizer.decode(&[0, 1, 100, 2]),
+            Some("ab</think>c".to_string())
+        );
+        // An id present in neither base vocab nor the rendered set (e.g. a
+        // special=true marker) stays swallowed — token_for_id returns None.
+        assert_eq!(tokenizer.decode(&[200]), Some(String::new()));
+
+        // The incremental streaming detokenizer must agree byte-for-byte.
+        let mut detok = IncrementalDetokenizer::new();
+        let mut out = String::new();
+        for id in [0u32, 100, 1] {
+            out.push_str(&detok.push(&tokenizer, id));
+        }
+        out.push_str(&detok.finish());
+        assert_eq!(out, "a</think>b");
     }
 }

--- a/crates/inference/src/tokenizer/mod.rs
+++ b/crates/inference/src/tokenizer/mod.rs
@@ -1,6 +1,7 @@
 //! Tokenizer module index and re-exports for WordPiece, BPE, common tokenizer types/loaders, and SentencePiece.
 pub mod bpe;
 pub mod common;
+pub(crate) mod detokenize;
 pub mod gemma_bpe;
 pub mod sentencepiece;
 pub mod wordpiece;

--- a/crates/inference/src/weights/ingress.rs
+++ b/crates/inference/src/weights/ingress.rs
@@ -282,6 +282,7 @@ impl<'a> IngestedTensor<'a> {
         }
     }
 
+    #[cfg(feature = "f16")]
     pub(super) fn decoded_f32_known_finite(
         source: &'a str,
         tensor_name: &'a str,

--- a/crates/inference/tests/gemma4_e2e_forward_test.rs
+++ b/crates/inference/tests/gemma4_e2e_forward_test.rs
@@ -21,7 +21,9 @@
 //!     --test gemma4_e2e_forward_test -- --nocapture
 //! ```
 
+#[cfg(feature = "f16")]
 use lattice_inference::Tokenizer as _;
+#[cfg(feature = "f16")]
 use lattice_inference::model::gemma4_model::Gemma4Model;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
@@ -159,6 +161,7 @@ fn resolve_model_dir() -> Option<PathBuf> {
     }
 }
 
+#[cfg(feature = "f16")]
 fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
     assert_eq!(a.len(), b.len());
     a.iter()

--- a/crates/inference/tests/vision_s4_merger_test.rs
+++ b/crates/inference/tests/vision_s4_merger_test.rs
@@ -44,6 +44,7 @@ struct TensorManifest {
 struct Manifest {
     #[allow(dead_code)] // only read by the f16-gated gate functions
     image_grid_thw: Vec<[u64; 3]>,
+    #[allow(dead_code)] // only read by the f16-gated gate functions
     vit_pre_merger: TensorManifest,
     vit_post_merger: TensorManifest,
 }


### PR DESCRIPTION
## Summary
Four commits:

1. **Dead-code feature gating** (`9e5533d`): items whose only caller is feature-gated are now gated behind the same feature, fixing the `-D warnings` dead-code failures that fired under narrow feature combinations (e.g. `cargo clippy -p lattice-inference --lib` default-features) while the workspace-level command stayed green.
2. **Isolated default-feature clippy scope** (`6956fe4`): adds a CI step running the crate-scoped default-feature clippy so the combination in (1) is actually observed by a gate instead of only by whoever runs the narrow command locally.
3. **Tokenizer module cycle removal** (`ea2e844`, fixes #1302): `detokenize.rs` moves from `model/qwen35/` to `tokenizer/`, with its tests; every use site updated. The dependency direction is now one-way — `tokenizer/*` has no `use crate::model::qwen35` imports while `model/qwen35/*` imports `crate::tokenizer` freely. Function bodies are relocated, not changed; two constructors widened to `pub(crate)` for the moved tests.
4. **Guard order in MTP verify entry points** (`94b3b77`, fixes #1308): `verify_tokens_batched` checked the GDN pool before range capacity, so an out-of-range `start_pos` with no pool reported the wrong error kind (`Inference` instead of `InvalidInput`). Range capacity now runs first; it depends only on positions and cache capacity, so the reorder is safe in every configuration. Sibling sweep found and fixed the identical pattern in `verify_tokens_batch_gemm`; the two other `check_forward_range_capacity` call sites have no pool guard and are unaffected.

## Validation
`cargo check`/`clippy --all-targets -- -D warnings` clean in both default and `metal-gpu` feature configs; `tokenizer::` 72/72, `stop_strings::` 28/28, `generation::` 41/41 (CPU); fmt clean. Known coverage gap, stated: the two GPU-gated regression tests for the guard reorder (`verify_tokens_rejects_out_of_range_start_pos_before_dispatch`, `forward_step_rejects_position_and_cache_capacity_before_dispatch`) require Metal dispatch and were not run in this environment — CI's Metal legs are the first execution of the reordered path.

## bench-compare disposition
Structural waiver (runtime source only; no manifest/dependency/feature-set/profile/harness change — commit 2 touches `.github/workflows/ci.yml` only). Searched all declared `crates/inference` bench targets for the changed symbols (`verify_tokens_batched`, `verify_tokens_batch_gemm`, `detokenize`, `incremental_detokenize`): zero matches, with a must-match control on the same population (`Sampler` in `topk_readback.rs`, 14 hits). `tokenizer_bench.rs` exercises `BpeTokenizer`/`WordPieceTokenizer` encode/decode, but the tokenizer commit relocates function bodies across modules without changing them (visibility widened to `pub(crate)` on two constructors; no body edits), so base and head compile identical executed source for every bench-reachable path. The dead-code commit gates items that by definition have no callers outside the gated feature. Residual risk: the guard-reorder path is Metal-gated and unmeasured by any bench; it is two preflight checks swapped ahead of dispatch, not decode-loop work.

Fixes #1302
Fixes #1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)