### PR TITLE
fix(quant): record QuaRot PPL-gate promotion state instead of implying it

### DIFF
--- a/crates/inference/src/bin/eval_perplexity.rs
+++ b/crates/inference/src/bin/eval_perplexity.rs
@@ -14,7 +14,11 @@
 //!   `quantize_quarot` directory, prints both reports, then the
 //!   `quarot - unrotated` PPL delta and the ADR-044 acceptance gate
 //!   verdict (< 0.5 PPL by default; override with `--delta-threshold`).
-//!   This is the ADR-044 step-4 acceptance measurement.
+//!   This is the ADR-044 step-4 acceptance measurement — it is also the
+//!   ONLY thing that can advance a `quantize_quarot` artifact's promotion
+//!   marker (#1103) out of `unpromoted`: this mode records the measured
+//!   delta/verdict into `<quarot-q4-dir>/quantize_index.json`'s
+//!   `promotion` field (`promoted` on PASS, `rejected` on FAIL).
 //! - `--quarot-q4-dir <PATH>` alone: runs only the QuaRot-Q4 forward path
 //!   (rarely useful — typically you want the unrotated baseline alongside).
 //!
@@ -92,6 +96,7 @@ use lattice_inference::error::InferenceError;
 use lattice_inference::forward::metal_qwen35::{LoraLayerData, MetalQwen35State};
 use lattice_inference::model::qwen35::{PerplexityConfig, PerplexityReport, Qwen35Model};
 use lattice_inference::model::qwen35_config::Qwen35Config;
+use lattice_inference::quant::quarot::convert::record_ppl_gate_result;
 use lattice_inference::tokenizer::bpe::BpeTokenizer;
 use lattice_inference::tokenizer::common::Tokenizer;
 
@@ -440,7 +445,11 @@ fn main() -> ExitCode {
         None
     };
 
