### PR TITLE
fix(inference): close the remaining Metal measurement lock gaps

### DIFF
--- a/crates/inference/benches/cross_turn_prefix_cache_bench.rs
+++ b/crates/inference/benches/cross_turn_prefix_cache_bench.rs
@@ -60,6 +60,7 @@ fn load_state_and_tokenizer() -> Option<(MetalQwen35State, BpeTokenizer)> {
     let dir = safetensors_model_dir()?;
     let model = Qwen35Model::from_safetensors(&dir).ok()?;
     let cfg = model.config().clone();
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
     let state = MetalQwen35State::new(model.weights(), &cfg, 4096).ok()?;
     let tokenizer = BpeTokenizer::from_tokenizer_json(&dir.join("tokenizer.json")).ok()?;
     Some((state, tokenizer))

--- a/crates/inference/benches/lm_head_bench.rs
+++ b/crates/inference/benches/lm_head_bench.rs
@@ -173,6 +173,7 @@ mod real {
                 };
                 let model = Qwen35Model::from_safetensors(dir)
                     .map_err(|err| format!("load Q8 safetensors from {}: {err}", dir.display()))?;
+                let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
                 let state = MetalQwen35State::new(model.weights(), model.config(), MAX_CACHE_LEN)
                     .map_err(|err| {
                     format!("create Q8 Metal state from {}: {err}", dir.display())
@@ -201,6 +202,7 @@ mod real {
                 };
                 let cfg = Qwen35Config::from_config_json(&dir.join("config.json"))
                     .map_err(|err| format!("parse Q4 config from {}: {err}", dir.display()))?;
+                let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
                 let state =
                     MetalQwen35State::from_q4_dir(dir, &tokenizer_path, &cfg, MAX_CACHE_LEN)
                         .map_err(|err| {

--- a/crates/inference/benches/metal_decode_bench.rs
+++ b/crates/inference/benches/metal_decode_bench.rs
@@ -84,6 +84,7 @@ fn load_q4_state() -> Result<(MetalQwen35State, Qwen35Config), Q4SetupError> {
     let tok = tokenizer_path_checked()?;
     let cfg = Qwen35Config::from_config_json(&dir.join("config.json"))
         .map_err(|error| Q4SetupError::Config(error.to_string()))?;
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
     let state =
         MetalQwen35State::from_q4_dir(&dir, &tok, &cfg, 4096).map_err(Q4SetupError::State)?;
     Ok((state, cfg))
@@ -95,6 +96,7 @@ fn load_q8_state() -> Option<(MetalQwen35State, Qwen35Config)> {
     let dir = safetensors_model_dir()?;
     let model = Qwen35Model::from_safetensors(&dir).ok()?;
     let cfg = model.config().clone();
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
     let state = MetalQwen35State::new(model.weights(), &cfg, 4096).ok()?;
     Some((state, cfg))
 }

--- a/crates/inference/benches/mtp_decode.rs
+++ b/crates/inference/benches/mtp_decode.rs
@@ -74,6 +74,8 @@ fn bench_baseline(c: &mut Criterion) {
         use lattice_inference::model::qwen35_config::{GenerateConfig, Qwen35Config};
         use lattice_inference::tokenizer::bpe::BpeTokenizer;
 
+        let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
+
         let Some(dir) = q4_model_dir() else {
             eprintln!("SKIP mtp_decode/baseline: Q4 model not found (need mtp_fc_weight.q4)");
             return;
@@ -169,6 +171,8 @@ fn bench_mtp(c: &mut Criterion) {
         use lattice_inference::forward::metal_qwen35::{ChatMessage, MetalQwen35State};
         use lattice_inference::model::qwen35_config::{GenerateConfig, Qwen35Config};
         use lattice_inference::tokenizer::bpe::BpeTokenizer;
+
+        let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
 
         let Some(dir) = q4_model_dir() else {
             eprintln!("SKIP mtp_decode/mtp: Q4 model not found (need mtp_fc_weight.q4)");

--- a/crates/inference/examples/bench_embedding.rs
+++ b/crates/inference/examples/bench_embedding.rs
@@ -27,6 +27,8 @@ fn main() {
         if dir.join("model.safetensors").exists() {
             println!("--- Pure Rust (Accelerate AMX) ---");
             let t0 = Instant::now();
+            #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+            let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
             let model = lattice_inference::QwenModel::from_directory(dir).unwrap();
             println!("  Load: {:.0}ms", t0.elapsed().as_millis());
 

--- a/crates/inference/examples/bench_gdn_decode.rs
+++ b/crates/inference/examples/bench_gdn_decode.rs
@@ -25,6 +25,8 @@ fn run() {
     use lattice_inference::model::qwen35_config::Qwen35Config;
     use std::time::Instant;
 
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
+
     let home = std::env::var("HOME").expect("HOME not set");
     let model_dir_str = std::env::var("LATTICE_MODEL_DIR")
         .unwrap_or_else(|_| format!("{home}/.lattice/models/qwen3.6-27b-q4"));

--- a/crates/inference/examples/bench_gdn_prefill_ab.rs
+++ b/crates/inference/examples/bench_gdn_prefill_ab.rs
@@ -50,6 +50,7 @@ fn run() {
     eprintln!("[bench_gdn_prefill_ab] model_dir={}", model_dir.display());
     eprintln!("[bench_gdn_prefill_ab] lens={lens:?} warmups={warmups} runs={runs}");
 
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
     let t_load = Instant::now();
     let model = Qwen35Model::from_safetensors(&model_dir).expect("load qwen3.5-0.8b");
     let mut state =
@@ -126,6 +127,7 @@ fn run_interleaved(
     eprintln!("[bench_gdn_prefill_ab] model_dir={}", model_dir.display());
     eprintln!("[bench_gdn_prefill_ab] lens={lens:?} warmups={warmups} runs={runs}");
 
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
     let t_load = Instant::now();
     let model = Qwen35Model::from_safetensors(model_dir).expect("load qwen3.5-0.8b");
     let mut state =

--- a/crates/inference/examples/bench_gdn_state.rs
+++ b/crates/inference/examples/bench_gdn_state.rs
@@ -82,6 +82,7 @@ fn run() {
         dir.display()
     );
 
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
     let mut state: MetalQwen35State = if is_q4 {
         let cfg = Qwen35Config::from_model_dir(dir).expect("load model config.json");
         let tokenizer_path = dir.join("tokenizer.json");

--- a/crates/inference/examples/bench_gpu.rs
+++ b/crates/inference/examples/bench_gpu.rs
@@ -42,6 +42,8 @@ fn run_bench() {
     // Load CPU model for comparison
     println!("Loading CPU model...");
     let t0 = Instant::now();
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
     let cpu_model = lattice_inference::QwenModel::from_directory(dir).unwrap();
     let cpu_load_ms = t0.elapsed().as_millis();
     println!("  CPU model loaded in {cpu_load_ms}ms\n");

--- a/crates/inference/examples/bench_persistent_state.rs
+++ b/crates/inference/examples/bench_persistent_state.rs
@@ -31,6 +31,8 @@ fn run() {
     use lattice_inference::tokenizer::bpe::BpeTokenizer;
     use std::time::Instant;
 
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
+
     let home = std::env::var("HOME").expect("HOME not set");
     let model_dir_str = std::env::var("LATTICE_MODEL_DIR")
         .unwrap_or_else(|_| format!("{home}/.lattice/models/qwen3.6-27b-q4"));

--- a/crates/inference/examples/bench_profile.rs
+++ b/crates/inference/examples/bench_profile.rs
@@ -24,6 +24,8 @@ fn main() {
 
     println!("Loading model...");
     let t0 = Instant::now();
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
     let model = QwenModel::from_directory(dir).unwrap();
     println!("Loaded in {:.0}ms\n", t0.elapsed().as_millis());
 

--- a/crates/inference/examples/bench_pruning.rs
+++ b/crates/inference/examples/bench_pruning.rs
@@ -23,6 +23,8 @@ fn run() {
     use lattice_inference::model::qwen35_config::Qwen35Config;
     use std::time::Instant;
 
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
+
     let home = std::env::var("HOME").expect("HOME not set");
     let model_dir_str = std::env::var("LATTICE_MODEL_DIR")
         .unwrap_or_else(|_| format!("{home}/.lattice/models/qwen3.6-27b-q4"));

--- a/crates/inference/examples/bench_q4_prefill.rs
+++ b/crates/inference/examples/bench_q4_prefill.rs
@@ -22,6 +22,8 @@ fn run() {
     use lattice_inference::model::qwen35_config::Qwen35Config;
     use std::time::Instant;
 
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
+
     let home = std::env::var("HOME").expect("HOME not set");
     let model_dir_str = std::env::var("LATTICE_MODEL_DIR")
         .unwrap_or_else(|_| format!("{home}/.lattice/models/qwen3.6-27b-q4"));

--- a/crates/inference/examples/bench_q8_prefill.rs
+++ b/crates/inference/examples/bench_q8_prefill.rs
@@ -21,6 +21,8 @@ fn run() {
     use lattice_inference::model::qwen35::Qwen35Model;
     use std::time::Instant;
 
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
+
     let home = std::env::var("HOME").expect("HOME not set");
     let model_dir_str = std::env::var("LATTICE_MODEL_DIR")
         .unwrap_or_else(|_| format!("{home}/.lattice/models/qwen3.5-0.8b"));

--- a/crates/inference/examples/bench_quality.rs
+++ b/crates/inference/examples/bench_quality.rs
@@ -32,6 +32,8 @@ fn run() {
     use lattice_inference::tokenizer::{BpeTokenizer, Tokenizer};
     use std::time::Instant;
 
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
+
     let home = std::env::var("HOME").expect("HOME not set");
     let model_dir_str = std::env::var("LATTICE_MODEL_DIR")
         .unwrap_or_else(|_| format!("{home}/.lattice/models/qwen3.6-27b-q4"));

--- a/crates/inference/examples/bench_stability.rs
+++ b/crates/inference/examples/bench_stability.rs
@@ -34,6 +34,8 @@ fn run() {
     use std::collections::HashMap;
     use std::time::Instant;
 
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
+
     let home = std::env::var("HOME").expect("HOME not set");
     let model_dir_str = std::env::var("LATTICE_MODEL_DIR")
         .unwrap_or_else(|_| format!("{home}/.lattice/models/qwen3.6-27b-q4"));

--- a/crates/inference/examples/bench_suite.rs
+++ b/crates/inference/examples/bench_suite.rs
@@ -535,6 +535,7 @@ fn bench_llm_metal() -> Vec<Metric> {
     let tokenizer = BpeTokenizer::from_tokenizer_json(&dir.join("tokenizer.json"))
         .expect("failed to load tokenizer");
 
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
     let t_init = Instant::now();
     let mut metal_state =
         MetalQwen35State::new(model.weights(), &cfg, 4096).expect("failed to init Metal GPU state");
@@ -610,6 +611,8 @@ fn bench_embedding() -> Vec<Metric> {
     }
 
     let t_load = Instant::now();
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
     let model =
         lattice_inference::QwenModel::from_directory(dir).expect("failed to load Qwen3-0.6B");
     let load_ms = t_load.elapsed().as_millis() as f64;

--- a/crates/inference/examples/decode_profile.rs
+++ b/crates/inference/examples/decode_profile.rs
@@ -57,6 +57,7 @@ fn run() {
     );
 
     let t_load = Instant::now();
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
     let mut state: MetalQwen35State = if is_q4 {
         let cfg = Qwen35Config::from_model_dir(dir).expect("load model config.json");
         let tokenizer_path = dir.join("tokenizer.json");

--- a/crates/inference/examples/layer_sweep.rs
+++ b/crates/inference/examples/layer_sweep.rs
@@ -33,6 +33,8 @@ fn main() {
 
     println!("Loading model...");
     let t0 = Instant::now();
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
     let model = QwenModel::from_directory(dir).unwrap();
     println!("Loaded in {:.0}ms\n", t0.elapsed().as_millis());
 

--- a/crates/inference/examples/profile_metal.rs
+++ b/crates/inference/examples/profile_metal.rs
@@ -16,6 +16,8 @@ fn main() {
     use lattice_inference::model::qwen35_config::GenerateConfig;
     use lattice_inference::tokenizer::bpe::BpeTokenizer;
 
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
+
     eprintln!("[bench] Loading model...");
     let t0 = std::time::Instant::now();
     let model = Qwen35Model::from_safetensors(dir).expect("load model");

--- a/crates/inference/src/model/qwen.rs
+++ b/crates/inference/src/model/qwen.rs
@@ -2298,6 +2298,8 @@ fn extract_json_f64(text: &str, key: &str) -> Option<f64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+    use crate::measurement::gpu_test_lock;
 
     #[test]
     fn test_qwen_config_dimensions() {
@@ -2456,10 +2458,12 @@ mod tests {
 
     #[test]
     #[ignore = "Requires model files: set LATTICE_INFERENCE_MODEL_DIR"]
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
     fn test_qwen_long_text_bench() {
         let Ok(model_dir) = std::env::var("LATTICE_INFERENCE_MODEL_DIR") else {
             return;
         };
+        let _gpu_lock = gpu_test_lock();
         let model = QwenModel::from_directory(std::path::Path::new(&model_dir)).unwrap();
         // Warmup
         let _ = model.encode("warmup").unwrap();
@@ -2478,10 +2482,12 @@ mod tests {
 
     #[test]
     #[ignore = "Requires model files: set LATTICE_INFERENCE_MODEL_DIR"]
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
     fn test_qwen_multilingual() {
         let Ok(model_dir) = std::env::var("LATTICE_INFERENCE_MODEL_DIR") else {
             return;
         };
+        let _gpu_lock = gpu_test_lock();
         let model = QwenModel::from_directory(std::path::Path::new(&model_dir)).unwrap();
 
         let pairs = [
@@ -2522,11 +2528,13 @@ mod tests {
 
     #[test]
     #[ignore = "Requires model files: set LATTICE_INFERENCE_MODEL_DIR"]
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
     fn test_qwen_encode_real_model() {
         let Ok(model_dir) = std::env::var("LATTICE_INFERENCE_MODEL_DIR") else {
             return;
         };
 
+        let _gpu_lock = gpu_test_lock();
         let model = QwenModel::from_directory(std::path::Path::new(&model_dir)).unwrap();
         assert_eq!(model.config().hidden_size, 1024);
         assert_eq!(model.dimensions(), 1024);

--- a/crates/inference/tests/metal_measurement_lock_contract.rs
+++ b/crates/inference/tests/metal_measurement_lock_contract.rs
@@ -146,36 +146,12 @@ const IN_CRATE_COMMAND_BUFFER_TESTS: &[&str] = &[
 const CONSTRUCTION_SELECTORS: &[CallSelector] = &[
     CallSelector::Path(&["MetalQwen35State", "new"]),
     CallSelector::Path(&["MetalQwen35State", "from_q4_dir"]),
+    // QwenModel::from_directory attempts MetalForwardPass::new internally
+    // (crates/inference/src/model/qwen.rs) whenever Metal is available, so
+    // every caller of it is a helper-mediated Metal construction site (#1274).
+    CallSelector::Path(&["QwenModel", "from_directory"]),
 ];
 const CONSTRUCTION_EXEMPTIONS: &[(&str, &str)] = &[
-    (
-        "bench:cross_turn_prefix_cache_bench:benches/cross_turn_prefix_cache_bench.rs=>benches/cross_turn_prefix_cache_bench.rs:63:35",
-        "load_state_and_tokenizer is an exact deferred Criterion construction tracked in #1274",
-    ),
-    (
-        "bench:lm_head_bench:benches/lm_head_bench.rs=>benches/lm_head_bench.rs:176:47",
-        "setup_lm_head_fixture Q8 initialization is an exact deferred Criterion construction tracked in #1274",
-    ),
-    (
-        "bench:lm_head_bench:benches/lm_head_bench.rs=>benches/lm_head_bench.rs:205:39",
-        "setup_lm_head_fixture Q4 initialization is an exact deferred Criterion construction tracked in #1274",
-    ),
-    (
-        "bench:metal_decode_bench:benches/metal_decode_bench.rs=>benches/metal_decode_bench.rs:88:27",
-        "load_q4_state is an exact deferred Criterion construction tracked in #1274",
-    ),
-    (
-        "bench:metal_decode_bench:benches/metal_decode_bench.rs=>benches/metal_decode_bench.rs:98:35",
-        "load_q8_state is an exact deferred Criterion construction tracked in #1274",
-    ),
-    (
-        "bench:mtp_decode:benches/mtp_decode.rs=>benches/mtp_decode.rs:103:49",
-        "bench_baseline is an exact deferred Criterion construction tracked in #1274",
-    ),
-    (
-        "bench:mtp_decode:benches/mtp_decode.rs=>benches/mtp_decode.rs:199:49",
-        "bench_mtp is an exact deferred Criterion construction tracked in #1274",
-    ),
     (
         "example:bench_concurrent:examples/bench_concurrent.rs=>examples/bench_concurrent.rs:444:27",
         "run state1 construction is reached only below main's checked live guard; arbitrary call-graph proof is outside this lexical contract",
@@ -185,72 +161,12 @@ const CONSTRUCTION_EXEMPTIONS: &[(&str, &str)] = &[
         "run state2 construction is reached only below main's checked live guard; arbitrary call-graph proof is outside this lexical contract",
     ),
     (
-        "example:bench_gdn_decode:examples/bench_gdn_decode.rs=>examples/bench_gdn_decode.rs:44:39",
-        "run is an exact deferred manually launched measurement construction tracked in #1274",
+        "example:bench_embed_quality:examples/bench_embed_quality.rs=>examples/bench_embed_quality.rs:136:52",
+        "run_bench QwenModel::from_directory is reached only below main's checked live guard; arbitrary call-graph proof is outside this lexical contract",
     ),
     (
-        "example:bench_gdn_prefill_ab:examples/bench_gdn_prefill_ab.rs=>examples/bench_gdn_prefill_ab.rs:56:27",
-        "run is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:bench_gdn_prefill_ab:examples/bench_gdn_prefill_ab.rs=>examples/bench_gdn_prefill_ab.rs:132:27",
-        "run_interleaved is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:bench_gdn_state:examples/bench_gdn_state.rs=>examples/bench_gdn_state.rs:88:27",
-        "run Q4 branch is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:bench_gdn_state:examples/bench_gdn_state.rs=>examples/bench_gdn_state.rs:92:27",
-        "run safetensors branch is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:bench_persistent_state:examples/bench_persistent_state.rs=>examples/bench_persistent_state.rs:47:39",
-        "run is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:bench_pruning:examples/bench_pruning.rs=>examples/bench_pruning.rs:98:49",
-        "run is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:bench_q4_prefill:examples/bench_q4_prefill.rs=>examples/bench_q4_prefill.rs:38:39",
-        "run is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:bench_q8_prefill:examples/bench_q8_prefill.rs=>examples/bench_q8_prefill.rs:47:39",
-        "run is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:bench_quality:examples/bench_quality.rs=>examples/bench_quality.rs:121:39",
-        "run baseline is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:bench_quality:examples/bench_quality.rs=>examples/bench_quality.rs:189:40",
-        "run pruned-8 branch is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:bench_quality:examples/bench_quality.rs=>examples/bench_quality.rs:220:41",
-        "run pruned-12 branch is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:bench_stability:examples/bench_stability.rs=>examples/bench_stability.rs:87:39",
-        "run is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:bench_suite:examples/bench_suite.rs=>examples/bench_suite.rs:540:27",
-        "bench_llm_metal is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:decode_profile:examples/decode_profile.rs=>examples/decode_profile.rs:63:27",
-        "run Q4 branch is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:decode_profile:examples/decode_profile.rs=>examples/decode_profile.rs:67:27",
-        "run safetensors branch is an exact deferred manually launched measurement construction tracked in #1274",
-    ),
-    (
-        "example:profile_metal:examples/profile_metal.rs=>examples/profile_metal.rs:29:39",
-        "main is an exact deferred manually launched measurement construction tracked in #1274",
+        "bin:backfill_qwen3:src/bin/backfill_qwen3.rs=>src/bin/backfill_qwen3.rs:37:28",
+        "one-time DB embedding migration over an unbounded row count belongs to a long-running batch process outside the bounded measurement-harness contract",
     ),
     (
         "bin:chat_metal:src/bin/chat_metal.rs=>src/bin/chat_metal.rs:770:39",


### PR DESCRIPTION
Closes the remaining migration tracked by #1274: the measurement entry points that were carrying deferral exemptions now take the shared Metal measurement lock, and the contract's construction selectors cover the helper-mediated path.

## Changes

- The four remaining Criterion targets (`cross_turn_prefix_cache_bench`, `lm_head_bench`, `metal_decode_bench`, `mtp_decode`) and the manually launched measurement examples acquire the lock through the single `gpu_test_lock()` implementation. No second lock, no second lock path.
- `QwenModel::from_directory` is added as a construction selector. It attempts `MetalForwardPass::new` internally whenever Metal is available, so every caller of it is a Metal construction site; the lexical contract previously could not see that class at all.
- The corresponding deferral exemptions are deleted rather than reworded. Each one previously read "tracked in #1274", so leaving them would leave the issue's own bookkeeping as the only record that the sites were unprotected.

## Feature gating

Two regressions surfaced during verification and are fixed here rather than shipped:

- `crates/inference/src/model/qwen.rs` imported `gpu_test_lock` unconditionally in an always-compiled test module, which broke the default-feature build since `measurement` is `cfg(target_os = "macos", feature = "metal-gpu")`. The import and its three consuming tests are now gated.
- Five helper-mediated example sites called the lock unconditionally in files whose `required-features` do not include `metal-gpu`. Under a real `--workspace --all-targets` build these compile with `f16` but not `metal-gpu`. They are gated accordingly. No exemption entries were added for them; adding entries made the "exemptions must identify current exact sites" assertion fail, which is the contract correctly rejecting a stale exemption.

## Verification

`cargo test -p lattice-inference --test metal_measurement_lock_contract` passes 53/53.

Mutation check: removing the lock from `load_q4_state` in `benches/metal_decode_bench.rs` makes the contract fail naming exactly that file and byte offset:

```
MetalQwen35State construction sites without a live shared-lock binding:
bench:metal_decode_bench:benches/metal_decode_bench.rs=>benches/metal_decode_bench.rs:88:27: no live shared-lock binding encloses this work
```

Restored, green again. The guard sees the class it claims to cover.

`cargo clippy -p lattice-inference --all-targets -- -D warnings` and `cargo clippy --workspace --all-targets -- -D warnings` both clean.

## bench-compare disposition

Structural waiver: no A/B was run. The diff adds lock acquisitions and `cfg` gates to bench and example entry points; it changes no kernel, no library code on any measured call path, and no manifest, lockfile, feature default, profile, build script, or bench-target definition. Population searched: all declared bench targets in `crates/{inference,embed,fann}/Cargo.toml`, plus the two targets `bench-compare` runs by default. Residual risk: acquiring a machine-wide lock serializes a measurement against concurrent GPU work, which changes when a bench runs rather than what it measures. Contended GPU work is exactly the confound the lock exists to exclude, so any timing difference from this change is the removal of a confound, not a regression — but it is unmeasured, and saying so is the point of this disposition.



Closes #1274
