### PR TITLE
ci: migrate remaining workflows onto the rust-setup composite action

### DIFF
--- a/.github/workflows/app-binaries.yml
+++ b/.github/workflows/app-binaries.yml
@@ -168,8 +168,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/rust-setup
         with:
           shared-key: app-binaries
       - name: Build all app-shipped binaries (required-features included)

--- a/.github/workflows/bench-update.yml
+++ b/.github/workflows/bench-update.yml
@@ -49,9 +49,7 @@ jobs:
         with:
           fetch-depth: 0  # need history for commit SHA + dates
 
-      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/rust-setup
         with:
           cache-on-failure: true
           shared-key: bench-${{ matrix.arch }}

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -130,9 +130,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
-      - name: Pin the real toolchain bin on PATH
-        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
+      - uses: ./.github/actions/rust-setup
+        with:
+          pin-cargo-path: true
       - name: Cache cargo-audit binary
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -153,9 +153,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
-      - name: Pin the real toolchain bin on PATH
-        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
+      - uses: ./.github/actions/rust-setup
+        with:
+          pin-cargo-path: true
       - name: Cache cargo-audit binary
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/embed-parity-release.yml
+++ b/.github/workflows/embed-parity-release.yml
@@ -43,9 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/rust-setup
         with:
           shared-key: embed-parity-release
 

--- a/.github/workflows/perf-postmerge-gate.yml
+++ b/.github/workflows/perf-postmerge-gate.yml
@@ -242,9 +242,7 @@ jobs:
           # no parent and the resolve step below would fail closed.
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/rust-setup
         with:
           cache-on-failure: true
           shared-key: perf-postmerge-${{ matrix.arch }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -93,13 +93,9 @@ jobs:
           ref: ${{ needs.prepare.outputs.sha }}
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
-
-      - name: Pin the real toolchain bin on PATH
-        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/rust-setup
         with:
+          pin-cargo-path: true
           shared-key: release-binaries-${{ matrix.target }}
 
       - name: Build lattice CLI (release)
@@ -147,13 +143,9 @@ jobs:
           ref: ${{ needs.prepare.outputs.sha }}
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@e43eeffd51aefeea929f4ea14e09fd077153e788 # 1.94.1
-
-      - name: Pin the real toolchain bin on PATH
-        run: dirname "$(rustup which cargo)" >> "$GITHUB_PATH"
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/rust-setup
         with:
+          pin-cargo-path: true
           shared-key: release-macos-app
 
       - name: Cache Swift release build


### PR DESCRIPTION
Migrates the eight remaining hand-rolled Rust toolchain + cache blocks onto the `./.github/actions/rust-setup` composite action introduced earlier, so every workflow that installs a toolchain gets the isolated `RUSTUP_HOME` that fixes the intermittent ARM clippy-component install conflict.

Sites migrated (eight, across six files):

| File | Job | Inputs carried over |
|---|---|---|
| `app-binaries.yml` | `build-app-bins` | `shared-key: app-binaries` |
| `bench-update.yml` | `bench` | `cache-on-failure: true`, `shared-key: bench-${{ matrix.arch }}` |
| `cargo-audit.yml` | `audit` | `pin-cargo-path: true` |
| `cargo-audit.yml` | `audit-native` | `pin-cargo-path: true` |
| `embed-parity-release.yml` | `embed-parity` | `shared-key: embed-parity-release` |
| `perf-postmerge-gate.yml` | `postmerge-ab` | `cache-on-failure: true`, `shared-key: perf-postmerge-${{ matrix.arch }}` |
| `release-binaries.yml` | `build` | `pin-cargo-path: true`, `shared-key: release-binaries-${{ matrix.target }}` |
| `release-binaries.yml` | `macos-app` | `pin-cargo-path: true`, `shared-key: release-macos-app` |

No site passed `components:` or `targets:` before, so none passes them now. Every `shared-key` and `cache-on-failure` value is carried across unchanged, since a silently changed cache key would split a cache while the job still passes.

Two deliberate non-changes:

- The `msrv` job in `ci.yml` stays inline. It pins a different toolchain (1.93.1) on purpose.
- The `semver-checks` job in `ci.yml` keeps its standalone `Swatinem/rust-cache` step. It installs no toolchain, so there is nothing for the composite action to replace.

Behaviour change worth calling out: `cargo-audit.yml`'s two jobs had no `Swatinem/rust-cache` step at all before (they cached only the standalone `cargo-audit` binary). The composite action always includes one, so those two jobs gain a build cache with no explicit `shared-key`. Neither job builds the workspace, so the added step has little to store.

Validation, since a workflow file that parses is not a workflow that runs:

- Every `with:` key at all eight sites was checked against `action.yml`'s declared `inputs:`. An unknown `with:` key is silently ignored by GitHub Actions, so a typo would otherwise produce a job running with the input missing and no error anywhere. All eight report no unknown keys and no missing required inputs.
- Each edited file was parsed with `yaml.safe_load` and the resulting job/step structure printed, rather than reviewed by eye.
- A repository-wide grep confirms exactly one remaining `dtolnay/rust-toolchain` reference, at `ci.yml:595` inside `msrv`.

Bench-compare disposition: not applicable. This PR touches only `.github/workflows/` and no file under `crates/inference/`, `crates/embed/`, or `crates/fann/`, so there is no runtime source change, no manifest, dependency, feature, profile, build-script or bench-target change, and nothing for an A/B to measure.

Closes #1326.
