### PR TITLE
feat(inference): CPU FP8 E4M3/E5M2 tensor decode

### DIFF
--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -15,6 +15,12 @@ enum DType {
     F32,
     F16,
     BF16,
+    /// OCP FP8 E4M3 ("FN": finite-only, no infinity), safetensors `F8_E4M3`.
+    /// Distinct from `F8_E4M3FNUZ`, which stays `Other` (lattice#684).
+    F8E4M3,
+    /// OCP FP8 E5M2, safetensors `F8_E5M2`. Distinct from `F8_E5M2FNUZ`,
+    /// which stays `Other` (lattice#684).
+    F8E5M2,
     /// A dtype safetensors defines but this crate does not materialize as
     /// f32 (I64, U8, BOOL, F64, ...). Tracked structurally (not silently
     /// dropped from `SafetensorsFile::tensors`) so extent validation still
@@ -31,6 +37,8 @@ impl DType {
             Self::F32 => "F32",
             Self::F16 => "F16",
             Self::BF16 => "BF16",
+            Self::F8E4M3 => "F8_E4M3",
+            Self::F8E5M2 => "F8_E5M2",
             Self::Other { label, .. } => label,
         }
     }
@@ -47,6 +55,8 @@ fn dtype_from_str(s: &str) -> Option<DType> {
         "F32" => DType::F32,
         "F16" => DType::F16,
         "BF16" => DType::BF16,
+        "F8_E4M3" => DType::F8E4M3,
+        "F8_E5M2" => DType::F8E5M2,
         _ => {
             let dtype = safetensors_dtype(s)?;
             DType::Other { label: dtype.name }
@@ -443,10 +453,76 @@ impl SafetensorsFile {
                     )));
                 }
             }
+            DType::F8E4M3 => {
+                #[cfg(feature = "f16")]
+                {
+                    (
+                        meta.converted_f32
+                            .get_or_init(|| {
+                                let (values, has_non_finite) = convert_f8_e4m3_bytes_to_f32(bytes);
+                                let _ = meta.validated.get_or_init(|| {
+                                    let tensor = if has_non_finite {
+                                        crate::weights::ingress::IngestedTensor::decoded_f32(
+                                            source, name, shape, dtype_name, &values,
+                                        )
+                                    } else {
+                                        crate::weights::ingress::IngestedTensor::decoded_f32_known_finite(
+                                            source, name, shape, dtype_name, &values,
+                                        )
+                                    };
+                                    crate::weights::ingress::validate_ingested_tensor(tensor)
+                                        .map_err(|e| e.to_string())
+                                });
+                                values.into_boxed_slice()
+                            })
+                            .as_ref(),
+                        true,
+                    )
+                }
+                #[cfg(not(feature = "f16"))]
+                {
+                    return Err(InferenceError::InvalidSafetensors(format!(
+                        "tensor {name} is F8_E4M3 but lattice-inference was built without the f16 feature"
+                    )));
+                }
+            }
+            DType::F8E5M2 => {
+                #[cfg(feature = "f16")]
+                {
+                    (
+                        meta.converted_f32
+                            .get_or_init(|| {
+                                let (values, has_non_finite) = convert_f8_e5m2_bytes_to_f32(bytes);
+                                let _ = meta.validated.get_or_init(|| {
+                                    let tensor = if has_non_finite {
+                                        crate::weights::ingress::IngestedTensor::decoded_f32(
+                                            source, name, shape, dtype_name, &values,
+                                        )
+                                    } else {
+                                        crate::weights::ingress::IngestedTensor::decoded_f32_known_finite(
+                                            source, name, shape, dtype_name, &values,
+                                        )
+                                    };
+                                    crate::weights::ingress::validate_ingested_tensor(tensor)
+                                        .map_err(|e| e.to_string())
+                                });
+                                values.into_boxed_slice()
+                            })
+                            .as_ref(),
+                        true,
+                    )
+                }
+                #[cfg(not(feature = "f16"))]
+                {
+                    return Err(InferenceError::InvalidSafetensors(format!(
+                        "tensor {name} is F8_E5M2 but lattice-inference was built without the f16 feature"
+                    )));
+                }
+            }
             DType::Other { label, .. } => {
                 return Err(InferenceError::InvalidSafetensors(format!(
                     "tensor {name} has unsupported dtype {label} (source: {}); only F32, F16, \
-                     and BF16 tensors can be materialized as f32",
+                     BF16, F8_E4M3, and F8_E5M2 tensors can be materialized as f32",
                     self.source
                 )));
             }