-    // Dual mode — compute delta and verdict.
+    // Dual mode — compute delta and verdict, then durably record the
+    // result against the QuaRot artifact's own promotion marker (#1103).
+    // This IS the ADR-044 step-4 acceptance measurement `quantize_quarot`
+    // itself cannot run (no baseline dir or corpus) — recording here closes
+    // the gap between "converter exits 0" and "quality gate ran".
     if let (Some(u), Some(q)) = (&unrotated_report, &quarot_report) {
         let threshold = delta_threshold.unwrap_or(0.5);
         let delta = q.ppl - u.ppl;
@@ -450,6 +459,24 @@ fn main() -> ExitCode {
         println!("QuaRot Q4 PPL:    {:.6}", q.ppl);
         println!("PPL delta:        {delta:+.6}  (quarot - unrotated)");
         println!("Threshold:        < {threshold:.6}");
+
+        let quarot_dir = quarot_q4_dir.as_deref().expect("quarot_report is Some");
+        let record = match record_ppl_gate_result(quarot_dir, u.ppl, q.ppl, threshold) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!(
+                    "ERROR: PPL delta was measured but could not be recorded against {}: {e}",
+                    quarot_dir.display()
+                );
+                return ExitCode::FAILURE;
+            }
+        };
+        println!(
+            "Promotion:        {:?} (recorded to {}/quantize_index.json)",
+            record.state,
+            quarot_dir.display()
+        );
+
         if delta < threshold {
             println!("Verdict:          PASS");
             return ExitCode::SUCCESS;

--- a/crates/inference/src/bin/quantize_quarot.rs
+++ b/crates/inference/src/bin/quantize_quarot.rs
@@ -36,7 +36,12 @@
 //!
 //! Exit codes:
 //! - `0`: conversion succeeded; output dir is complete (or dry-run
-//!   verified the pipeline).
+//!   verified the pipeline). This means the forward-equivalence gate
+//!   passed — it does NOT mean the artifact is quality-validated. Every
+//!   non-dry-run artifact is written with `quantize_index.json`'s
+//!   `promotion` field set to `unpromoted` (see #1103); only a separate
+//!   `eval_perplexity --q4-dir <baseline> --quarot-q4-dir <this output>`
+//!   run can record a `promoted`/`rejected` verdict against it.
 //! - `1`: error (refuse-on-fail, missing file, parse failure, etc.).
 //!   Standard error contains the diagnostic; output dir is left empty
 //!   when the forward-equivalence gate refused.
@@ -162,6 +167,20 @@ fn main() -> ExitCode {
     let elapsed = start.elapsed();
 
     print_report(&report, elapsed.as_secs_f64());
+    if !dry_run {
+        eprintln!();
+        eprintln!("=== Promotion (ADR-044 / #1103) ===");
+        eprintln!("State:             UNPROMOTED");
+        eprintln!(
+            "Reason:            forward-equivalence gate passed (rotation correctness); \
+             the PPL acceptance gate (quantization quality) has not been run."
+        );
+        eprintln!(
+            "Next step:         eval_perplexity --q4-dir <unrotated baseline> \
+             --quarot-q4-dir {} --tokenizer-dir <src> --corpus-file <corpus>",
+            output_dir.display()
+        );
+    }
     ExitCode::SUCCESS
 }
 

--- a/crates/inference/src/quant/quarot/convert.rs
+++ b/crates/inference/src/quant/quarot/convert.rs
@@ -130,6 +130,86 @@ struct IndexEntry {
     numel: usize,
 }
 
+/// Promotion status of a `quantize_quarot` artifact (issue #1103).
+///
+/// The converter's forward-equivalence gate (rotation correctness) and the
+/// ADR-044 PPL acceptance gate (quantization quality, run separately via
+/// `bin/eval_perplexity --q4-dir <baseline> --quarot-q4-dir <this output>`)
+/// check different things. `convert_quarot_qwen35` can only ever establish
+/// [`PromotionState::Unpromoted`] — it has no baseline Q4 directory or
+/// corpus to measure PPL against. Only [`record_ppl_gate_result`], called
+/// after the acceptance measurement actually runs, can flip this to
+/// [`PromotionState::Promoted`] or [`PromotionState::Rejected`].
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PromotionState {
+    /// The PPL acceptance gate has not been recorded against this
+    /// artifact. Default state for every artifact `convert_quarot_qwen35`
+    /// writes; a caller MUST NOT treat an unpromoted artifact as
+    /// quality-validated.
+    Unpromoted,
+    /// A recorded PPL measurement passed the acceptance threshold
+    /// (`delta < threshold`).
+    Promoted,
+    /// A recorded PPL measurement failed the acceptance threshold
+    /// (`delta >= threshold`).
+    Rejected,
+}
+
+/// A recorded ADR-044 dual-Q4 PPL acceptance measurement.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+pub struct PplGateRecord {
+    pub unrotated_ppl: f64,
+    pub quarot_ppl: f64,
+    /// `quarot_ppl - unrotated_ppl`.
+    pub delta: f64,
+    pub delta_threshold: f64,
+}
+
+/// Promotion marker persisted in `quantize_index.json` (issue #1103). Makes
+/// the two-step contract (forward-equivalence at convert time, PPL quality
+/// gate at measurement time) explicit and durable on the artifact itself,
+/// instead of letting a complete artifact + exit 0 read as "fully
+/// validated" when the quality gate never ran.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+pub struct PromotionRecord {
+    pub state: PromotionState,
+    /// Human-readable explanation of `state` — always present so a reader
+    /// never has to infer WHY from the state alone.
+    pub reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ppl_gate: Option<PplGateRecord>,
+}
+
+impl PromotionRecord {
+    fn unpromoted() -> Self {
+        Self {
+            state: PromotionState::Unpromoted,
+            reason: "PPL acceptance gate has not been run against this artifact; run \
+                     `eval_perplexity --q4-dir <unrotated baseline> --quarot-q4-dir <this \
+                     output dir> --tokenizer-dir <src> --corpus-file <corpus>` to record a \
+                     result before treating it as quality-validated (ADR-044 step 4, #1103)."
+                .to_string(),
+            ppl_gate: None,
+        }
+    }
+}
+
+/// Legacy artifacts (pre-#1103) and any manifest missing the `promotion`
+/// field deserialize to this — still `Unpromoted`, with a reason that
+/// distinguishes "never recorded" from "predates promotion tracking".
+impl Default for PromotionRecord {
+    fn default() -> Self {
+        Self {
+            state: PromotionState::Unpromoted,
+            reason: "no promotion record present in quantize_index.json (artifact predates \
+                     #1103 promotion tracking, or the gate has not been run)"
+                .to_string(),
+            ppl_gate: None,
+        }
+    }
+}
+
 /// Wire format for `quantize_index.json` produced by `convert_quarot_qwen35`.
 ///
 /// ADR-051 §"quantize_quarot Binary Change": the rotation seed is the runtime's
