### PR TITLE
fix(hygiene): scrub absolute developer paths from Swift preview literals

### DIFF
--- a/apps/macos/Sources/LatticeStudio/Components/CLIFooter.swift
+++ b/apps/macos/Sources/LatticeStudio/Components/CLIFooter.swift
@@ -95,7 +95,7 @@ struct CLIFooter: View {
     VStack(spacing: 0) {
         Spacer()
         CLIFooter(
-            command: "lattice_serve --model /Users/you/.lattice/models/qwen3.5-0.8b --port 11435",
+            command: "lattice_serve --model ~/.lattice/models/qwen3.5-0.8b --port 11435",
             caption: "http://127.0.0.1:11435/v1"
         )
     }

--- a/apps/macos/Sources/LatticeStudio/Components/Field.swift
+++ b/apps/macos/Sources/LatticeStudio/Components/Field.swift
@@ -151,7 +151,7 @@ struct LatticeNumericField: View {
 
         LatticeField(prompt: "Model name or path", text: .constant(""))
 
-        LatticeField(prompt: "Dataset path", text: .constant("/Users/lion/data/train.jsonl"))
+        LatticeField(prompt: "Dataset path", text: .constant("~/data/train.jsonl"))
 
         LatticeField(prompt: "With error", text: .constant("bad-path"), errorMessage: "File not found")
 

--- a/scripts/lint-absolute-paths.sh
+++ b/scripts/lint-absolute-paths.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 # Reject developer-specific home paths from tracked documentation, Rust,
-# manifests, scripts, workflows, and JSON.
-#
-# Swift remains outside this check until its existing preview literals are
-# normalized under #1102.
+# manifests, scripts, workflows, JSON, and Swift.
 #
 # The historical benchmark evidence directory is intentionally excluded: those
 # immutable reports preserve the exact commands and paths used for their runs.
@@ -52,6 +49,7 @@ run_check() {
         '*.yml' \
         '*.yaml' \
         '*.json' \
+        '*.swift' \
         ':(exclude)scripts/bench_evidence/**' \
         >"$matches_file" 2>"$errors_file"
     grep_rc=$?
@@ -98,7 +96,8 @@ selftest() {
     esac
     trap 'rm -rf "$sandbox"' 0 1 2 3 15
 
-    mkdir -p "$sandbox/docs" "$sandbox/crates/demo/src" "$sandbox/scripts/bench_evidence/run"
+    mkdir -p "$sandbox/docs" "$sandbox/crates/demo/src" "$sandbox/apps/demo/Sources" \
+        "$sandbox/scripts/bench_evidence/run"
     printf 'Use $%s/model-name.\n' 'LATTICE_MODEL_CACHE' >"$sandbox/docs/clean.md"
     printf '%s\n' 'fn main() {}' >"$sandbox/crates/demo/src/main.rs"
     printf '/%s/%s/projects/archive/model\n' 'Users' 'archived-runner' \
@@ -118,7 +117,9 @@ selftest() {
     printf '/%s/%s/projects/demo\n' 'Users' 'developer' >"$sandbox/docs/dirty.md"
     printf '// /%s/%s/src/demo\n' 'home' 'developer' \
         >"$sandbox/crates/demo/src/dirty.rs"
-    git -C "$sandbox" add docs/dirty.md crates/demo/src/dirty.rs
+    printf '// "/%s/%s/data/train.jsonl"\n' 'Users' 'developer' \
+        >"$sandbox/apps/demo/Sources/Dirty.swift"
+    git -C "$sandbox" add docs/dirty.md crates/demo/src/dirty.rs apps/demo/Sources/Dirty.swift
     dirty_output="$sandbox/dirty.out"
     run_check "$sandbox" >"$dirty_output" 2>&1
     dirty_rc=$?
@@ -134,6 +135,11 @@ selftest() {
     fi
     if ! grep -F 'crates/demo/src/dirty.rs:1:' "$dirty_output" >/dev/null; then
         echo "lint-absolute-paths selftest: Linux-style dirty finding was not reported" >&2
+        cat "$dirty_output" >&2
+        return 1
+    fi
+    if ! grep -F 'apps/demo/Sources/Dirty.swift:1:' "$dirty_output" >/dev/null; then
+        echo "lint-absolute-paths selftest: Swift dirty finding was not reported" >&2
         cat "$dirty_output" >&2
         return 1
     fi


### PR DESCRIPTION
Closes #1102 (absolute developer-path category).

Two SwiftUI `#Preview` blocks embedded developer-specific home paths, one leaking a real username:

- `apps/macos/Sources/LatticeStudio/Components/CLIFooter.swift` — `--model /Users/you/...` example → `~/.lattice/models/...`
- `apps/macos/Sources/LatticeStudio/Components/Field.swift` — dataset-path preview literal → `~/data/train.jsonl`

`scripts/lint-absolute-paths.sh` already rejects `/Users`/`/home` home paths in tracked `*.md *.rs *.toml *.sh *.py *.yml *.yaml *.json`, but its header explicitly excluded Swift pending this cleanup. This PR:

1. Fixes both literals to `~`-relative example paths.
2. Extends the lint's pathspec to `*.swift` and removes the stale exclusion comment.
3. Adds a selftest arm with a planted violation in a sandbox `.swift` file, asserted present in the dirty-tree findings — proving the extension detects Swift violations rather than merely adding the glob.

Verification (all run at this head):

- `./scripts/lint-absolute-paths.sh --selftest` → clean/dirty/failure fixtures pass, rc 0
- `./scripts/lint-absolute-paths.sh` → clean, rc 0
- `./scripts/lint-docs.sh` → passes (includes this check)
- Repo-wide `git grep -E "/(Users|home)/[^/[:space:]]+/"`: remaining hits are only in `scripts/bench_evidence/**`, the intentionally excluded immutable historical reports (their exclusion and rationale pre-date this change).

The `.rs` example files and `apps/macos/*.md` docs listed in #1102's candidate list were already clean at current main; that list predates earlier fixes. The issue's other categories (personal names in manifests, process vocabulary in comments) are separate sweeps.

No `crates/inference/` or `crates/embed/` changes — bench-compare disposition not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