@@ -908,6 +984,30 @@ fn convert_bf16_bytes_to_f32(bytes: &[u8]) -> (Vec<f32>, bool) {
     for chunk in bytes.chunks_exact(2) {
         let value =
             crate::weights::half_bits::bf16_bits_to_f32(u16::from_le_bytes([chunk[0], chunk[1]]));
+        has_non_finite |= !value.is_finite();
+        out.push(value);
+    }
+    (out, has_non_finite)
+}
+
+#[cfg(feature = "f16")]
+fn convert_f8_e4m3_bytes_to_f32(bytes: &[u8]) -> (Vec<f32>, bool) {
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut has_non_finite = false;
+    for &byte in bytes {
+        let value = crate::weights::half_bits::f8_e4m3_bits_to_f32(byte);
+        has_non_finite |= !value.is_finite();
+        out.push(value);
+    }
+    (out, has_non_finite)
+}
+
+#[cfg(feature = "f16")]
+fn convert_f8_e5m2_bytes_to_f32(bytes: &[u8]) -> (Vec<f32>, bool) {
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut has_non_finite = false;
+    for &byte in bytes {
+        let value = crate::weights::half_bits::f8_e5m2_bits_to_f32(byte);
         has_non_finite |= !value.is_finite();
         out.push(value);
     }
@@ -2799,6 +2899,88 @@ mod tests {
         let err = sf
             .get_f32_tensor("t")
             .expect_err("BF16 +inf bit pattern must be rejected");
+        assert!(
+            err.to_string().contains("non-finite"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_file(&path).ok();
+    }
+
+    #[cfg(feature = "f16")]
+    #[test]
+    fn test_f8_e4m3_tensor_decodes_through_safetensors_path() {
+        let path = temp_path("lattice_weights_f8_e4m3_decode");
+        // 0x00 = +0.0, 0x38 = 1.0, 0xb8 = -1.0, 0x7e = 448.0 (largest finite E4M3).
+        let raw: [u8; 4] = [0x00, 0x38, 0xb8, 0x7e];
+        write_raw_tensor(&path, "t", "F8_E4M3", &[raw.len()], &raw);
+
+        let sf = SafetensorsFile::open(&path).expect("open: header/extent are valid");
+        let (values, shape) = sf
+            .get_f32_tensor("t")
+            .expect("finite F8_E4M3 values must decode");
+        assert_eq!(shape, &[raw.len()]);
+        assert_eq!(values, &[0.0f32, 1.0, -1.0, 448.0]);
+
+        fs::remove_file(&path).ok();
+    }
+
+    #[cfg(feature = "f16")]
+    #[test]
+    fn test_f8_e4m3_tensor_rejects_nan_bit_pattern_through_safetensors_path() {
+        let path = temp_path("lattice_weights_f8_e4m3_nan");
+        // E4M3FN's sole NaN encoding: exponent and mantissa both all-ones.
+        let one_bits: u8 = 0x38;
+        let nan_bits: u8 = 0x7f;
+        write_raw_tensor(&path, "t", "F8_E4M3", &[2], &[one_bits, nan_bits]);
+
+        let sf = SafetensorsFile::open(&path).expect("open: header/extent are valid");
+        let err = sf
+            .get_f32_tensor("t")
+            .expect_err("F8_E4M3 NaN bit pattern must be rejected");
+        assert!(
+            err.to_string().contains("non-finite"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.to_string().contains("element index 1"),
+            "unexpected error: {err}"
+        );
+
+        fs::remove_file(&path).ok();
+    }
+
+    #[cfg(feature = "f16")]
+    #[test]
+    fn test_f8_e5m2_tensor_decodes_through_safetensors_path() {
+        let path = temp_path("lattice_weights_f8_e5m2_decode");
+        // 0x00 = +0.0, 0x3c = 1.0, 0xbc = -1.0, 0x7b = 57344.0 (largest finite E5M2).
+        let raw: [u8; 4] = [0x00, 0x3c, 0xbc, 0x7b];
+        write_raw_tensor(&path, "t", "F8_E5M2", &[raw.len()], &raw);
+
+        let sf = SafetensorsFile::open(&path).expect("open: header/extent are valid");
+        let (values, shape) = sf
+            .get_f32_tensor("t")
+            .expect("finite F8_E5M2 values must decode");
+        assert_eq!(shape, &[raw.len()]);
+        assert_eq!(values, &[0.0f32, 1.0, -1.0, 57344.0]);
+
+        fs::remove_file(&path).ok();
+    }
+
+    #[cfg(feature = "f16")]
+    #[test]
+    fn test_f8_e5m2_tensor_rejects_infinity_bit_pattern_through_safetensors_path() {
+        let path = temp_path("lattice_weights_f8_e5m2_inf");
+        // E5M2 +infinity: exponent all-ones, mantissa zero.
+        let inf_bits: u8 = 0x7c;
+        let one_bits: u8 = 0x3c;
+        write_raw_tensor(&path, "t", "F8_E5M2", &[2], &[inf_bits, one_bits]);
+
+        let sf = SafetensorsFile::open(&path).expect("open: header/extent are valid");
+        let err = sf
+            .get_f32_tensor("t")
+            .expect_err("F8_E5M2 +inf bit pattern must be rejected");
         assert!(
             err.to_string().contains("non-finite"),
             "unexpected error: {err}"

--- a/crates/inference/src/weights/half_bits.rs
+++ b/crates/inference/src/weights/half_bits.rs
@@ -62,6 +62,89 @@ pub(crate) fn bf16_bits_to_f32(bits: u16) -> f32 {
     f32::from_bits((bits as u32) << 16)
 }
 
+/// Widen an OCP FP8 E4M3 (safetensors `F8_E4M3`, PyTorch `float8_e4m3fn`)
+/// bit pattern to `f32`, exactly.
+///
+/// This is the "FN" (finite-only) OCP variant: 1 sign bit, 4 exponent bits
+/// (bias 7), 3 mantissa bits, no infinities — the all-ones exponent field
+/// is used for ordinary finite values (max magnitude 448) *except* the one
+/// pattern where the mantissa is also all-ones, which is the sole NaN
+/// encoding (both signs). This is deliberately distinct from `F8_E4M3FNUZ`
+/// (AMD's variant: single unsigned NaN, no negative zero), which this
+/// function does not decode (lattice#684).
+#[cfg(feature = "f16")]
+#[inline]
+pub(crate) fn f8_e4m3_bits_to_f32(bits: u8) -> f32 {
+    let sign = ((bits >> 7) & 0x1) as u32;
+    let exp = ((bits >> 3) & 0x0f) as u32;
+    let frac = (bits & 0x07) as u32;
+
+    let f32_bits = match (exp, frac) {
+        // Zero (signed)
+        (0, 0) => sign << 31,
+        // Subnormal: normalize by shifting the leading 1 into bit 3, then
+        // strip it and treat the remainder as the f32 mantissa.
+        (0, _) => {
+            let mut mant = frac;
+            let mut e = -6i32;
+            while (mant & 0x08) == 0 {
+                mant <<= 1;
+                e -= 1;
+            }
+            mant &= 0x07;
+            (sign << 31) | (((e + 127) as u32) << 23) | (mant << 20)
+        }
+        // The single E4M3FN NaN encoding: exponent and mantissa both all-ones.
+        (0x0f, 0x07) => (sign << 31) | 0x7fc0_0000,
+        // Normal (including exponent=0b1111 with a non-max mantissa, which
+        // is a finite value in this "FN" variant, not infinity).
+        _ => (sign << 31) | (((exp as i32 - 7 + 127) as u32) << 23) | (frac << 20),
+    };
+
+    f32::from_bits(f32_bits)
+}
+
+/// Widen an OCP FP8 E5M2 (safetensors `F8_E5M2`, PyTorch `float8_e5m2`) bit
+/// pattern to `f32`, exactly.
+///
+/// Standard IEEE-754-style layout: 1 sign bit, 5 exponent bits (bias 15), 2
+/// mantissa bits, with the all-ones exponent field reserved for infinity
+/// (zero mantissa) and NaN (nonzero mantissa) — same shape as f16, just
+/// narrower. Distinct from `F8_E5M2FNUZ`, which this function does not
+/// decode (lattice#684).
+#[cfg(feature = "f16")]
+#[inline]
+pub(crate) fn f8_e5m2_bits_to_f32(bits: u8) -> f32 {
+    let sign = ((bits >> 7) & 0x1) as u32;
+    let exp = ((bits >> 2) & 0x1f) as u32;
+    let frac = (bits & 0x03) as u32;
+
+    let f32_bits = match (exp, frac) {
+        // Zero (signed)
+        (0, 0) => sign << 31,
+        // Subnormal: normalize by shifting the leading 1 into bit 2, then
+        // strip it and treat the remainder as the f32 mantissa.
+        (0, _) => {
+            let mut mant = frac;
+            let mut e = -14i32;
+            while (mant & 0x04) == 0 {
+                mant <<= 1;
+                e -= 1;
+            }
+            mant &= 0x03;
+            (sign << 31) | (((e + 127) as u32) << 23) | (mant << 21)
+        }
+        // Infinity
+        (0x1f, 0) => (sign << 31) | 0x7f80_0000,
+        // NaN
+        (0x1f, _) => (sign << 31) | 0x7fc0_0000 | (frac << 21),
+        // Normal
+        _ => (sign << 31) | (((exp as i32 - 15 + 127) as u32) << 23) | (frac << 21),
+    };
+
+    f32::from_bits(f32_bits)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -374,5 +457,627 @@ mod tests {
             assert_eq!(f32_to_f16_bits(f), bits, "encode mismatch for {f}");
             assert_eq!(f16_bits_to_f32(bits), f, "decode mismatch for {bits:#06x}");
         }
+    }
+
+    /// Exhaustive independent-oracle table (lattice#684) for OCP FP8 E4M3
+    /// (`torch.float8_e4m3fn`), covering all 256 bit patterns. Generated via:
+    ///
+    /// ```python
+    /// import torch
+    /// for b in range(256):
+    ///     t = torch.tensor([b], dtype=torch.uint8).view(torch.float8_e4m3fn)
+    ///     f = t.float().item()
+    ///     # f != f (NaN) -> None; else f32 bit pattern of f -> Some(bits)
+    /// ```
+    ///
+    /// `torch` shares no code with this module's hand-rolled bit math, so
+    /// this is a genuine independent-decoder check, the same role the `half`
+    /// crate plays for the f16/bf16 oracle tests above.
+    #[cfg(feature = "f16")]
+    const F8_E4M3_ORACLE: [(u8, Option<u32>); 256] = [
+        (0x00, Some(0x00000000_u32)),
+        (0x01, Some(0x3b000000_u32)),
+        (0x02, Some(0x3b800000_u32)),
+        (0x03, Some(0x3bc00000_u32)),
+        (0x04, Some(0x3c000000_u32)),
+        (0x05, Some(0x3c200000_u32)),
+        (0x06, Some(0x3c400000_u32)),
+        (0x07, Some(0x3c600000_u32)),
+        (0x08, Some(0x3c800000_u32)),
+        (0x09, Some(0x3c900000_u32)),
+        (0x0a, Some(0x3ca00000_u32)),
+        (0x0b, Some(0x3cb00000_u32)),
+        (0x0c, Some(0x3cc00000_u32)),
+        (0x0d, Some(0x3cd00000_u32)),
+        (0x0e, Some(0x3ce00000_u32)),
+        (0x0f, Some(0x3cf00000_u32)),
+        (0x10, Some(0x3d000000_u32)),
+        (0x11, Some(0x3d100000_u32)),
+        (0x12, Some(0x3d200000_u32)),
+        (0x13, Some(0x3d300000_u32)),
+        (0x14, Some(0x3d400000_u32)),
+        (0x15, Some(0x3d500000_u32)),
+        (0x16, Some(0x3d600000_u32)),
+        (0x17, Some(0x3d700000_u32)),
+        (0x18, Some(0x3d800000_u32)),
+        (0x19, Some(0x3d900000_u32)),
+        (0x1a, Some(0x3da00000_u32)),
+        (0x1b, Some(0x3db00000_u32)),
+        (0x1c, Some(0x3dc00000_u32)),
+        (0x1d, Some(0x3dd00000_u32)),
+        (0x1e, Some(0x3de00000_u32)),
+        (0x1f, Some(0x3df00000_u32)),
+        (0x20, Some(0x3e000000_u32)),
+        (0x21, Some(0x3e100000_u32)),
+        (0x22, Some(0x3e200000_u32)),
+        (0x23, Some(0x3e300000_u32)),
+        (0x24, Some(0x3e400000_u32)),
+        (0x25, Some(0x3e500000_u32)),
+        (0x26, Some(0x3e600000_u32)),
+        (0x27, Some(0x3e700000_u32)),
+        (0x28, Some(0x3e800000_u32)),
+        (0x29, Some(0x3e900000_u32)),
+        (0x2a, Some(0x3ea00000_u32)),
+        (0x2b, Some(0x3eb00000_u32)),
+        (0x2c, Some(0x3ec00000_u32)),
+        (0x2d, Some(0x3ed00000_u32)),
+        (0x2e, Some(0x3ee00000_u32)),
+        (0x2f, Some(0x3ef00000_u32)),
+        (0x30, Some(0x3f000000_u32)),
+        (0x31, Some(0x3f100000_u32)),
+        (0x32, Some(0x3f200000_u32)),
+        (0x33, Some(0x3f300000_u32)),
+        (0x34, Some(0x3f400000_u32)),
+        (0x35, Some(0x3f500000_u32)),
+        (0x36, Some(0x3f600000_u32)),
+        (0x37, Some(0x3f700000_u32)),
+        (0x38, Some(0x3f800000_u32)),
+        (0x39, Some(0x3f900000_u32)),
+        (0x3a, Some(0x3fa00000_u32)),
+        (0x3b, Some(0x3fb00000_u32)),
+        (0x3c, Some(0x3fc00000_u32)),
+        (0x3d, Some(0x3fd00000_u32)),
+        (0x3e, Some(0x3fe00000_u32)),
+        (0x3f, Some(0x3ff00000_u32)),
+        (0x40, Some(0x40000000_u32)),
+        (0x41, Some(0x40100000_u32)),
+        (0x42, Some(0x40200000_u32)),
+        (0x43, Some(0x40300000_u32)),
+        (0x44, Some(0x40400000_u32)),
+        (0x45, Some(0x40500000_u32)),
+        (0x46, Some(0x40600000_u32)),
+        (0x47, Some(0x40700000_u32)),
+        (0x48, Some(0x40800000_u32)),
+        (0x49, Some(0x40900000_u32)),
+        (0x4a, Some(0x40a00000_u32)),
+        (0x4b, Some(0x40b00000_u32)),
+        (0x4c, Some(0x40c00000_u32)),
+        (0x4d, Some(0x40d00000_u32)),
+        (0x4e, Some(0x40e00000_u32)),
+        (0x4f, Some(0x40f00000_u32)),
+        (0x50, Some(0x41000000_u32)),
+        (0x51, Some(0x41100000_u32)),
+        (0x52, Some(0x41200000_u32)),
+        (0x53, Some(0x41300000_u32)),
+        (0x54, Some(0x41400000_u32)),
+        (0x55, Some(0x41500000_u32)),
+        (0x56, Some(0x41600000_u32)),
+        (0x57, Some(0x41700000_u32)),
+        (0x58, Some(0x41800000_u32)),
+        (0x59, Some(0x41900000_u32)),
+        (0x5a, Some(0x41a00000_u32)),
+        (0x5b, Some(0x41b00000_u32)),
+        (0x5c, Some(0x41c00000_u32)),
+        (0x5d, Some(0x41d00000_u32)),
+        (0x5e, Some(0x41e00000_u32)),
+        (0x5f, Some(0x41f00000_u32)),
+        (0x60, Some(0x42000000_u32)),
+        (0x61, Some(0x42100000_u32)),
+        (0x62, Some(0x42200000_u32)),
+        (0x63, Some(0x42300000_u32)),
+        (0x64, Some(0x42400000_u32)),
+        (0x65, Some(0x42500000_u32)),
+        (0x66, Some(0x42600000_u32)),
+        (0x67, Some(0x42700000_u32)),
+        (0x68, Some(0x42800000_u32)),
+        (0x69, Some(0x42900000_u32)),
+        (0x6a, Some(0x42a00000_u32)),
+        (0x6b, Some(0x42b00000_u32)),
+        (0x6c, Some(0x42c00000_u32)),
+        (0x6d, Some(0x42d00000_u32)),
+        (0x6e, Some(0x42e00000_u32)),
+        (0x6f, Some(0x42f00000_u32)),
+        (0x70, Some(0x43000000_u32)),
+        (0x71, Some(0x43100000_u32)),
+        (0x72, Some(0x43200000_u32)),
+        (0x73, Some(0x43300000_u32)),
+        (0x74, Some(0x43400000_u32)),
+        (0x75, Some(0x43500000_u32)),
+        (0x76, Some(0x43600000_u32)),
+        (0x77, Some(0x43700000_u32)),
+        (0x78, Some(0x43800000_u32)),
+        (0x79, Some(0x43900000_u32)),
+        (0x7a, Some(0x43a00000_u32)),
+        (0x7b, Some(0x43b00000_u32)),
+        (0x7c, Some(0x43c00000_u32)),
+        (0x7d, Some(0x43d00000_u32)),
+        (0x7e, Some(0x43e00000_u32)),
+        (0x7f, None),
+        (0x80, Some(0x80000000_u32)),
+        (0x81, Some(0xbb000000_u32)),
+        (0x82, Some(0xbb800000_u32)),
+        (0x83, Some(0xbbc00000_u32)),
+        (0x84, Some(0xbc000000_u32)),
+        (0x85, Some(0xbc200000_u32)),
+        (0x86, Some(0xbc400000_u32)),
+        (0x87, Some(0xbc600000_u32)),
+        (0x88, Some(0xbc800000_u32)),
+        (0x89, Some(0xbc900000_u32)),
+        (0x8a, Some(0xbca00000_u32)),
+        (0x8b, Some(0xbcb00000_u32)),
+        (0x8c, Some(0xbcc00000_u32)),
+        (0x8d, Some(0xbcd00000_u32)),
+        (0x8e, Some(0xbce00000_u32)),
+        (0x8f, Some(0xbcf00000_u32)),
+        (0x90, Some(0xbd000000_u32)),
+        (0x91, Some(0xbd100000_u32)),
+        (0x92, Some(0xbd200000_u32)),
+        (0x93, Some(0xbd300000_u32)),
+        (0x94, Some(0xbd400000_u32)),
+        (0x95, Some(0xbd500000_u32)),
+        (0x96, Some(0xbd600000_u32)),
+        (0x97, Some(0xbd700000_u32)),
+        (0x98, Some(0xbd800000_u32)),
+        (0x99, Some(0xbd900000_u32)),
+        (0x9a, Some(0xbda00000_u32)),
+        (0x9b, Some(0xbdb00000_u32)),
+        (0x9c, Some(0xbdc00000_u32)),
+        (0x9d, Some(0xbdd00000_u32)),
+        (0x9e, Some(0xbde00000_u32)),
+        (0x9f, Some(0xbdf00000_u32)),
+        (0xa0, Some(0xbe000000_u32)),
+        (0xa1, Some(0xbe100000_u32)),
+        (0xa2, Some(0xbe200000_u32)),
+        (0xa3, Some(0xbe300000_u32)),
+        (0xa4, Some(0xbe400000_u32)),
+        (0xa5, Some(0xbe500000_u32)),
+        (0xa6, Some(0xbe600000_u32)),
+        (0xa7, Some(0xbe700000_u32)),
+        (0xa8, Some(0xbe800000_u32)),
+        (0xa9, Some(0xbe900000_u32)),
+        (0xaa, Some(0xbea00000_u32)),
+        (0xab, Some(0xbeb00000_u32)),
+        (0xac, Some(0xbec00000_u32)),
+        (0xad, Some(0xbed00000_u32)),
+        (0xae, Some(0xbee00000_u32)),
+        (0xaf, Some(0xbef00000_u32)),
+        (0xb0, Some(0xbf000000_u32)),
+        (0xb1, Some(0xbf100000_u32)),
+        (0xb2, Some(0xbf200000_u32)),
+        (0xb3, Some(0xbf300000_u32)),
+        (0xb4, Some(0xbf400000_u32)),
+        (0xb5, Some(0xbf500000_u32)),
+        (0xb6, Some(0xbf600000_u32)),
+        (0xb7, Some(0xbf700000_u32)),
+        (0xb8, Some(0xbf800000_u32)),
+        (0xb9, Some(0xbf900000_u32)),
+        (0xba, Some(0xbfa00000_u32)),
+        (0xbb, Some(0xbfb00000_u32)),
+        (0xbc, Some(0xbfc00000_u32)),
+        (0xbd, Some(0xbfd00000_u32)),
+        (0xbe, Some(0xbfe00000_u32)),
+        (0xbf, Some(0xbff00000_u32)),
+        (0xc0, Some(0xc0000000_u32)),
+        (0xc1, Some(0xc0100000_u32)),
+        (0xc2, Some(0xc0200000_u32)),
+        (0xc3, Some(0xc0300000_u32)),
+        (0xc4, Some(0xc0400000_u32)),
+        (0xc5, Some(0xc0500000_u32)),
+        (0xc6, Some(0xc0600000_u32)),
+        (0xc7, Some(0xc0700000_u32)),
+        (0xc8, Some(0xc0800000_u32)),
+        (0xc9, Some(0xc0900000_u32)),
+        (0xca, Some(0xc0a00000_u32)),
+        (0xcb, Some(0xc0b00000_u32)),
+        (0xcc, Some(0xc0c00000_u32)),
+        (0xcd, Some(0xc0d00000_u32)),
+        (0xce, Some(0xc0e00000_u32)),
+        (0xcf, Some(0xc0f00000_u32)),
+        (0xd0, Some(0xc1000000_u32)),
+        (0xd1, Some(0xc1100000_u32)),
+        (0xd2, Some(0xc1200000_u32)),
+        (0xd3, Some(0xc1300000_u32)),
+        (0xd4, Some(0xc1400000_u32)),
+        (0xd5, Some(0xc1500000_u32)),
+        (0xd6, Some(0xc1600000_u32)),
+        (0xd7, Some(0xc1700000_u32)),
+        (0xd8, Some(0xc1800000_u32)),
+        (0xd9, Some(0xc1900000_u32)),
+        (0xda, Some(0xc1a00000_u32)),
+        (0xdb, Some(0xc1b00000_u32)),
+        (0xdc, Some(0xc1c00000_u32)),
+        (0xdd, Some(0xc1d00000_u32)),
+        (0xde, Some(0xc1e00000_u32)),
+        (0xdf, Some(0xc1f00000_u32)),
+        (0xe0, Some(0xc2000000_u32)),
+        (0xe1, Some(0xc2100000_u32)),
+        (0xe2, Some(0xc2200000_u32)),
+        (0xe3, Some(0xc2300000_u32)),
+        (0xe4, Some(0xc2400000_u32)),
+        (0xe5, Some(0xc2500000_u32)),
+        (0xe6, Some(0xc2600000_u32)),
+        (0xe7, Some(0xc2700000_u32)),
+        (0xe8, Some(0xc2800000_u32)),
+        (0xe9, Some(0xc2900000_u32)),
+        (0xea, Some(0xc2a00000_u32)),
+        (0xeb, Some(0xc2b00000_u32)),
+        (0xec, Some(0xc2c00000_u32)),
+        (0xed, Some(0xc2d00000_u32)),
+        (0xee, Some(0xc2e00000_u32)),
+        (0xef, Some(0xc2f00000_u32)),
+        (0xf0, Some(0xc3000000_u32)),
+        (0xf1, Some(0xc3100000_u32)),
+        (0xf2, Some(0xc3200000_u32)),
+        (0xf3, Some(0xc3300000_u32)),
+        (0xf4, Some(0xc3400000_u32)),
+        (0xf5, Some(0xc3500000_u32)),
+        (0xf6, Some(0xc3600000_u32)),
+        (0xf7, Some(0xc3700000_u32)),
+        (0xf8, Some(0xc3800000_u32)),
+        (0xf9, Some(0xc3900000_u32)),
+        (0xfa, Some(0xc3a00000_u32)),
+        (0xfb, Some(0xc3b00000_u32)),
+        (0xfc, Some(0xc3c00000_u32)),
+        (0xfd, Some(0xc3d00000_u32)),
+        (0xfe, Some(0xc3e00000_u32)),
+        (0xff, None),
+    ];
+
+    #[cfg(feature = "f16")]
+    #[test]
+    fn f8_e4m3_bits_to_f32_matches_independent_torch_oracle_exhaustive() {
+        let mut checked = 0u32;
+        for &(bits, expected) in &F8_E4M3_ORACLE {
+            let got = f8_e4m3_bits_to_f32(bits);
+            match expected {
+                Some(bits_expected) => {
+                    assert_eq!(
+                        got.to_bits(),
+                        bits_expected,
+                        "f8_e4m3_bits_to_f32({bits:#04x}) diverges from torch oracle: \
+                         ours={:#010x} oracle={bits_expected:#010x}",
+                        got.to_bits()
+                    );
+                }
+                None => {
+                    assert!(got.is_nan(), "bits {bits:#04x} must decode to NaN");
+                }
+            }
+            checked += 1;
+        }
+        assert_eq!(
+            checked, 256,
+            "expected the full E4M3 8-bit space to be checked"
+        );
+    }
+
+    #[cfg(feature = "f16")]
+    #[test]
+    fn f8_e4m3_special_values() {
+        assert_eq!(f8_e4m3_bits_to_f32(0x00), 0.0f32);
+        assert!(f8_e4m3_bits_to_f32(0x80).is_sign_negative());
+        assert_eq!(f8_e4m3_bits_to_f32(0x80), 0.0f32);
+        assert_eq!(f8_e4m3_bits_to_f32(0x38), 1.0f32); // 0_0111_000
+        assert_eq!(f8_e4m3_bits_to_f32(0xb8), -1.0f32);
+        assert_eq!(f8_e4m3_bits_to_f32(0x7e), 448.0f32); // largest finite E4M3
+        assert!(f8_e4m3_bits_to_f32(0x7f).is_nan());
+        assert!(f8_e4m3_bits_to_f32(0xff).is_nan());
+        // No infinities in this "FN" variant — the top of the finite range
+        // is a normal, non-special value.
+        assert!(f8_e4m3_bits_to_f32(0x7e).is_finite());
+    }
+
+    /// Exhaustive independent-oracle table (lattice#684) for OCP FP8 E5M2
+    /// (`torch.float8_e5m2`), covering all 256 bit patterns. Generated the
+    /// same way as `F8_E4M3_ORACLE` above, substituting `torch.float8_e5m2`.
+    #[cfg(feature = "f16")]
+    const F8_E5M2_ORACLE: [(u8, Option<u32>); 256] = [
+        (0x00, Some(0x00000000_u32)),
+        (0x01, Some(0x37800000_u32)),
+        (0x02, Some(0x38000000_u32)),
+        (0x03, Some(0x38400000_u32)),
+        (0x04, Some(0x38800000_u32)),
+        (0x05, Some(0x38a00000_u32)),
+        (0x06, Some(0x38c00000_u32)),
+        (0x07, Some(0x38e00000_u32)),
+        (0x08, Some(0x39000000_u32)),
+        (0x09, Some(0x39200000_u32)),
+        (0x0a, Some(0x39400000_u32)),
+        (0x0b, Some(0x39600000_u32)),
+        (0x0c, Some(0x39800000_u32)),
+        (0x0d, Some(0x39a00000_u32)),
+        (0x0e, Some(0x39c00000_u32)),
+        (0x0f, Some(0x39e00000_u32)),
+        (0x10, Some(0x3a000000_u32)),
+        (0x11, Some(0x3a200000_u32)),
+        (0x12, Some(0x3a400000_u32)),
+        (0x13, Some(0x3a600000_u32)),
+        (0x14, Some(0x3a800000_u32)),
+        (0x15, Some(0x3aa00000_u32)),
+        (0x16, Some(0x3ac00000_u32)),
+        (0x17, Some(0x3ae00000_u32)),
+        (0x18, Some(0x3b000000_u32)),
+        (0x19, Some(0x3b200000_u32)),
+        (0x1a, Some(0x3b400000_u32)),
+        (0x1b, Some(0x3b600000_u32)),
+        (0x1c, Some(0x3b800000_u32)),
+        (0x1d, Some(0x3ba00000_u32)),
+        (0x1e, Some(0x3bc00000_u32)),
+        (0x1f, Some(0x3be00000_u32)),
+        (0x20, Some(0x3c000000_u32)),
+        (0x21, Some(0x3c200000_u32)),
+        (0x22, Some(0x3c400000_u32)),
+        (0x23, Some(0x3c600000_u32)),
+        (0x24, Some(0x3c800000_u32)),
+        (0x25, Some(0x3ca00000_u32)),
+        (0x26, Some(0x3cc00000_u32)),
+        (0x27, Some(0x3ce00000_u32)),
+        (0x28, Some(0x3d000000_u32)),
+        (0x29, Some(0x3d200000_u32)),
+        (0x2a, Some(0x3d400000_u32)),
+        (0x2b, Some(0x3d600000_u32)),
+        (0x2c, Some(0x3d800000_u32)),
+        (0x2d, Some(0x3da00000_u32)),
+        (0x2e, Some(0x3dc00000_u32)),
+        (0x2f, Some(0x3de00000_u32)),
+        (0x30, Some(0x3e000000_u32)),
+        (0x31, Some(0x3e200000_u32)),
+        (0x32, Some(0x3e400000_u32)),
+        (0x33, Some(0x3e600000_u32)),
+        (0x34, Some(0x3e800000_u32)),
+        (0x35, Some(0x3ea00000_u32)),
+        (0x36, Some(0x3ec00000_u32)),
+        (0x37, Some(0x3ee00000_u32)),
+        (0x38, Some(0x3f000000_u32)),
+        (0x39, Some(0x3f200000_u32)),
+        (0x3a, Some(0x3f400000_u32)),
+        (0x3b, Some(0x3f600000_u32)),
+        (0x3c, Some(0x3f800000_u32)),
+        (0x3d, Some(0x3fa00000_u32)),
+        (0x3e, Some(0x3fc00000_u32)),
+        (0x3f, Some(0x3fe00000_u32)),
+        (0x40, Some(0x40000000_u32)),
+        (0x41, Some(0x40200000_u32)),
+        (0x42, Some(0x40400000_u32)),
+        (0x43, Some(0x40600000_u32)),
+        (0x44, Some(0x40800000_u32)),
+        (0x45, Some(0x40a00000_u32)),
+        (0x46, Some(0x40c00000_u32)),
+        (0x47, Some(0x40e00000_u32)),
+        (0x48, Some(0x41000000_u32)),
+        (0x49, Some(0x41200000_u32)),
+        (0x4a, Some(0x41400000_u32)),
+        (0x4b, Some(0x41600000_u32)),
+        (0x4c, Some(0x41800000_u32)),
+        (0x4d, Some(0x41a00000_u32)),
+        (0x4e, Some(0x41c00000_u32)),
+        (0x4f, Some(0x41e00000_u32)),
+        (0x50, Some(0x42000000_u32)),
+        (0x51, Some(0x42200000_u32)),
+        (0x52, Some(0x42400000_u32)),
+        (0x53, Some(0x42600000_u32)),
+        (0x54, Some(0x42800000_u32)),
+        (0x55, Some(0x42a00000_u32)),
+        (0x56, Some(0x42c00000_u32)),
+        (0x57, Some(0x42e00000_u32)),
+        (0x58, Some(0x43000000_u32)),
+        (0x59, Some(0x43200000_u32)),
+        (0x5a, Some(0x43400000_u32)),
+        (0x5b, Some(0x43600000_u32)),
+        (0x5c, Some(0x43800000_u32)),
+        (0x5d, Some(0x43a00000_u32)),
+        (0x5e, Some(0x43c00000_u32)),
+        (0x5f, Some(0x43e00000_u32)),
+        (0x60, Some(0x44000000_u32)),
+        (0x61, Some(0x44200000_u32)),
+        (0x62, Some(0x44400000_u32)),
+        (0x63, Some(0x44600000_u32)),
+        (0x64, Some(0x44800000_u32)),
+        (0x65, Some(0x44a00000_u32)),
+        (0x66, Some(0x44c00000_u32)),
+        (0x67, Some(0x44e00000_u32)),
+        (0x68, Some(0x45000000_u32)),
+        (0x69, Some(0x45200000_u32)),
+        (0x6a, Some(0x45400000_u32)),
+        (0x6b, Some(0x45600000_u32)),
+        (0x6c, Some(0x45800000_u32)),
+        (0x6d, Some(0x45a00000_u32)),
+        (0x6e, Some(0x45c00000_u32)),
+        (0x6f, Some(0x45e00000_u32)),
+        (0x70, Some(0x46000000_u32)),
+        (0x71, Some(0x46200000_u32)),
+        (0x72, Some(0x46400000_u32)),
+        (0x73, Some(0x46600000_u32)),
+        (0x74, Some(0x46800000_u32)),
+        (0x75, Some(0x46a00000_u32)),
+        (0x76, Some(0x46c00000_u32)),
+        (0x77, Some(0x46e00000_u32)),
+        (0x78, Some(0x47000000_u32)),
+        (0x79, Some(0x47200000_u32)),
+        (0x7a, Some(0x47400000_u32)),
+        (0x7b, Some(0x47600000_u32)),
+        (0x7c, Some(0x7f800000_u32)),
+        (0x7d, None),
+        (0x7e, None),
+        (0x7f, None),
+        (0x80, Some(0x80000000_u32)),
+        (0x81, Some(0xb7800000_u32)),
+        (0x82, Some(0xb8000000_u32)),
+        (0x83, Some(0xb8400000_u32)),
+        (0x84, Some(0xb8800000_u32)),
+        (0x85, Some(0xb8a00000_u32)),
+        (0x86, Some(0xb8c00000_u32)),
+        (0x87, Some(0xb8e00000_u32)),
+        (0x88, Some(0xb9000000_u32)),
+        (0x89, Some(0xb9200000_u32)),
+        (0x8a, Some(0xb9400000_u32)),
+        (0x8b, Some(0xb9600000_u32)),
+        (0x8c, Some(0xb9800000_u32)),
+        (0x8d, Some(0xb9a00000_u32)),
+        (0x8e, Some(0xb9c00000_u32)),
+        (0x8f, Some(0xb9e00000_u32)),
+        (0x90, Some(0xba000000_u32)),
+        (0x91, Some(0xba200000_u32)),
+        (0x92, Some(0xba400000_u32)),
+        (0x93, Some(0xba600000_u32)),
+        (0x94, Some(0xba800000_u32)),
+        (0x95, Some(0xbaa00000_u32)),
+        (0x96, Some(0xbac00000_u32)),
+        (0x97, Some(0xbae00000_u32)),
+        (0x98, Some(0xbb000000_u32)),
+        (0x99, Some(0xbb200000_u32)),
+        (0x9a, Some(0xbb400000_u32)),
+        (0x9b, Some(0xbb600000_u32)),
+        (0x9c, Some(0xbb800000_u32)),
+        (0x9d, Some(0xbba00000_u32)),
+        (0x9e, Some(0xbbc00000_u32)),
+        (0x9f, Some(0xbbe00000_u32)),
+        (0xa0, Some(0xbc000000_u32)),
+        (0xa1, Some(0xbc200000_u32)),
+        (0xa2, Some(0xbc400000_u32)),
+        (0xa3, Some(0xbc600000_u32)),
+        (0xa4, Some(0xbc800000_u32)),
+        (0xa5, Some(0xbca00000_u32)),
+        (0xa6, Some(0xbcc00000_u32)),
+        (0xa7, Some(0xbce00000_u32)),
+        (0xa8, Some(0xbd000000_u32)),
+        (0xa9, Some(0xbd200000_u32)),
+        (0xaa, Some(0xbd400000_u32)),
+        (0xab, Some(0xbd600000_u32)),
+        (0xac, Some(0xbd800000_u32)),
+        (0xad, Some(0xbda00000_u32)),
+        (0xae, Some(0xbdc00000_u32)),
+        (0xaf, Some(0xbde00000_u32)),
+        (0xb0, Some(0xbe000000_u32)),
+        (0xb1, Some(0xbe200000_u32)),
+        (0xb2, Some(0xbe400000_u32)),
+        (0xb3, Some(0xbe600000_u32)),
+        (0xb4, Some(0xbe800000_u32)),
+        (0xb5, Some(0xbea00000_u32)),
+        (0xb6, Some(0xbec00000_u32)),
+        (0xb7, Some(0xbee00000_u32)),
+        (0xb8, Some(0xbf000000_u32)),
+        (0xb9, Some(0xbf200000_u32)),
+        (0xba, Some(0xbf400000_u32)),
+        (0xbb, Some(0xbf600000_u32)),
+        (0xbc, Some(0xbf800000_u32)),
+        (0xbd, Some(0xbfa00000_u32)),
+        (0xbe, Some(0xbfc00000_u32)),
+        (0xbf, Some(0xbfe00000_u32)),
+        (0xc0, Some(0xc0000000_u32)),
+        (0xc1, Some(0xc0200000_u32)),
+        (0xc2, Some(0xc0400000_u32)),
+        (0xc3, Some(0xc0600000_u32)),
+        (0xc4, Some(0xc0800000_u32)),
+        (0xc5, Some(0xc0a00000_u32)),
+        (0xc6, Some(0xc0c00000_u32)),
+        (0xc7, Some(0xc0e00000_u32)),
+        (0xc8, Some(0xc1000000_u32)),
+        (0xc9, Some(0xc1200000_u32)),
+        (0xca, Some(0xc1400000_u32)),
+        (0xcb, Some(0xc1600000_u32)),
+        (0xcc, Some(0xc1800000_u32)),
+        (0xcd, Some(0xc1a00000_u32)),
+        (0xce, Some(0xc1c00000_u32)),
+        (0xcf, Some(0xc1e00000_u32)),
+        (0xd0, Some(0xc2000000_u32)),
+        (0xd1, Some(0xc2200000_u32)),
+        (0xd2, Some(0xc2400000_u32)),
+        (0xd3, Some(0xc2600000_u32)),
+        (0xd4, Some(0xc2800000_u32)),
+        (0xd5, Some(0xc2a00000_u32)),
+        (0xd6, Some(0xc2c00000_u32)),
+        (0xd7, Some(0xc2e00000_u32)),
+        (0xd8, Some(0xc3000000_u32)),
+        (0xd9, Some(0xc3200000_u32)),
+        (0xda, Some(0xc3400000_u32)),
+        (0xdb, Some(0xc3600000_u32)),
+        (0xdc, Some(0xc3800000_u32)),
+        (0xdd, Some(0xc3a00000_u32)),
+        (0xde, Some(0xc3c00000_u32)),
+        (0xdf, Some(0xc3e00000_u32)),
+        (0xe0, Some(0xc4000000_u32)),
+        (0xe1, Some(0xc4200000_u32)),
+        (0xe2, Some(0xc4400000_u32)),
+        (0xe3, Some(0xc4600000_u32)),
+        (0xe4, Some(0xc4800000_u32)),
+        (0xe5, Some(0xc4a00000_u32)),
+        (0xe6, Some(0xc4c00000_u32)),
+        (0xe7, Some(0xc4e00000_u32)),
+        (0xe8, Some(0xc5000000_u32)),
+        (0xe9, Some(0xc5200000_u32)),
+        (0xea, Some(0xc5400000_u32)),
+        (0xeb, Some(0xc5600000_u32)),
+        (0xec, Some(0xc5800000_u32)),
+        (0xed, Some(0xc5a00000_u32)),
+        (0xee, Some(0xc5c00000_u32)),
+        (0xef, Some(0xc5e00000_u32)),
+        (0xf0, Some(0xc6000000_u32)),
+        (0xf1, Some(0xc6200000_u32)),
+        (0xf2, Some(0xc6400000_u32)),
+        (0xf3, Some(0xc6600000_u32)),
+        (0xf4, Some(0xc6800000_u32)),
+        (0xf5, Some(0xc6a00000_u32)),
+        (0xf6, Some(0xc6c00000_u32)),
+        (0xf7, Some(0xc6e00000_u32)),
+        (0xf8, Some(0xc7000000_u32)),
+        (0xf9, Some(0xc7200000_u32)),
+        (0xfa, Some(0xc7400000_u32)),
+        (0xfb, Some(0xc7600000_u32)),
+        (0xfc, Some(0xff800000_u32)),
+        (0xfd, None),
+        (0xfe, None),
+        (0xff, None),
+    ];
+
+    #[cfg(feature = "f16")]
+    #[test]
+    fn f8_e5m2_bits_to_f32_matches_independent_torch_oracle_exhaustive() {
+        let mut checked = 0u32;
+        for &(bits, expected) in &F8_E5M2_ORACLE {
+            let got = f8_e5m2_bits_to_f32(bits);
+            match expected {
+                Some(bits_expected) => {
+                    assert_eq!(
+                        got.to_bits(),
+                        bits_expected,
+                        "f8_e5m2_bits_to_f32({bits:#04x}) diverges from torch oracle: \
+                         ours={:#010x} oracle={bits_expected:#010x}",
+                        got.to_bits()
+                    );
+                }
+                None => {
+                    assert!(got.is_nan(), "bits {bits:#04x} must decode to NaN");
+                }
+            }
+            checked += 1;
+        }
+        assert_eq!(
+            checked, 256,
+            "expected the full E5M2 8-bit space to be checked"
+        );
+    }
+
+    #[cfg(feature = "f16")]
+    #[test]
+    fn f8_e5m2_special_values() {
+        assert_eq!(f8_e5m2_bits_to_f32(0x00), 0.0f32);
+        assert!(f8_e5m2_bits_to_f32(0x80).is_sign_negative());
+        assert_eq!(f8_e5m2_bits_to_f32(0x80), 0.0f32);
+        assert_eq!(f8_e5m2_bits_to_f32(0x3c), 1.0f32); // 0_01111_00
+        assert_eq!(f8_e5m2_bits_to_f32(0xbc), -1.0f32);
+        assert_eq!(f8_e5m2_bits_to_f32(0x7c), f32::INFINITY);
+        assert_eq!(f8_e5m2_bits_to_f32(0xfc), f32::NEG_INFINITY);
+        assert!(f8_e5m2_bits_to_f32(0x7f).is_nan());
     }
 }


### PR DESCRIPTION
Part of #684 (CPU slice; Metal dequant and full FP8-checkpoint loader wiring remain follow-up).

Adds OCP FP8 decode primitives `f8_e4m3_bits_to_f32` / `f8_e5m2_bits_to_f32` (non-FNUZ variants only — FNUZ zero/inf/NaN semantics differ and stay rejected) to `weights/half_bits.rs`, and wires `DType::F8E4M3` / `DType::F8E5M2` through `SafetensorsFile::get_f32_tensor` mirroring the existing F16/BF16 arms, including the non-finite ingress-validation reject path. Previously these dtypes were recognized structurally (extent validation) but hard-rejected at materialization.

Gated `#[cfg(feature = "f16")]` like the other reduced-precision decode paths; no manifest, feature-set, or lockfile changes.

**Correctness evidence**: each format's decode is verified against an exhaustive 256-bit-pattern oracle table generated from PyTorch (`torch.float8_e4m3fn` / `torch.float8_e5m2`, torch 2.11.0) — an independent implementation sharing no code with the Rust bit math. Special-value tests (zero, negative zero, NaN patterns, E5M2 infinities, max-finite) and end-to-end safetensors-path decode tests included. Mutation check run for both formats: flipping the exponent bias constant fails 3 independent tests per format (oracle sweep, special values, end-to-end decode); restore returns all green.

**Gates** (all rc=0): workspace clippy default features; `-p lattice-inference --all-targets --features f16` clippy; `cargo fmt --all --check`; full `weights::` module (280 tests); default-feature compile unaffected.

**bench-compare disposition (structural)**: no A/B run — the diff is unreachable by any declared bench target. The two touched files change (a) new `#[cfg(feature = "f16")]` functions in `half_bits.rs` and (b) new match arms in `get_f32_tensor` that execute only when a loaded tensor's dtype is F8_E4M3/F8_E5M2. Population searched: all declared bench targets in `crates/inference/Cargo.toml` (including the `required-features = ["f16", ...]` ones, where the code does compile in) and both default `bench-compare` targets. No bench fixture or bench-loaded checkpoint contains an FP8 tensor, so no bench group can execute the new arms; the pre-existing dtype dispatch arms are untouched and weight materialization happens at model-load time, outside every timed region. Build inputs identical between base and head (no manifest/lockfile/feature/profile changes). Residual risk: the FP8 decode path itself is unmeasured; when the Metal dequant follow-up lands, that PR owes a measured run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



### bench-compare disposition

**Verdict: structural waiver — no A/B measurement.**

The change adds two new `#[cfg(feature = "f16")]` FP8 decode functions to `half_bits.rs` and wires them through new match arms in `get_f32_tensor`. All 24 declared bench targets in `crates/inference/Cargo.toml` were searched for a call path to this code. None exercises it:

- The default `bench-compare` target (`elementwise_cpu_bench`) benches CPU elementwise, norm, and activation kernels — no safetensors loading, no `get_f32_tensor` call.
- `f16_convert_bench`'s `safetensors_ingress_widen` group calls `get_f32_tensor` but only with `"F16"` and `"BF16"` fixture files — the new `F8_E4M3`/`F8_E5M2` match arms are compiled but never reached by a bench group.
- The four `f16`-gated bench targets (`decode_attn_bench`, `metal_decode_bench`, `cross_turn_prefix_cache_bench`, `mtp_decode`) load model checkpoints via `from_safetensors`, but no published or fixture checkpoint contains an FP8 tensor, so the new decode path cannot execute at load time.
- The remaining 19 targets are attention, KV-cache, tokenizer, grammar, pruning, Hadamard, and other domain benches — none reference safetensors or the weights module's decode API at all.

The same absence applies to `crates/embed/benches/` and `crates/fann/benches/`.

**Build-input check**: no manifest, lockfile, feature, profile, build-script, bench-definition, or harness changes. The change is pure runtime source, so no pre-compilation or runner-invocation path is different.

**Residual risk**: the FP8 decode throughput and ingress latency are unmeasured. The decode is a byte-per-element widening with a branch-heavy subnormal path — worst-case patterns (all subnormals) may be significantly slower than the measured F16/BF16 arms. Coverage of this code path belongs in the follow-up that adds Metal dequant on FP8 checkpoints, which will load real FP8 tensors and can report decode latency as part of the full-model bench.

To measure preemptively without an FP8 checkpoint: add `"F8_E4M3"` and `"F8_E5M2"` cases to `f16_convert_bench`'s `safetensors_fixture`/`bench_safetensors_ingress_widen`, then run:

```
cargo bench -p lattice-inference --bench f16_convert_bench --features f16,bench-internals -- safetensors_ingress_widen
```