@@ -162,6 +242,13 @@ struct QuantizeIndex {
     online: Option<OnlineArtifactDescriptor>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     artifact_version: Option<ArtifactVersion>,
+    /// Promotion marker (#1103). `#[serde(default)]` keeps every manifest
+    /// written before this field existed byte-compatible on read: an
+    /// absent field deserializes to [`PromotionRecord::default`], which is
+    /// `Unpromoted` — the safe, fail-closed reading of "we don't know
+    /// whether the gate ran" for a manifest older than the tracking itself.
+    #[serde(default)]
+    promotion: PromotionRecord,
 }
 
 /// Read the QuaRot rotation seed from `quantize_index.json` per ADR-051.
@@ -298,6 +385,136 @@ pub(crate) fn read_quarot_seed_from_index(
         })?;
     }
     Ok(index.quarot_seed)
+}
+
+/// Record an ADR-044 dual-Q4 PPL acceptance measurement against a
+/// `quantize_quarot` output directory (issue #1103).
+///
+/// Reads the existing `quantize_index.json` in `quarot_dir` (must be the
+/// object-form QuaRot manifest — a bare-array `quantize_q4` manifest has no
+/// `promotion` field to record against and is rejected), flips `promotion`
+/// to [`PromotionState::Promoted`] when `quarot_ppl - unrotated_ppl <
+/// delta_threshold` or [`PromotionState::Rejected`] otherwise, and writes
+/// the manifest back. Every other field round-trips unchanged.
+///
+/// This function performs no PPL measurement itself — it only records a
+/// measurement the caller already computed (`bin/eval_perplexity`'s
+/// dual-Q4 mode calls this after printing its own verdict). Fail-closed: a
+/// missing, malformed, or bare-array manifest is `Err`, never a silent
+/// no-op — a caller that cannot durably record the result must not report
+/// success either.
+pub fn record_ppl_gate_result(
+    quarot_dir: &Path,
+    unrotated_ppl: f64,
+    quarot_ppl: f64,
+    delta_threshold: f64,
+) -> Result<PromotionRecord, InferenceError> {
+    let path = quarot_dir.join("quantize_index.json");
+    let bytes = fs::read(&path).map_err(|e| {
+        InferenceError::Inference(format!(
+            "record_ppl_gate_result: failed to read {}: {e}",
+            path.display()
+        ))
+    })?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|e| {
+        InferenceError::Inference(format!(
+            "record_ppl_gate_result: {}: malformed quantize_index.json: {e}",
+            path.display()
+        ))
+    })?;
+    if value.is_array() {
+        return Err(InferenceError::Inference(format!(
+            "record_ppl_gate_result: {} is a bare-array manifest (quantize_q4 shape, no \
+             promotion field); only a quantize_quarot object-form manifest can record a \
+             PPL gate result",
+            path.display()
+        )));
+    }
+    let mut index: QuantizeIndex = serde_json::from_value(value).map_err(|e| {
+        InferenceError::Inference(format!(
+            "record_ppl_gate_result: {}: malformed quantize_index.json: {e}",
+            path.display()
+        ))
+    })?;
+
+    let delta = quarot_ppl - unrotated_ppl;
+    let passed = delta < delta_threshold;
+    let record = PromotionRecord {
+        state: if passed {
+            PromotionState::Promoted
+        } else {
+            PromotionState::Rejected
+        },
+        reason: if passed {
+            format!(
+                "ADR-044 PPL acceptance gate passed: delta {delta:+.6} < threshold \
+                 {delta_threshold:.6} (quarot {quarot_ppl:.6} - unrotated {unrotated_ppl:.6})"
+            )
+        } else {
+            format!(
+                "ADR-044 PPL acceptance gate failed: delta {delta:+.6} >= threshold \
+                 {delta_threshold:.6} (quarot {quarot_ppl:.6} - unrotated {unrotated_ppl:.6})"
+            )
+        },
+        ppl_gate: Some(PplGateRecord {
+            unrotated_ppl,
+            quarot_ppl,
+            delta,
+            delta_threshold,
+        }),
+    };
+    index.promotion = record.clone();
+
+    let json = serde_json::to_string_pretty(&index).map_err(|e| {
+        InferenceError::Inference(format!(
+            "record_ppl_gate_result: failed to serialize {}: {e}",
+            path.display()
+        ))
+    })?;
+    fs::write(&path, json).map_err(|e| {
+        InferenceError::Inference(format!(
+            "record_ppl_gate_result: failed to write {}: {e}",
+            path.display()
+        ))
+    })?;
+
+    Ok(record)
+}
+
+/// Read the current promotion marker from a `quantize_quarot` output
+/// directory (issue #1103). `Ok(PromotionRecord::default())` — i.e.
+/// [`PromotionState::Unpromoted`] — for a present object-form manifest with
+/// no `promotion` field (pre-#1103 artifact). `Err` for a missing manifest,
+/// malformed JSON, or a bare-array (`quantize_q4`) manifest, which has no
+/// promotion concept to read.
+pub fn read_promotion_record(quarot_dir: &Path) -> Result<PromotionRecord, InferenceError> {
+    let path = quarot_dir.join("quantize_index.json");
+    let bytes = fs::read(&path).map_err(|e| {
+        InferenceError::Inference(format!(
+            "read_promotion_record: failed to read {}: {e}",
+            path.display()
+        ))
+    })?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).map_err(|e| {
+        InferenceError::Inference(format!(
+            "read_promotion_record: {}: malformed quantize_index.json: {e}",
+            path.display()
+        ))
+    })?;
+    if value.is_array() {
+        return Err(InferenceError::Inference(format!(
+            "read_promotion_record: {} is a bare-array manifest (quantize_q4 shape); it has \
+             no promotion field",
+            path.display()
+        )));
+    }
+    let index: QuantizeIndex = serde_json::from_value(value).map_err(|e| {
+        InferenceError::Inference(format!(
+            "read_promotion_record: {}: malformed quantize_index.json: {e}",
+            path.display()
+        ))
+    })?;
+    Ok(index.promotion)
 }
 
 fn inject_quarot_seed(json: &str, seed: u64) -> Result<String, InferenceError> {
@@ -700,6 +917,11 @@ pub fn convert_quarot_qwen35(
             // here yet.
             online: None,
             artifact_version: None,
+            // #1103: every artifact this function writes starts
+            // Unpromoted — the forward-equivalence gate above verified
+            // rotation correctness, not quantization quality. Only
+            // `record_ppl_gate_result` can advance this state.
+            promotion: PromotionRecord::unpromoted(),
         };
         let index_json = serde_json::to_string_pretty(&index_record).map_err(|e| {
             InferenceError::Inference(format!(
@@ -2971,6 +3193,7 @@ mod tests {
             tensors: vec![],
             online: Some(descriptor.clone()),
             artifact_version: Some(crate::quant::quarot::io::ArtifactVersion::V1Online),
+            promotion: PromotionRecord::default(),
         };
         let json = serde_json::to_string(&index).unwrap();
         let round_tripped: QuantizeIndex = serde_json::from_str(&json).unwrap();
@@ -3011,6 +3234,7 @@ mod tests {
             tensors: vec![],
             online: Some(descriptor),
             artifact_version: Some(crate::quant::quarot::io::ArtifactVersion::V1Online),
+            promotion: PromotionRecord::default(),
         };
         let json = serde_json::to_string(&index).unwrap();
         let tmp = tempfile::tempdir().unwrap();
@@ -3066,6 +3290,7 @@ mod tests {
             tensors: vec![],
             online: Some(invalid_descriptor),
             artifact_version: Some(crate::quant::quarot::io::ArtifactVersion::V1Online),
+            promotion: PromotionRecord::default(),
         };
         let json = serde_json::to_string(&index).unwrap();
         let tmp = tempfile::tempdir().unwrap();
@@ -3115,6 +3340,7 @@ mod tests {
             tensors: vec![],
             online: Some(descriptor),
             artifact_version: Some(crate::quant::quarot::io::ArtifactVersion::V1Online),
+            promotion: PromotionRecord::default(),
         };
         let json = serde_json::to_string(&index).unwrap();
         let tmp = tempfile::tempdir().unwrap();
@@ -3176,5 +3402,218 @@ mod tests {
             err.contains("rotation descriptor is missing or null"),
             "got: {err}"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // Promotion marker (#1103): the converter's forward-equivalence gate
+    // is not the ADR-044 PPL acceptance gate. `convert_quarot_qwen35` must
+    // never write an artifact that reads as quality-validated before the
+    // PPL gate has actually been recorded against it.
+    // ------------------------------------------------------------------
+
+    /// The defect class #1103 describes: a complete artifact + exit 0
+    /// reads as "validated" when the PPL quality gate never ran. This test
+    /// pins the fix — a fresh, successful conversion must write an
+    /// explicit `unpromoted` marker, not silence.
+    ///
+    /// Mutation check performed by hand while writing this test: changing
+    /// the `promotion: PromotionRecord::unpromoted()` field in
+    /// `convert_quarot_qwen35`'s `index_record` construction to
+    /// `PromotionRecord { state: PromotionState::Promoted, reason:
+    /// "stub".into(), ppl_gate: None }` (simulating the original defect —
+    /// a converter that marks itself validated without ever running the
+    /// quality gate) makes this test fail on the
+    /// `record.state == PromotionState::Unpromoted` assertion. Restoring
+    /// the real field makes it pass again. See REPORT.md for the recorded
+    /// before/after run output.
+    #[test]
+    fn convert_quarot_qwen35_writes_unpromoted_promotion_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("input");
+        let output = tmp.path().join("output");
+        let cfg = tiny_cfg(true);
+        write_input_dir(&cfg, &input, 1);
+
+        convert_quarot_qwen35(
+            &input,
+            &output,
+            &ConversionOptions {
+                rotation_seed: 0xC0FFEE,
+                tolerance: 1e-5,
+                num_probe_tokens: 2,
+                dry_run: false,
+            },
+        )
+        .unwrap();
+
+        let record = read_promotion_record(&output).unwrap();
+        assert_eq!(
+            record.state,
+            PromotionState::Unpromoted,
+            "a fresh conversion must not claim promoted/rejected before the PPL \
+             acceptance gate has been recorded against it"
+        );
+        assert!(
+            record.ppl_gate.is_none(),
+            "no PPL gate has run yet; ppl_gate must be absent"
+        );
+        assert!(
+            record.reason.contains("PPL acceptance gate"),
+            "reason must explain WHY the artifact is unpromoted, got: {}",
+            record.reason
+        );
+
+        // Also visible directly in the raw JSON, for a reader who doesn't
+        // go through the typed helper.
+        let idx_str = fs::read_to_string(output.join("quantize_index.json")).unwrap();
+        let idx: Value = serde_json::from_str(&idx_str).unwrap();
+        assert_eq!(
+            idx.get("promotion").and_then(|p| p.get("state")),
+            Some(&Value::String("unpromoted".to_string())),
+            "quantize_index.json must carry a top-level, human-readable promotion.state"
+        );
+    }
+
+    /// Dry-run performs no writes at all (existing contract), so it must
+    /// not be mistaken for having recorded a promotion state either —
+    /// there is no `quantize_index.json` to read.
+    #[test]
+    fn convert_quarot_qwen35_dry_run_writes_no_promotion_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let input = tmp.path().join("input");
+        let output = tmp.path().join("output");
+        let cfg = tiny_cfg(true);
+        write_input_dir(&cfg, &input, 1);
+
+        convert_quarot_qwen35(
+            &input,
+            &output,
+            &ConversionOptions {
+                rotation_seed: 0xC0FFEE,
+                tolerance: 1e-5,
+                num_probe_tokens: 2,
+                dry_run: true,
+            },
+        )
+        .unwrap();
+
+        assert!(
+            !output.join("quantize_index.json").exists(),
+            "dry-run must not write any files, including the promotion marker"
+        );
+    }
+
+    fn object_form_manifest_json(promoted_state: Option<&str>) -> String {
+        let mut obj = serde_json::json!({
+            "quarot_seed": 42,
+            "tensors": [],
+        });
+        if let Some(state) = promoted_state {
+            obj["promotion"] = serde_json::json!({"state": state, "reason": "test fixture"});
+        }
+        serde_json::to_string(&obj).unwrap()
+    }
+
+    #[test]
+    fn record_ppl_gate_result_promotes_on_pass() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("quantize_index.json"),
+            object_form_manifest_json(None),
+        )
+        .unwrap();
+
+        let record = record_ppl_gate_result(tmp.path(), 25.0, 24.5, 0.5).unwrap();
+        assert_eq!(record.state, PromotionState::Promoted);
+        let gate = record.ppl_gate.clone().expect("ppl_gate must be recorded");
+        assert_eq!(gate.unrotated_ppl, 25.0);
+        assert_eq!(gate.quarot_ppl, 24.5);
+        assert!((gate.delta - (-0.5)).abs() < 1e-12);
+        assert_eq!(gate.delta_threshold, 0.5);
+
+        // Persisted, not just returned.
+        let reread = read_promotion_record(tmp.path()).unwrap();
+        assert_eq!(reread, record);
+    }
+
+    #[test]
+    fn record_ppl_gate_result_rejects_on_fail() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("quantize_index.json"),
+            object_form_manifest_json(None),
+        )
+        .unwrap();
+
+        // delta == threshold is a fail (strict `<` to pass, per ADR-044).
+        let record = record_ppl_gate_result(tmp.path(), 25.0, 25.5, 0.5).unwrap();
+        assert_eq!(record.state, PromotionState::Rejected);
+
+        let reread = read_promotion_record(tmp.path()).unwrap();
+        assert_eq!(reread.state, PromotionState::Rejected);
+    }
+
+    #[test]
+    fn record_ppl_gate_result_overwrites_prior_state() {
+        // A re-recorded measurement (e.g. re-running the gate after a
+        // model fix) must overwrite the previous marker, not accumulate.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("quantize_index.json"),
+            object_form_manifest_json(Some("rejected")),
+        )
+        .unwrap();
+
+        let record = record_ppl_gate_result(tmp.path(), 25.0, 24.0, 0.5).unwrap();
+        assert_eq!(record.state, PromotionState::Promoted);
+        let reread = read_promotion_record(tmp.path()).unwrap();
+        assert_eq!(reread.state, PromotionState::Promoted);
+    }
+
+    #[test]
+    fn record_ppl_gate_result_rejects_bare_array_manifest() {
+        // `quantize_q4`'s manifest shape — a bare tensor array, no
+        // `promotion` concept at all. Recording against it is a caller
+        // bug (wrong directory), not a legitimate no-op.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("quantize_index.json"), r#"[]"#).unwrap();
+
+        let err = record_ppl_gate_result(tmp.path(), 25.0, 24.0, 0.5)
+            .expect_err("a bare-array manifest must be rejected, not silently accepted");
+        assert!(err.to_string().contains("bare-array"), "got: {err}");
+    }
+
+    #[test]
+    fn record_ppl_gate_result_errs_on_missing_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        let err = record_ppl_gate_result(tmp.path(), 25.0, 24.0, 0.5)
+            .expect_err("recording against a directory with no manifest must fail closed");
+        assert!(err.to_string().contains("failed to read"), "got: {err}");
+    }
+
+    #[test]
+    fn read_promotion_record_defaults_to_unpromoted_for_legacy_manifest() {
+        // A manifest written before #1103 (no `promotion` field at all)
+        // must read as Unpromoted, not error and not silently claim
+        // Promoted.
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join("quantize_index.json"),
+            r#"{"quarot_seed":7,"tensors":[]}"#,
+        )
+        .unwrap();
+
+        let record = read_promotion_record(tmp.path()).unwrap();
+        assert_eq!(record.state, PromotionState::Unpromoted);
+        assert!(record.reason.contains("predates"));
+    }
+
+    #[test]
+    fn read_promotion_record_rejects_bare_array_manifest() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("quantize_index.json"), r#"[]"#).unwrap();
+        let err = read_promotion_record(tmp.path())
+            .expect_err("a bare-array manifest has no promotion field and must be rejected");
+        assert!(err.to_string().contains("bare-array"), "got: {err}");
     }
 }


