### PR TITLE
fix(bench): thread the resolved Python interpreter through the bench harness handoff

### DIFF
--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -38,6 +38,7 @@ if ! mkdir -p "$REPO/.cache" 2>/dev/null; then
 fi
 source "$REPO/scripts/lib/bench-python.sh"
 PYTHON_BIN="$(bench_require_python3 "bench-compare.sh")" || exit 1
+export PYTHON_BIN
 exec "$PYTHON_BIN" "$REPO/scripts/lib/bench_supervision.py" run \
   --label "bench-compare" \
   --entrypoint \

--- a/scripts/e2e-parity-local.sh
+++ b/scripts/e2e-parity-local.sh
@@ -15,4 +15,4 @@ bench_supervise_entry "e2e-parity-local" handoff - "$@"
     cargo build --release --bin qwen35_generate -p lattice-inference --features f16
 )
 cd "$REPO"
-exec python3 scripts/e2e_parity_check.py
+exec "${PYTHON_BIN:?PYTHON_BIN not set - bench_supervise_entry should have exported it}" scripts/e2e_parity_check.py

--- a/scripts/lib/bench-compare-impl.sh
+++ b/scripts/lib/bench-compare-impl.sh
@@ -118,6 +118,22 @@ if ! REPO="$(cd "$(dirname "$0")/../.." && pwd)"; then
   printf 'directory was removed or is unreachable). Refusing to continue.\n' >&2 || :
   exit 2
 fi
+
+# scripts/bench-compare.sh (the entry point) resolves and exports PYTHON_BIN
+# before it hands off to this body, so the normal path just inherits it. This
+# file is also directly invocable (deliberately refused a few lines below,
+# once verify_locks runs) or unit-testable standalone, and neither of those
+# callers exports PYTHON_BIN — so resolve it here too, but only when it
+# didn't already arrive from an entry point, so the entry point's resolution
+# still governs the normal path.
+if [ -z "${PYTHON_BIN:-}" ]; then
+  source "$REPO/scripts/lib/bench-python.sh"
+  if ! PYTHON_BIN="$(bench_require_python3 "$0")"; then
+    exit 2
+  fi
+  export PYTHON_BIN
+fi
+
 QUICK_FLAGS="--quick"  # adaptive two-point samples in each of four ABBA arms
 RUN_STARTED_UTC="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 if [ -n "${BENCH_HOST_ID:-}" ]; then

--- a/scripts/lib/bench-compare-impl.sh
+++ b/scripts/lib/bench-compare-impl.sh
@@ -123,7 +123,7 @@ RUN_STARTED_UTC="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 if [ -n "${BENCH_HOST_ID:-}" ]; then
   RUN_HOST_ID="configured:${BENCH_HOST_ID}"
 else
-  RUN_HOST_ID="$(python3 "$REPO/scripts/lib/bench-host-id.py")"
+  RUN_HOST_ID="$("$PYTHON_BIN" "$REPO/scripts/lib/bench-host-id.py")"
 fi
 RUN_OS="$(uname -srm)"
 PROVENANCE_FILE="$REPO/.cache/bench-run-provenance.txt"
