### PR TITLE
bench(embed): add a Manhattan distance group to the simd bench target

### DIFF
--- a/crates/embed/benches/simd.rs
+++ b/crates/embed/benches/simd.rs
@@ -13,7 +13,7 @@ use lattice_embed::simd::{
     QuantizationTier, QuantizedData, QuantizedVector, SimdConfig, approximate_cosine_distance,
     approximate_cosine_distance_prepared, approximate_cosine_distance_prepared_with_meta,
     approximate_dot_product_prepared, approximate_int4_batch_prepared,
-    approximate_int8_batch_prepared,
+    approximate_int8_batch_prepared, manhattan_distance,
 };
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -1226,8 +1226,35 @@ fn bench_prepared_batch_sizes(c: &mut Criterion) {
     group.finish();
 }
 
+fn manhattan_distance_scalar(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b.iter()).map(|(x, y)| (x - y).abs()).sum()
+}
+
+/// Compare SIMD vs scalar Manhattan (L1) distance.
+fn bench_manhattan_simd_vs_scalar(c: &mut Criterion) {
+    let mut group = c.benchmark_group("simd_manhattan_distance");
+
+    for dim in DIMENSIONS {
+        let a = generate_vector(dim, 42);
+        let b = generate_vector(dim, 123);
+
+        group.throughput(Throughput::Elements(dim as u64));
+
+        group.bench_with_input(BenchmarkId::new("scalar", dim), &dim, |bench, _| {
+            bench.iter(|| black_box(manhattan_distance_scalar(black_box(&a), black_box(&b))));
+        });
+
+        group.bench_with_input(BenchmarkId::new("simd", dim), &dim, |bench, _| {
+            bench.iter(|| black_box(manhattan_distance(black_box(&a), black_box(&b))));
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     simd_benches,
+    bench_manhattan_simd_vs_scalar,
     bench_cosine_simd_vs_scalar,
     bench_dot_product_simd_vs_scalar,
     bench_normalize_simd_vs_scalar,


### PR DESCRIPTION
`simd::manhattan_distance` had no bench group, so no A/B run could observe a change to it. This adds a `simd_manhattan_distance` group to the existing `lattice-embed` `simd` bench target, comparing the SIMD path against a scalar reference across the four dimensions the target already sweeps (384, 768, 1024, 1536).

The group is lifted from #1332, where it sits alongside a per-head attention change I measured and recommended against merging as-is. The bench group is the durable half of that PR and does not depend on the source change, so it lands on its own.

Reachability verified rather than assumed, since "the group exists" and "the group runs" are different claims and this issue is about the second one:

```
$ ./target/release/deps/simd-<hash> --test "simd_manhattan_distance"
Testing simd_manhattan_distance/scalar/384 ... Success
... 8 ids, all Success
```

Both arms in the same session: the matching filter runs 8 benchmark ids, and a deliberately non-matching filter (`simd_manhattan_distance_NOSUCHGROUP`) runs 0 and still exits 0. The second arm is why the first is worth quoting — a Criterion filter that matches nothing exits successfully, so an executed count is the only honest evidence that a group ran.

## Bench-compare disposition

This PR adds a bench group and changes no runtime source. There is no before/after to report, because the group does not exist on the base side — an A/B has nothing to compare against. What it does change is coverage: after this lands, a future change to `manhattan_distance` becomes measurable, which is the point. No performance claim is made here and none should be read into it.

Closes #1294.