### PR DESCRIPTION
Closes #1103.

`quantize_quarot` ran only the forward-equivalence gate (rotation correctness) and exited 0 with a complete artifact — the ADR-044 PPL acceptance criterion (quantization quality) lived in `eval_perplexity`'s dual-Q4 mode and was never invoked from the converter path. A rotation-correct but quality-failing artifact read as validated.

This lands the explicit two-step contract rather than wiring a hard pass/fail into the converter: per ADR-044's superseded-conclusion section, offline QuaRot v0 is currently net-negative vs unrotated Q4 (pending online R3/R4, #703), and the shipping-tier CI gate already treats the QuaRot delta as informational — so a converter-internal hard gate would refuse every real conversion today, which is a policy decision belonging to ADR-044/#616, not this fix. A promotion marker records provenance without re-deciding that policy:

- `QuantizeIndex` gains a `#[serde(default)] promotion: PromotionRecord` field (`Unpromoted`/`Promoted`/`Rejected` + reason + gate numbers). Absent field deserializes to `Unpromoted`, so every existing manifest stays byte-compatible.
- `convert_quarot_qwen35` always stamps fresh artifacts `Unpromoted`; the CLI prints an explicit `Promotion: UNPROMOTED` block with the follow-up `eval_perplexity` command, and its docs no longer imply exit-0 means quality-validated.
- `eval_perplexity` dual-Q4 mode now records the gate verdict into the artifact via `record_ppl_gate_result` (fail-closed: missing/malformed manifest is a hard error, and a measured-but-unrecorded gate exits nonzero).