@@ -185,7 +185,7 @@ verify_locks() {
     exit 2
   fi
 
-  if ! python3 "$REPO/scripts/lib/bench_supervision.py" verify; then
+  if ! "$PYTHON_BIN" "$REPO/scripts/lib/bench_supervision.py" verify; then
     echo "bench-compare: cooperative supervisor handoff failed —" \
          "refusing to measure." >&2
     exit 2
@@ -219,7 +219,7 @@ machine_state_probe() {
   fi
   if [ "$platform" = "Darwin" ]; then
     record="$(
-      python3 "$REPO/scripts/perf_governor.py" \
+      "$PYTHON_BIN" "$REPO/scripts/perf_governor.py" \
         --checkpoint \
         --label "$label" \
         --cooldown 30 \
@@ -227,7 +227,7 @@ machine_state_probe() {
     )" || rc=$?
   else
     record="$(
-      python3 "$REPO/scripts/lib/machine-state-probe.py" --label "$label"
+      "$PYTHON_BIN" "$REPO/scripts/lib/machine-state-probe.py" --label "$label"
     )" || rc=$?
   fi
   if [ "$rc" -ne 0 ] || [ -z "$record" ]; then
@@ -247,7 +247,7 @@ quiet_gate() {
   if [ -n "${PERF_POSTMERGE_STATUS_DIR:-}" ]; then
     probe_args+=(--phase "$phase" --jsonl-out "$AMBIENT_SAMPLES_FILE")
   fi
-  line="$(python3 "$REPO/scripts/lib/quiet-probe.py" "${probe_args[@]}")" || rc=$?
+  line="$("$PYTHON_BIN" "$REPO/scripts/lib/quiet-probe.py" "${probe_args[@]}")" || rc=$?
   echo "$line"
   QUIET_SAMPLES="${QUIET_SAMPLES}${QUIET_SAMPLES:+
 }$line"
@@ -508,18 +508,18 @@ clear_criterion_root "$HEAD_CONTROL_EMBED_CRITERION_ROOT"
 clear_criterion_root "$BASE_CONTROL_INFERENCE_CRITERION_ROOT"
 clear_criterion_root "$BASE_CONTROL_EMBED_CRITERION_ROOT"
 if [ "$FAIL_ON_REGRESSION" = "1" ]; then
-  python3 "$GATE_SCRIPT" "$BASE_INFERENCE_CRITERION_ROOT" \
+  "$PYTHON_BIN" "$GATE_SCRIPT" "$BASE_INFERENCE_CRITERION_ROOT" \
     --baseline-name "$BENCH_BASELINE_NAME" --prepare-baseline-copy
-  python3 "$GATE_SCRIPT" "$BASE_EMBED_CRITERION_ROOT" \
+  "$PYTHON_BIN" "$GATE_SCRIPT" "$BASE_EMBED_CRITERION_ROOT" \
     --baseline-name "$BENCH_BASELINE_NAME" --prepare-baseline-copy
 fi
-python3 "$GATE_SCRIPT" "$HEAD_CONTROL_INFERENCE_CRITERION_ROOT" \
+"$PYTHON_BIN" "$GATE_SCRIPT" "$HEAD_CONTROL_INFERENCE_CRITERION_ROOT" \
   --baseline-name "$BENCH_HEAD_BASELINE_NAME" --prepare-baseline-copy
-python3 "$GATE_SCRIPT" "$HEAD_CONTROL_EMBED_CRITERION_ROOT" \
+"$PYTHON_BIN" "$GATE_SCRIPT" "$HEAD_CONTROL_EMBED_CRITERION_ROOT" \
   --baseline-name "$BENCH_HEAD_BASELINE_NAME" --prepare-baseline-copy
-python3 "$GATE_SCRIPT" "$BASE_CONTROL_INFERENCE_CRITERION_ROOT" \
+"$PYTHON_BIN" "$GATE_SCRIPT" "$BASE_CONTROL_INFERENCE_CRITERION_ROOT" \
   --baseline-name "$BENCH_HEAD_BASELINE_NAME" --prepare-baseline-copy
-python3 "$GATE_SCRIPT" "$BASE_CONTROL_EMBED_CRITERION_ROOT" \
+"$PYTHON_BIN" "$GATE_SCRIPT" "$BASE_CONTROL_EMBED_CRITERION_ROOT" \
   --baseline-name "$BENCH_HEAD_BASELINE_NAME" --prepare-baseline-copy
 
 # --- Measurement-integrity helpers ---
@@ -637,12 +637,12 @@ copy_base_artifacts() {
 
 prepare_target_root() {
   local target="$1" base_root="$2" head_root="$3" baseline_name="$4"
-  python3 "$GATE_SCRIPT" "$head_root" \
+  "$PYTHON_BIN" "$GATE_SCRIPT" "$head_root" \
     --baseline-name "$baseline_name" --prepare-baseline-copy
   copy_base_artifacts "$target selected baseline copy" \
     -a "$base_root/" "$head_root/" \
     --include="**/$baseline_name/**" --include='*/' --exclude='*'
-  python3 "$GATE_SCRIPT" "$head_root" \
+  "$PYTHON_BIN" "$GATE_SCRIPT" "$head_root" \
     --baseline-name "$baseline_name" --prepare-head
 }
 
@@ -946,7 +946,7 @@ run_target_gate() {
   fi
 
   if [ -d "$criterion_root" ]; then
-    python3 "$GATE_SCRIPT" \
+    "$PYTHON_BIN" "$GATE_SCRIPT" \
       "$criterion_root" "local-compare/$target" "${gate_args[@]}" 2>&1 || gate_rc=$?
   else
     gate_rc=2
@@ -1003,7 +1003,7 @@ echo "Done. Base=$BASE_REF ($BASE_SHA), Head=$HEAD_REF ($HEAD_SHA)"
 MEASUREMENT_RC=$?
 set -e
 
-if ! python3 "$REPO/scripts/lib/bench_supervision.py" verify; then
+if ! "$PYTHON_BIN" "$REPO/scripts/lib/bench_supervision.py" verify; then
   echo "bench-compare: final cooperative supervisor sample failed —" \
        "refusing to certify it." >&2
   exit 2

--- a/scripts/lib/bench-supervision.sh
+++ b/scripts/lib/bench-supervision.sh
@@ -17,27 +17,28 @@ bench_supervise_entry() {
     local measurement="$3"
     shift 3
 
-    local repo helper python_bin
+    local repo helper
     if ! repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"; then
         printf 'bench-supervision: FATAL: cannot resolve the repository root from %s; ' "${BASH_SOURCE[0]}" >&2 || :
         printf 'refusing to continue.\n' >&2 || :
         exit 2
     fi
     helper="$repo/scripts/lib/bench_supervision.py"
-    python_bin="$(bench_require_python3 "${0##*/}")" || exit 1
+    PYTHON_BIN="$(bench_require_python3 "${0##*/}")" || exit 1
+    export PYTHON_BIN
 
     if [[ -z "${LATTICE_BENCH_LOCK_STATUS:-}" ]]; then
         if [[ "$mode" == "durable" ]]; then
-            exec "$python_bin" "$helper" run --label "$label" --quiet --entrypoint -- "$0" "$@"
+            exec "$PYTHON_BIN" "$helper" run --label "$label" --quiet --entrypoint -- "$0" "$@"
         fi
-        exec "$python_bin" "$helper" run --label "$label" --entrypoint -- "$0" "$@"
+        exec "$PYTHON_BIN" "$helper" run --label "$label" --entrypoint -- "$0" "$@"
     fi
     if [[ "$mode" == "durable" ]]; then
-        if ! "$python_bin" "$helper" verify --require-quiet; then
+        if ! "$PYTHON_BIN" "$helper" verify --require-quiet; then
             exit 2
         fi
     else
-        if ! "$python_bin" "$helper" verify; then
+        if ! "$PYTHON_BIN" "$helper" verify; then
             exit 2
         fi
     fi
@@ -61,7 +62,7 @@ bench_supervise_entry() {
     if [[ "$restore_errexit" -eq 1 ]]; then
         set -e
     fi
-    if ! "$python_bin" "$helper" verify; then
+    if ! "$PYTHON_BIN" "$helper" verify; then
         return 2
     fi
     return "$measurement_rc"
@@ -75,7 +76,7 @@ bench_quiet_checkpoint() {
         printf 'refusing to continue.\n' >&2 || :
         exit 2
     fi
-    if ! python3 "$repo/scripts/lib/quiet-probe.py" --label "$label"; then
+    if ! "${PYTHON_BIN:?PYTHON_BIN not set - bench_quiet_checkpoint requires bench_supervise_entry to have run first}" "$repo/scripts/lib/quiet-probe.py" --label "$label"; then
         echo "bench-supervision: machine was not quiet at $label; refusing to continue" >&2 || :
         exit 2
     fi

--- a/scripts/lib/bench-supervision.sh
+++ b/scripts/lib/bench-supervision.sh
@@ -76,7 +76,11 @@ bench_quiet_checkpoint() {
         printf 'refusing to continue.\n' >&2 || :
         exit 2
     fi
-    if ! "${PYTHON_BIN:?PYTHON_BIN not set - bench_quiet_checkpoint requires bench_supervise_entry to have run first}" "$repo/scripts/lib/quiet-probe.py" --label "$label"; then
+    if [[ -z "${PYTHON_BIN:-}" ]]; then
+        PYTHON_BIN="$(bench_require_python3 "${0##*/}")" || exit 1
+        export PYTHON_BIN
+    fi
+    if ! "$PYTHON_BIN" "$repo/scripts/lib/quiet-probe.py" --label "$label"; then
         echo "bench-supervision: machine was not quiet at $label; refusing to continue" >&2 || :
         exit 2
     fi

--- a/tests/test_bench_measurement_supervision.py
+++ b/tests/test_bench_measurement_supervision.py
@@ -2517,6 +2517,90 @@ class BenchCompareDirectInvocationRefusal(unittest.TestCase):
         self.assertNotIn("=== bench-compare:", result.stdout)
 
 
+class ImplBodyInheritsResolvedPythonInterpreter(unittest.TestCase):
+    """bench-compare.sh resolves an interpreter meeting the harness's 3.11
+    floor and exports it as PYTHON_BIN; bench-compare-impl.sh must consume
+    that inherited variable rather than a bare `python3` lookup, or a stock
+    macOS PATH (old /usr/bin/python3 ahead of a newer interpreter) makes the
+    body die on the floor check instead of using the interpreter its own
+    entry point already found (lattice#1333).
+
+    This drives the real scripts/lib/bench-compare-impl.sh, not a rewritten
+    copy: only scripts/lib/bench-host-id.py is needed alongside it, since the
+    very first thing the body does (before touching git, locks, or cargo) is
+    resolve a run host id through a Python interpreter.
+    """
+
+    def _build_fixture(self, tmp: str) -> Path:
+        root = Path(tmp) / "repo"
+        lib = root / "scripts" / "lib"
+        lib.mkdir(parents=True)
+        shutil.copy2(
+            REPO / "scripts" / "lib" / "bench-compare-impl.sh",
+            lib / "bench-compare-impl.sh",
+        )
+        (lib / "bench-compare-impl.sh").chmod(0o755)
+        shutil.copy2(
+            REPO / "scripts" / "lib" / "bench-host-id.py",
+            lib / "bench-host-id.py",
+        )
+        return root
+
+    def _run(self, tmp: str, root: Path) -> subprocess.CompletedProcess[str]:
+        bindir = Path(tmp) / "bin"
+        bindir.mkdir()
+        stub_python3 = bindir / "python3"
+        stub_python3.write_text(
+            "#!/usr/bin/env bash\n"
+            "echo 'STUB_PYTHON3_INVOKED: Python 3.9.6 (fixture, pre-floor)' >&2\n"
+            "exit 17\n"
+        )
+        stub_python3.chmod(0o755)
+
+        self.assertGreaterEqual(
+            sys.version_info[:2],
+            (3, 11),
+            "the interpreter running this test must itself satisfy the "
+            "harness's floor to stand in as the resolved PYTHON_BIN",
+        )
+        env = {
+            **os.environ,
+            "PATH": f"{bindir}:{os.environ['PATH']}",
+            "PYTHON_BIN": sys.executable,
+            "LATTICE_BENCH_HOST_ID_FILE": f"{tmp}/bench-host-id",
+        }
+        for name in (
+            "LATTICE_BENCH_LOCK_STATUS",
+            "LATTICE_BENCH_LOCK_FDS",
+            "LATTICE_BENCH_SUPERVISOR_FD",
+        ):
+            env.pop(name, None)
+        return subprocess.run(
+            ["bash", str(root / "scripts" / "lib" / "bench-compare-impl.sh")],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=30,
+        )
+
+    def test_impl_body_proceeds_past_host_id_handoff_instead_of_dying_on_stub(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._build_fixture(tmp)
+            result = self._run(tmp, root)
+
+        # The stub is never reached: the body used the inherited PYTHON_BIN
+        # for the host-id resolution, so it proceeds to the next real
+        # checkpoint (the supervisor lock-status refusal) instead of dying
+        # inside the stub at exit 17.
+        self.assertNotIn("STUB_PYTHON3_INVOKED", result.stderr, result.stderr)
+        self.assertNotEqual(17, result.returncode, result.stderr)
+        self.assertEqual(2, result.returncode, result.stderr)
+        self.assertIn("no lock status at", result.stderr)
+        self.assertIn(
+            "Run scripts/bench-compare.sh, not this file directly", result.stderr
+        )
+
+
 class _FailOnEmptyTestProgram(unittest.TestProgram):
     def runTests(self) -> None:
         if self.test.countTestCases() == 0:

--- a/tests/test_bench_measurement_supervision.py
+++ b/tests/test_bench_measurement_supervision.py
@@ -2609,9 +2609,17 @@ class ImplBodyInheritsResolvedPythonInterpreter(unittest.TestCase):
         "unbound variable" error (lattice#1333's original failure mode) and
         not with a silent fall back to an unqualified `python3`.
 
-        PATH here is deliberately narrowed to /bin:/usr/bin, where macOS
-        ships only a pre-3.11 /usr/bin/python3, so bench_require_python3 has
-        no qualifying candidate and must refuse with its own diagnostic.
+        PATH here is a fixture-only directory that shadows every name
+        bench_resolve_python3 tries (python3.13, python3.12, python3.11,
+        python3) with a stub that always fails the version-floor probe, so
+        bench_require_python3 has no qualifying candidate regardless of
+        what real interpreters the host running this test happens to ship.
+        A bare /bin:/usr/bin PATH is not a portable way to get that: it
+        relies on the host's system python3 being pre-3.11, which is true
+        of macOS but not of Ubuntu 24.04 CI images, whose /usr/bin/python3
+        is 3.12 and would satisfy the floor -- letting resolution succeed
+        and fall through to the next real checkpoint (the lock-status
+        guard) instead of exercising this refusal.
         """
         with tempfile.TemporaryDirectory() as tmp:
             root = self._build_fixture(tmp)
@@ -2619,8 +2627,14 @@ class ImplBodyInheritsResolvedPythonInterpreter(unittest.TestCase):
                 REPO / "scripts" / "lib" / "bench-python.sh",
                 root / "scripts" / "lib" / "bench-python.sh",
             )
+            bindir = Path(tmp) / "bin"
+            bindir.mkdir()
+            for name in ("python3.13", "python3.12", "python3.11", "python3"):
+                stub = bindir / name
+                stub.write_text("#!/usr/bin/env bash\nexit 1\n")
+                stub.chmod(0o755)
             env = {
-                "PATH": "/bin:/usr/bin",
+                "PATH": f"{bindir}:/usr/bin:/bin",
                 "LATTICE_BENCH_HOST_ID_FILE": f"{tmp}/bench-host-id",
             }
             for name in (

--- a/tests/test_bench_measurement_supervision.py
+++ b/tests/test_bench_measurement_supervision.py
@@ -2600,6 +2600,50 @@ class ImplBodyInheritsResolvedPythonInterpreter(unittest.TestCase):
             "Run scripts/bench-compare.sh, not this file directly", result.stderr
         )
 
+    def test_impl_body_direct_invocation_resolves_its_own_interpreter_when_unset(
+        self,
+    ):
+        """A direct invocation (no entry point, so PYTHON_BIN never arrived)
+        must still end up with a qualifying interpreter, resolved by the
+        body itself via scripts/lib/bench-python.sh -- not with bash's own
+        "unbound variable" error (lattice#1333's original failure mode) and
+        not with a silent fall back to an unqualified `python3`.
+
+        PATH here is deliberately narrowed to /bin:/usr/bin, where macOS
+        ships only a pre-3.11 /usr/bin/python3, so bench_require_python3 has
+        no qualifying candidate and must refuse with its own diagnostic.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._build_fixture(tmp)
+            shutil.copy2(
+                REPO / "scripts" / "lib" / "bench-python.sh",
+                root / "scripts" / "lib" / "bench-python.sh",
+            )
+            env = {
+                "PATH": "/bin:/usr/bin",
+                "LATTICE_BENCH_HOST_ID_FILE": f"{tmp}/bench-host-id",
+            }
+            for name in (
+                "LATTICE_BENCH_LOCK_STATUS",
+                "LATTICE_BENCH_LOCK_FDS",
+                "LATTICE_BENCH_SUPERVISOR_FD",
+                "PYTHON_BIN",
+            ):
+                env.pop(name, None)
+            result = subprocess.run(
+                ["bash", str(root / "scripts" / "lib" / "bench-compare-impl.sh")],
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=30,
+            )
+
+        self.assertEqual(2, result.returncode, result.stderr)
+        self.assertNotIn("unbound variable", result.stderr, result.stderr)
+        self.assertIn(
+            "no Python >= 3.11 found on PATH", result.stderr, result.stderr
+        )
+
 
 class _FailOnEmptyTestProgram(unittest.TestProgram):
     def runTests(self) -> None:


### PR DESCRIPTION
`scripts/bench-compare.sh` resolves a Python interpreter meeting the harness's 3.11 floor and then hands off to a body that called bare `python3` everywhere, so the resolution was discarded at the first handoff. On a machine whose PATH `python3` is older than 3.11 — stock macOS, where `/usr/bin/python3` is 3.9 — the run died before measuring anything, regardless of which interpreters were installed.

Measured before the fix, on a bench machine with a 3.12 interpreter present under its versioned name:

```
bench-supervision: requires Python >= 3.11 (...) found 3.9.6 at /Library/Developer/CommandLineTools/usr/bin/python3.
bench-compare: cooperative supervisor handoff failed — refusing to measure.
```

`bench_resolve_python3` returned the 3.12 path on that same machine and shell, so the resolver was never what failed.

## Changes

- `scripts/bench-compare.sh` exports `PYTHON_BIN` so the resolution survives the handoff.
- All 15 bare `python3` sites in `scripts/lib/bench-compare-impl.sh` now use it, fail-closed: an unset variable aborts rather than silently falling back to PATH. The silent fallback is how this stayed invisible.
- Two siblings found by the sweep and fixed the same way. `scripts/lib/bench-supervision.sh` resolved an interpreter into a function-local variable that died on return, so callers running code after `bench_supervise_entry` had nothing to use; its `bench_quiet_checkpoint` also called `quiet-probe.py` through bare `python3`, and that script has no version self-guard, so a wrong interpreter there fails quietly rather than refusing loudly. `scripts/e2e-parity-local.sh` had the same post-return problem on its final `exec`.

## Scope not taken

`scripts/bench-command.sh` was already correct: it resolves and `exec`s with the resolved path. `scripts/bench-gate.sh`, `scripts/bench_quality.sh`, `scripts/bench_decode_slopefit.sh`, and the Makefile's agentic bench targets are out of scope, with the per-file reasons recorded on the issue rather than changed speculatively.

## Testing

New regression test in `tests/test_bench_measurement_supervision.py`: it places a stub `python3` reporting a pre-3.11 version early on PATH, exports a conforming interpreter, and asserts the body proceeds past the handoff. Verified mutation-sensitive — restoring the bare `python3` calls makes it fail, and it passes with the fix. Existing suites stay green (63 and 28 tests).

## bench-compare disposition

Structural waiver: no A/B was run. The diff touches shell entry points and a Python test only, with no Rust source, no manifest, lockfile, feature, profile, build script, or bench-target definition change, so base and head compile to identical bench binaries. Population searched: all declared bench targets in `crates/{inference,embed,fann}/Cargo.toml`, plus the two targets `bench-compare` runs by default. Residual risk: this change alters which interpreter the harness invokes, which is a change to how measurements are produced rather than to what is measured. That is unmeasurable by an A/B by construction, and the regression test above is the control that covers it.

Fixes #1333.