Tests: 11 new (58 total in the module) — end-to-end unpromoted-marker test pinned by defect re-injection (marker forged to `Promoted` → test fails with the assertion naming the class; restored → green), dry-run-writes-nothing, promote/reject/overwrite/malformed-manifest arms for both record and read paths. Full `quant::` module 296 pass.

Sibling sweep across all workspace `src/bin/*.rs` artifact producers: no other binary has the claimed-but-unwired inline gate shape (`quantize_q4`'s quality gate is a separate, already-wired CI step; the rest are not converters).

Note: crate-scoped `clippy --all-targets -D warnings` currently fails on two pre-existing dead-code diagnostics unrelated to this diff (#1300); verified identical on unmodified HEAD via stash — the touched files produce no findings.

## bench-compare disposition

Structural: no A/B run — the diff touches two non-bench binaries and the offline conversion module; no declared bench target in any crate invokes conversion or the eval CLI, and no manifest/lockfile/feature/profile input changed. Population searched: all declared bench targets in `crates/{inference,embed,fann}/Cargo.toml` plus the two default bench-compare targets. Residual risk: the conversion path itself is unmeasured by benches, unchanged from before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




## bench-compare disposition

**No A/B run.** This PR touches two non-bench binaries (`quantize_quarot` and
`eval_perplexity`) and the offline conversion module. The new functions
(`record_ppl_gate_result`, `read_promotion_record`, and the `promotion` field
on `QuantizeIndex`) are not called by any of the 24 declared bench targets in
`crates/inference/Cargo.toml`, the 5 targets in `crates/embed/Cargo.toml`, or
the 1 target in `crates/fann/Cargo.toml`.

`QuantizeIndex` gains a `#[serde(default)] promotion: PromotionRecord` field.
Three benches that load Q4 artifacts via `from_q4_dir` (`metal_decode_bench`,
`lm_head_bench`, `mtp_decode`) parse this struct, but `#[serde(default)]`
preserves byte-identical deserialization of every existing manifest — the
structural addition is a passive schema change, not a measurable runtime
difference. No bench target invokes `convert_quarot_qwen35`,
`record_ppl_gate_result`, or `read_promotion_record`.

No manifest, lockfile, feature, profile, build-script, or bench-harness
definition changed (`git diff origin/main...origin/show/w3-quant -- '**/Cargo.toml' '**/Cargo.lock'
'**/build.rs' Makefile` produces zero output).

**Residual risk**: the conversion and promotion-recording code paths are
unmeasured by any bench. This is unchanged from before the PR — the
`quantize_quarot` binary has never been exercised by a bench target, and
`eval_perplexity`'s dual-Q4 mode has never been exercised by a bench target.
The change does not make any previously measured path unmeasured.
