### PR TITLE
feat(inference): add a Metal BF16 perplexity mode to eval_perplexity

### DIFF
--- a/crates/inference/src/bin/eval_perplexity.rs
+++ b/crates/inference/src/bin/eval_perplexity.rs
@@ -2,10 +2,19 @@
 //!
 //! ADR-044 step 4 (sub-steps 4a/4b/4c).
 //!
-//! Three measurement modes, mutually exclusive:
+//! Four measurement modes, mutually exclusive:
 //! - `--model-dir <PATH>`: CPU forward path on a BF16/F16/F32 safetensors
 //!   checkpoint via [`Qwen35Model::from_safetensors`] (the baseline shipped in
 //!   step 4a).
+//! - `--metal-model-dir <PATH>`: Metal GPU forward path on a BF16/F16/F32
+//!   safetensors checkpoint (same directory layout as `--model-dir`), via
+//!   [`MetalQwen35State::new`] on weights loaded through
+//!   [`Qwen35Model::from_safetensors`]. This is the full-precision
+//!   configuration actually served over Metal — the CPU path above
+//!   approximates it but does not exercise the Metal kernels (f16
+//!   accumulation, kernel-specific rounding) that drift can hide in.
+//!   Carries its own tokenizer from the checkpoint directory, same as
+//!   `--model-dir`; does not take `--tokenizer-dir`.
 //! - `--q4-dir <PATH>`: Metal Q4 forward path via
 //!   [`MetalQwen35State::from_q4_dir`] on a directory produced by
 //!   `bin/quantize_q4` (unrotated 4-bit weights).
@@ -31,6 +40,12 @@
 //!   --corpus-file wiki.test.raw \
 //!   --window 512 --stride 256
 //!
+//! # Metal BF16 safetensors (full-precision Metal serving path)
+//! cargo run --release --features f16,metal-gpu --bin eval_perplexity -- \
+//!   --metal-model-dir ~/.lattice/models/qwen3.5-0.8b \
+//!   --corpus-file wiki.test.raw \
+//!   --window 512 --stride 256
+//!
 //! # Metal Q4 single (step 4b)
 //! cargo run --release --features f16,metal-gpu --bin eval_perplexity -- \
 //!   --q4-dir ~/.lattice/models/qwen3.5-0.8b-q4 \
@@ -48,27 +63,36 @@
 //! Flags:
 //! - `--model-dir <PATH>`: CPU mode. Directory with `config.json` + safetensors
 //!   + `tokenizer.json`. Loaded via [`Qwen35Model::from_safetensors`].
+//! - `--metal-model-dir <PATH>`: Metal BF16/F16/F32 mode. Same directory
+//!   layout as `--model-dir` (`config.json` + safetensors + `tokenizer.json`).
+//!   Loaded via [`Qwen35Model::from_safetensors`], then its weights and config
+//!   are handed to [`MetalQwen35State::new`]. Requires the `metal-gpu` feature
+//!   on macOS to actually run; without it, state construction fails at
+//!   runtime with a capability error, same as the other Metal modes.
 //! - `--q4-dir <PATH>`: Metal Q4 mode. Directory with `.q4` / `.f16` /
 //!   `config.json` / `quantize_index.json` produced by `bin/quantize_q4`.
 //! - `--quarot-q4-dir <PATH>`: Metal Q4 mode on a `bin/quantize_quarot`
 //!   output directory (rotated 4-bit weights, same file layout).
-//! - `--tokenizer-dir <PATH>`: Metal modes only. Directory containing
-//!   `tokenizer.json`. Both `quantize_q4` and `quantize_quarot` ship the
-//!   model weights but NOT the BPE tokenizer, so this typically points at
-//!   the source safetensors directory.
+//! - `--tokenizer-dir <PATH>`: Metal **Q4** modes only (`--q4-dir` /
+//!   `--quarot-q4-dir`). Directory containing `tokenizer.json`. Both
+//!   `quantize_q4` and `quantize_quarot` ship the model weights but NOT the
+//!   BPE tokenizer, so this typically points at the source safetensors
+//!   directory. `--model-dir` and `--metal-model-dir` carry their own
+//!   tokenizer and ignore this flag.
 //! - `--corpus-file <PATH>`: UTF-8 text file. Tokenized end-to-end with
 //!   the model's BPE tokenizer.
 //! - `--window <USIZE>`: context window length in tokens. Default `512`.
 //! - `--stride <USIZE>`: tokens advanced between windows. Default `256`.
 //! - `--max-tokens <USIZE>`: cap total tokens scored (after tokenization).
 //!   Useful for smoke runs on a long corpus. Default: no cap.
-//! - `--max-cache-len <USIZE>`: Metal modes only. KV-cache capacity passed
-//!   to `MetalQwen35State::from_q4_dir`. Must be `>= window`. Default:
-//!   `max(window, 4096)`.
+//! - `--max-cache-len <USIZE>`: Metal modes only (`--metal-model-dir`,
+//!   `--q4-dir`, `--quarot-q4-dir`). KV-cache capacity passed to the Metal
+//!   state constructor. Must be `>= window`. Default: `max(window, 4096)`.
 //! - `--delta-threshold <F64>`: dual-Q4 mode only. PPL delta threshold for
 //!   the ADR-044 acceptance gate. Default `0.5`. Exit code `1` if the
 //!   measured `quarot - unrotated` delta meets or exceeds this value.
-//! - `--random-lora-rank <N>`: Metal modes only. Generate a random synthetic
+//! - `--random-lora-rank <N>`: Metal modes only (`--metal-model-dir`,
+//!   `--q4-dir`, `--quarot-q4-dir`). Generate a random synthetic
 //!   LoRA adapter at rank N and load it, exercising the full
 //!   Metal+QuaRot+LoRA code path end-to-end.
 //! - `--quarot-seed <N>`: u64 seed for QuaRot counter-rotation and random
@@ -114,10 +138,45 @@ fn emit_perplexity_event(label: &str, report: &PerplexityReport, elapsed_ms: u12
     println!("@@lattice {obj}");
 }
 
-fn main() -> ExitCode {
-    let args: Vec<String> = std::env::args().collect();
+/// Outcome of [`parse_args`]: either the caller asked for `--help`/`-h`
+/// (print usage, exit success), or a fully validated set of arguments.
+#[derive(Debug)]
+enum ArgsOutcome {
+    Help,
+    Args(Box<ParsedArgs>),
+}
 
+/// Parsed and validated CLI arguments. Everything mode-selection and
+/// mutual-exclusion related has already been checked by the time this is
+/// constructed — `main` only has to dispatch on which `Option` fields are
+/// `Some`.
+#[derive(Debug)]
+struct ParsedArgs {
+    model_dir: Option<PathBuf>,
+    metal_model_dir: Option<PathBuf>,
+    q4_dir: Option<PathBuf>,
+    quarot_q4_dir: Option<PathBuf>,
+    tokenizer_dir: Option<PathBuf>,
+    corpus_file: PathBuf,
+    cfg: PerplexityConfig,
+    max_tokens: Option<usize>,
+    resolved_max_cache_len: usize,
+    delta_threshold: Option<f64>,
+    random_lora_rank: Option<usize>,
+    quarot_seed: Option<u64>,
+    lora_scale: Option<f32>,
+    emit_json: bool,
+    json_label: Option<String>,
+}
+
+/// Parse argv into [`ArgsOutcome`], or an error message describing the
+/// first invalid flag / value / mode combination encountered. Pure and
+/// side-effect-free (no I/O, no process exit) so the validation rules —
+/// mode mutual exclusion, which flags require `--tokenizer-dir`, which
+/// require a Metal mode — are unit-testable without a model checkpoint.
+fn parse_args(args: &[String]) -> Result<ArgsOutcome, String> {
     let mut model_dir: Option<PathBuf> = None;
+    let mut metal_model_dir: Option<PathBuf> = None;
     let mut q4_dir: Option<PathBuf> = None;
     let mut quarot_q4_dir: Option<PathBuf> = None;
     let mut tokenizer_dir: Option<PathBuf> = None;
@@ -139,116 +198,123 @@ fn main() -> ExitCode {
             "--model-dir" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--model-dir requires an argument");
+                    return Err("--model-dir requires an argument".to_string());
                 };
                 model_dir = Some(PathBuf::from(v));
+            }
+            "--metal-model-dir" => {
+                i += 1;
+                let Some(v) = args.get(i) else {
+                    return Err("--metal-model-dir requires an argument".to_string());
+                };
+                metal_model_dir = Some(PathBuf::from(v));
             }
             "--q4-dir" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--q4-dir requires an argument");
+                    return Err("--q4-dir requires an argument".to_string());
                 };
                 q4_dir = Some(PathBuf::from(v));
             }
             "--quarot-q4-dir" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--quarot-q4-dir requires an argument");
+                    return Err("--quarot-q4-dir requires an argument".to_string());
                 };
                 quarot_q4_dir = Some(PathBuf::from(v));
             }
             "--tokenizer-dir" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--tokenizer-dir requires an argument");
+                    return Err("--tokenizer-dir requires an argument".to_string());
                 };
                 tokenizer_dir = Some(PathBuf::from(v));
             }
             "--corpus-file" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--corpus-file requires an argument");
+                    return Err("--corpus-file requires an argument".to_string());
                 };
                 corpus_file = Some(PathBuf::from(v));
             }
             "--window" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--window requires an argument");
+                    return Err("--window requires an argument".to_string());
                 };
                 window = Some(match v.parse::<usize>() {
                     Ok(n) => n,
-                    Err(e) => return usage(&format!("--window: invalid usize: {e}")),
+                    Err(e) => return Err(format!("--window: invalid usize: {e}")),
                 });
             }
             "--stride" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--stride requires an argument");
+                    return Err("--stride requires an argument".to_string());
                 };
                 stride = Some(match v.parse::<usize>() {
                     Ok(n) => n,
-                    Err(e) => return usage(&format!("--stride: invalid usize: {e}")),
+                    Err(e) => return Err(format!("--stride: invalid usize: {e}")),
                 });
             }
             "--max-tokens" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--max-tokens requires an argument");
+                    return Err("--max-tokens requires an argument".to_string());
                 };
                 max_tokens = Some(match v.parse::<usize>() {
                     Ok(n) => n,
-                    Err(e) => return usage(&format!("--max-tokens: invalid usize: {e}")),
+                    Err(e) => return Err(format!("--max-tokens: invalid usize: {e}")),
                 });
             }
             "--max-cache-len" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--max-cache-len requires an argument");
+                    return Err("--max-cache-len requires an argument".to_string());
                 };
                 max_cache_len = Some(match v.parse::<usize>() {
                     Ok(n) => n,
-                    Err(e) => return usage(&format!("--max-cache-len: invalid usize: {e}")),
+                    Err(e) => return Err(format!("--max-cache-len: invalid usize: {e}")),
                 });
             }
             "--delta-threshold" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--delta-threshold requires an argument");
+                    return Err("--delta-threshold requires an argument".to_string());
                 };
                 delta_threshold = Some(match v.parse::<f64>() {
                     Ok(n) => n,
-                    Err(e) => return usage(&format!("--delta-threshold: invalid f64: {e}")),
+                    Err(e) => return Err(format!("--delta-threshold: invalid f64: {e}")),
                 });
             }
             "--random-lora-rank" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--random-lora-rank requires an argument");
+                    return Err("--random-lora-rank requires an argument".to_string());
                 };
                 random_lora_rank = Some(match v.parse::<usize>() {
                     Ok(n) => n,
-                    Err(e) => return usage(&format!("--random-lora-rank: invalid usize: {e}")),
+                    Err(e) => return Err(format!("--random-lora-rank: invalid usize: {e}")),
                 });
             }
             "--quarot-seed" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--quarot-seed requires an argument");
+                    return Err("--quarot-seed requires an argument".to_string());
                 };
                 quarot_seed = Some(match v.parse::<u64>() {
                     Ok(n) => n,
-                    Err(e) => return usage(&format!("--quarot-seed: invalid u64: {e}")),
+                    Err(e) => return Err(format!("--quarot-seed: invalid u64: {e}")),
                 });
             }
             "--lora-scale" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--lora-scale requires an argument");
+                    return Err("--lora-scale requires an argument".to_string());
                 };
                 lora_scale = Some(match v.parse::<f32>() {
                     Ok(n) => n,
-                    Err(e) => return usage(&format!("--lora-scale: invalid f32: {e}")),
+                    Err(e) => return Err(format!("--lora-scale: invalid f32: {e}")),
                 });
             }
             "--json" => {
@@ -257,35 +323,63 @@ fn main() -> ExitCode {
             "--label" => {
                 i += 1;
                 let Some(v) = args.get(i) else {
-                    return usage("--label requires an argument");
+                    return Err("--label requires an argument".to_string());
                 };
                 json_label = Some(v.clone());
             }
-            "--help" | "-h" => {
-                eprintln!("{USAGE}");
-                return ExitCode::SUCCESS;
-            }
-            other => return usage(&format!("unknown argument: {other}")),
+            "--help" | "-h" => return Ok(ArgsOutcome::Help),
+            other => return Err(format!("unknown argument: {other}")),
         }
         i += 1;
     }
 
     let Some(corpus_file) = corpus_file else {
-        return usage("--corpus-file is required");
+        return Err("--corpus-file is required".to_string());
     };
 
+    // ------------------------------------------------------------------
+    // Mode mutual-exclusion / requirement rules. `metal_paths_used` covers
+    // the two Q4 modes (they share the "requires --tokenizer-dir" rule,
+    // since neither `quantize_q4` nor `quantize_quarot` output ships a
+    // tokenizer); `metal_model_used` is the new BF16-on-Metal mode, which
+    // carries its own tokenizer like `--model-dir` and so is deliberately
+    // NOT part of `metal_paths_used`. `any_metal_used` is every mode that
+    // constructs a `MetalQwen35State` and therefore shares the Metal
+    // KV-cache-size rule and the `--random-lora-rank` requirement.
+    // ------------------------------------------------------------------
     let metal_paths_used = q4_dir.is_some() || quarot_q4_dir.is_some();
+    let metal_model_used = metal_model_dir.is_some();
+    let any_metal_used = metal_paths_used || metal_model_used;
+
     if model_dir.is_some() && metal_paths_used {
-        return usage("--model-dir is mutually exclusive with --q4-dir / --quarot-q4-dir");
+        return Err(
+            "--model-dir is mutually exclusive with --q4-dir / --quarot-q4-dir".to_string(),
+        );
     }
-    if !metal_paths_used && model_dir.is_none() {
-        return usage("one of --model-dir, --q4-dir, or --quarot-q4-dir is required");
+    if model_dir.is_some() && metal_model_used {
+        return Err("--model-dir is mutually exclusive with --metal-model-dir".to_string());
+    }
+    if metal_model_used && metal_paths_used {
+        return Err(
+            "--metal-model-dir is mutually exclusive with --q4-dir / --quarot-q4-dir".to_string(),
+        );
+    }
+    if !any_metal_used && model_dir.is_none() {
+        return Err(
+            "one of --model-dir, --metal-model-dir, --q4-dir, or --quarot-q4-dir is required"
+                .to_string(),
+        );
     }
     if metal_paths_used && tokenizer_dir.is_none() {
-        return usage("--tokenizer-dir is required when using --q4-dir or --quarot-q4-dir");
+        return Err(
+            "--tokenizer-dir is required when using --q4-dir or --quarot-q4-dir".to_string(),
+        );
     }
-    if random_lora_rank.is_some() && !metal_paths_used {
-        return usage("--random-lora-rank requires --q4-dir or --quarot-q4-dir (Metal mode only)");
+    if random_lora_rank.is_some() && !any_metal_used {
+        return Err(
+            "--random-lora-rank requires --metal-model-dir, --q4-dir, or --quarot-q4-dir (Metal mode only)"
+                .to_string(),
+        );
     }
 
     let cfg = PerplexityConfig {
@@ -294,16 +388,69 @@ fn main() -> ExitCode {
     };
 
     let resolved_max_cache_len = max_cache_len.unwrap_or_else(|| cfg.window.max(4096));
-    if metal_paths_used && resolved_max_cache_len < cfg.window {
-        return usage(&format!(
+    if any_metal_used && resolved_max_cache_len < cfg.window {
+        return Err(format!(
             "--max-cache-len ({resolved_max_cache_len}) must be >= --window ({}); the Metal KV cache must fit a full window",
             cfg.window
         ));
     }
 
+    Ok(ArgsOutcome::Args(Box::new(ParsedArgs {
+        model_dir,
+        metal_model_dir,
+        q4_dir,
+        quarot_q4_dir,
+        tokenizer_dir,
+        corpus_file,
+        cfg,
+        max_tokens,
+        resolved_max_cache_len,
+        delta_threshold,
+        random_lora_rank,
+        quarot_seed,
+        lora_scale,
+        emit_json,
+        json_label,
+    })))
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+
+    let ParsedArgs {
+        model_dir,
+        metal_model_dir,
+        q4_dir,
+        quarot_q4_dir,
+        tokenizer_dir,
+        corpus_file,
+        cfg,
+        max_tokens,
+        resolved_max_cache_len,
+        delta_threshold,
+        random_lora_rank,
+        quarot_seed,
+        lora_scale,
+        emit_json,
+        json_label,
+    } = match parse_args(&args) {
+        Ok(ArgsOutcome::Help) => {
+            eprintln!("{USAGE}");
+            return ExitCode::SUCCESS;
+        }
+        Ok(ArgsOutcome::Args(parsed)) => *parsed,
+        Err(msg) => return usage(&msg),
+    };
+
+    let metal_paths_used = q4_dir.is_some() || quarot_q4_dir.is_some();
+    let any_metal_used = metal_paths_used || metal_model_dir.is_some();
+
     eprintln!("=== eval_perplexity ===");
     if let Some(ref p) = model_dir {
         eprintln!("Model dir (CPU):  {}", p.display());
+    }
+    if let Some(ref p) = metal_model_dir {
+        eprintln!("Metal model dir:  {}", p.display());
     }
     if let Some(ref p) = q4_dir {
         eprintln!("Q4 dir (Metal):   {}", p.display());
@@ -317,7 +464,7 @@ fn main() -> ExitCode {
     eprintln!("Corpus:           {}", corpus_file.display());
     eprintln!("Window:           {}", cfg.window);
     eprintln!("Stride:           {}", cfg.stride);
-    if metal_paths_used {
+    if any_metal_used {
         eprintln!("Max cache len:    {resolved_max_cache_len}");
     }
     if let Some(cap) = max_tokens {
@@ -374,7 +521,30 @@ fn main() -> ExitCode {
     }
 
     // -----------------------------------------------------------------------
-    // Modes 2 + 3: Metal Q4 forward path (single or dual delta).
+    // Mode 2: Metal GPU forward path on a BF16/F16/F32 safetensors checkpoint
+    // (the full-precision configuration served over Metal).
+    // -----------------------------------------------------------------------
+    if let Some(metal_model_dir) = metal_model_dir {
+        return match run_metal_model_dir(
+            &metal_model_dir,
+            resolved_max_cache_len,
+            max_tokens,
+            &corpus_text,
+            &corpus_file,
+            &cfg,
+            random_lora_rank,
+            quarot_seed,
+            lora_scale.unwrap_or(1.0),
+            emit_json,
+            json_label.as_deref().or(Some("metal-bf16")),
+        ) {
+            Ok(_) => ExitCode::SUCCESS,
+            Err(code) => code,
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // Modes 3 + 4: Metal Q4 forward path (single or dual delta).
     // -----------------------------------------------------------------------
     let tokenizer_dir = tokenizer_dir.expect("checked above");
     let tokenizer_path = tokenizer_dir.join("tokenizer.json");
@@ -566,6 +736,108 @@ fn run_metal_q4(
         };
     eprintln!("[{label}] loaded in {}ms", t_load.elapsed().as_millis());
 
+    run_on_metal_state(
+        &mut state,
+        cfg_loaded,
+        tokens,
+        ppl_cfg,
+        label,
+        random_lora_rank,
+        quarot_seed,
+        lora_scale,
+        emit_json,
+        json_label,
+    )
+}
+
+/// Load a BF16/F16/F32 safetensors checkpoint (the same directory layout
+/// `--model-dir` reads) and run it through the Metal GPU forward path
+/// instead of the CPU path. Reuses [`Qwen35Model::from_safetensors`] for
+/// loading (weights, config, and tokenizer all come from there — this mode
+/// carries its own tokenizer exactly like `--model-dir`, unlike the Q4
+/// modes) and [`run_on_metal_state`] for the LoRA-attach + perplexity +
+/// report sequence, which is identical to the Q4 modes because
+/// `MetalQwen35State::compute_perplexity` is loading-path-agnostic — it
+/// drives the same shared `run_strided_perplexity` window walk regardless
+/// of whether the state came from `new` or `from_q4_dir`.
+#[allow(clippy::too_many_arguments)]
+fn run_metal_model_dir(
+    metal_model_dir: &std::path::Path,
+    max_cache_len: usize,
+    max_tokens: Option<usize>,
+    corpus_text: &str,
+    corpus_file: &std::path::Path,
+    ppl_cfg: &PerplexityConfig,
+    random_lora_rank: Option<usize>,
+    quarot_seed: Option<u64>,
+    lora_scale: f32,
+    emit_json: bool,
+    json_label: Option<&str>,
+) -> Result<PerplexityReport, ExitCode> {
+    let label = "Metal BF16 safetensors";
+
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
+
+    let t_load = Instant::now();
+    let model = match Qwen35Model::from_safetensors(metal_model_dir) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("ERROR: failed to load model: {e}");
+            return Err(ExitCode::FAILURE);
+        }
+    };
+    eprintln!("Model loaded in {}ms", t_load.elapsed().as_millis());
+
+    let tokens = tokenize_with(model.tokenizer(), corpus_text, max_tokens, corpus_file)?;
+
+    let t_state = Instant::now();
+    let mut state = match MetalQwen35State::new(model.weights(), model.config(), max_cache_len) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!(
+                "ERROR: failed to construct Metal state from {}: {e}",
+                metal_model_dir.display()
+            );
+            return Err(ExitCode::FAILURE);
+        }
+    };
+    eprintln!(
+        "[{label}] Metal state constructed in {}ms",
+        t_state.elapsed().as_millis()
+    );
+
+    run_on_metal_state(
+        &mut state,
+        model.config(),
+        &tokens,
+        ppl_cfg,
+        label,
+        random_lora_rank,
+        quarot_seed,
+        lora_scale,
+        emit_json,
+        json_label,
+    )
+}
+
+/// Shared tail for every Metal mode once a [`MetalQwen35State`] has been
+/// constructed (regardless of whether it came from `from_q4_dir` or `new`):
+/// optionally attach a random synthetic LoRA adapter, then run and report
+/// perplexity via the state's own `compute_perplexity`.
+#[allow(clippy::too_many_arguments)]
+fn run_on_metal_state(
+    state: &mut MetalQwen35State,
+    cfg_loaded: &Qwen35Config,
+    tokens: &[u32],
+    ppl_cfg: &PerplexityConfig,
+    label: &str,
+    random_lora_rank: Option<usize>,
+    quarot_seed: Option<u64>,
+    lora_scale: f32,
+    emit_json: bool,
+    json_label: Option<&str>,
+) -> Result<PerplexityReport, ExitCode> {
     if let Some(rank) = random_lora_rank {
         let layers = generate_random_lora_layers(cfg_loaded, rank, quarot_seed.unwrap_or(0));
         let module_count = layers.len();
@@ -684,10 +956,15 @@ const USAGE: &str = "\
 usage: eval_perplexity [MODE-FLAGS] --corpus-file <PATH> [OPTIONS]
 
 Compute strided sliding-window perplexity of a Qwen3.5 model on a UTF-8
-text corpus (ADR-044 step 4). Three measurement modes:
+text corpus (ADR-044 step 4). Four measurement modes:
 
   CPU safetensors (step 4a):
     --model-dir <PATH>     Directory with config.json + safetensors + tokenizer.json.
+
+  Metal BF16 safetensors (full-precision Metal serving path):
+    --metal-model-dir <PATH>
+                           Same directory layout as --model-dir. Carries its
+                           own tokenizer; does not take --tokenizer-dir.
 
   Metal Q4 single (step 4b):
     --q4-dir <PATH>        bin/quantize_q4 output dir (unrotated 4-bit weights).
@@ -710,11 +987,14 @@ options:
   --window <USIZE>         Context window in tokens. Default 512.
   --stride <USIZE>         Tokens advanced per window. Default 256.
   --max-tokens <USIZE>     Cap total tokens after tokenization (for smoke runs).
-  --max-cache-len <USIZE>  Metal modes only. KV-cache capacity passed to
-                           from_q4_dir. Must be >= --window. Default max(window, 4096).
+  --max-cache-len <USIZE>  Metal modes only (--metal-model-dir, --q4-dir,
+                           --quarot-q4-dir). KV-cache capacity passed to the
+                           Metal state constructor. Must be >= --window.
+                           Default max(window, 4096).
   --delta-threshold <F64>  Dual-Q4 mode only. PPL delta acceptance threshold.
                            Default 0.5. Exit 1 if measured delta >= threshold.
-  --random-lora-rank <N>   Metal modes only. Generate a random synthetic LoRA
+  --random-lora-rank <N>   Metal modes only (--metal-model-dir, --q4-dir,
+                           --quarot-q4-dir). Generate a random synthetic LoRA
                            adapter at rank N for all supported modules on all
                            layers and load it via load_lora_adapter. Exercises
                            the full Metal+QuaRot+LoRA code path end-to-end.
@@ -726,8 +1006,9 @@ options:
   --json                   Emit a structured @@lattice line to stdout for each target
                            evaluated (machine-readable output for the macOS app).
   --label <STRING>         Label to use in the --json event (overrides per-target default).
-                           Defaults: bf16 for --model-dir, q4 for --q4-dir, quarot
-                           for --quarot-q4-dir.
+                           Defaults: bf16 for --model-dir, metal-bf16 for
+                           --metal-model-dir, q4 for --q4-dir, quarot for
+                           --quarot-q4-dir.
   -h, --help               Print this help and exit.
 
 The harness mirrors HuggingFace's fixed-length-model recipe: each non-
@@ -825,5 +1106,213 @@ mod tests {
             "a Q4 dir with no config.json must be a hard error, not a guessed preset"
         );
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // -- #1327: --metal-model-dir argument parsing and mode validation ----
+    //
+    // `parse_args` is the pure, side-effect-free extraction of the CLI's
+    // parsing + mode-validation rules (previously inline in `main`), added
+    // specifically so these rules are testable without a model checkpoint.
+
+    fn argv(pieces: &[&str]) -> Vec<String> {
+        std::iter::once("eval_perplexity".to_string())
+            .chain(pieces.iter().map(std::string::ToString::to_string))
+            .collect()
+    }
+
+    fn expect_args(pieces: &[&str]) -> ParsedArgs {
+        match parse_args(&argv(pieces)) {
+            Ok(ArgsOutcome::Args(p)) => *p,
+            Ok(ArgsOutcome::Help) => panic!("expected Args, got Help for {pieces:?}"),
+            Err(e) => panic!("expected Ok(Args) for {pieces:?}, got Err({e:?})"),
+        }
+    }
+
+    fn expect_err(pieces: &[&str]) -> String {
+        match parse_args(&argv(pieces)) {
+            Err(e) => e,
+            Ok(outcome) => panic!("expected Err for {pieces:?}, got Ok({outcome:?})"),
+        }
+    }
+
+    #[test]
+    fn metal_model_dir_parses_and_reaches_its_own_mode() {
+        let p = expect_args(&[
+            "--metal-model-dir",
+            "/tmp/does-not-need-to-exist",
+            "--corpus-file",
+            "/tmp/corpus.txt",
+        ]);
+        assert_eq!(
+            p.metal_model_dir,
+            Some(PathBuf::from("/tmp/does-not-need-to-exist"))
+        );
+        assert_eq!(
+            p.model_dir, None,
+            "--metal-model-dir must not set model_dir"
+        );
+        assert_eq!(p.q4_dir, None);
+        assert_eq!(p.quarot_q4_dir, None);
+        assert_eq!(
+            p.tokenizer_dir, None,
+            "--metal-model-dir carries its own tokenizer; --tokenizer-dir was never passed"
+        );
+    }
+
+    #[test]
+    fn metal_model_dir_does_not_require_tokenizer_dir() {
+        // Unlike --q4-dir / --quarot-q4-dir, --metal-model-dir loads its
+        // tokenizer from the checkpoint directory itself (same as
+        // --model-dir), so omitting --tokenizer-dir must be valid.
+        expect_args(&["--metal-model-dir", "/tmp/m", "--corpus-file", "/tmp/c.txt"]);
+    }
+
+    #[test]
+    fn metal_model_dir_accepts_random_lora_rank() {
+        // --random-lora-rank requires "Metal mode"; --metal-model-dir builds
+        // a MetalQwen35State exactly like the Q4 modes do, via the same
+        // load_lora_adapter API, so it must count as Metal mode too.
+        let p = expect_args(&[
+            "--metal-model-dir",
+            "/tmp/m",
+            "--corpus-file",
+            "/tmp/c.txt",
+            "--random-lora-rank",
+            "8",
+        ]);
+        assert_eq!(p.random_lora_rank, Some(8));
+    }
+
+    // -- pre-existing rules: still rejected, original message text --------
+
+    #[test]
+    fn model_dir_and_q4_dir_still_mutually_exclusive_with_original_message() {
+        let e = expect_err(&[
+            "--model-dir",
+            "/tmp/m",
+            "--q4-dir",
+            "/tmp/q",
+            "--tokenizer-dir",
+            "/tmp/t",
+            "--corpus-file",
+            "/tmp/c.txt",
+        ]);
+        assert_eq!(
+            e, "--model-dir is mutually exclusive with --q4-dir / --quarot-q4-dir",
+            "pre-existing rule's message must be byte-for-byte unchanged"
+        );
+    }
+
+    #[test]
+    fn q4_dir_without_tokenizer_dir_still_rejected_with_original_message() {
+        let e = expect_err(&["--q4-dir", "/tmp/q", "--corpus-file", "/tmp/c.txt"]);
+        assert_eq!(
+            e, "--tokenizer-dir is required when using --q4-dir or --quarot-q4-dir",
+            "pre-existing rule's message must be byte-for-byte unchanged"
+        );
+    }
+
+    #[test]
+    fn no_mode_flag_still_rejected() {
+        let e = expect_err(&["--corpus-file", "/tmp/c.txt"]);
+        assert!(
+            e.contains("--metal-model-dir"),
+            "the 'one of ...' message must enumerate the new mode too: {e:?}"
+        );
+        assert!(
+            e.contains("--model-dir") && e.contains("--q4-dir") && e.contains("--quarot-q4-dir")
+        );
+    }
+
+    #[test]
+    fn random_lora_rank_without_any_metal_mode_still_rejected() {
+        let e = expect_err(&[
+            "--model-dir",
+            "/tmp/m",
+            "--corpus-file",
+            "/tmp/c.txt",
+            "--random-lora-rank",
+            "4",
+        ]);
+        assert!(
+            e.contains("--random-lora-rank"),
+            "message must still name the offending flag: {e:?}"
+        );
+        assert!(
+            e.contains("--metal-model-dir"),
+            "message must be widened to mention the new Metal mode: {e:?}"
+        );
+    }
+
+    // -- new rules: rejected, message names the actual conflict -----------
+
+    #[test]
+    fn metal_model_dir_and_model_dir_are_mutually_exclusive() {
+        let e = expect_err(&[
+            "--metal-model-dir",
+            "/tmp/m",
+            "--model-dir",
+            "/tmp/m2",
+            "--corpus-file",
+            "/tmp/c.txt",
+        ]);
+        assert_eq!(
+            e,
+            "--model-dir is mutually exclusive with --metal-model-dir"
+        );
+    }
+
+    #[test]
+    fn metal_model_dir_and_q4_dir_are_mutually_exclusive() {
+        let e = expect_err(&[
+            "--metal-model-dir",
+            "/tmp/m",
+            "--q4-dir",
+            "/tmp/q",
+            "--tokenizer-dir",
+            "/tmp/t",
+            "--corpus-file",
+            "/tmp/c.txt",
+        ]);
+        assert_eq!(
+            e,
+            "--metal-model-dir is mutually exclusive with --q4-dir / --quarot-q4-dir"
+        );
+    }
+
+    #[test]
+    fn metal_model_dir_and_quarot_q4_dir_are_mutually_exclusive() {
+        let e = expect_err(&[
+            "--metal-model-dir",
+            "/tmp/m",
+            "--quarot-q4-dir",
+            "/tmp/q",
+            "--tokenizer-dir",
+            "/tmp/t",
+            "--corpus-file",
+            "/tmp/c.txt",
+        ]);
+        assert_eq!(
+            e,
+            "--metal-model-dir is mutually exclusive with --q4-dir / --quarot-q4-dir"
+        );
+    }
+
+    #[test]
+    fn metal_model_dir_max_cache_len_below_window_is_rejected() {
+        let e = expect_err(&[
+            "--metal-model-dir",
+            "/tmp/m",
+            "--corpus-file",
+            "/tmp/c.txt",
+            "--window",
+            "1024",
+            "--max-cache-len",
+            "512",
+        ]);
+        assert!(
+            e.contains("--max-cache-len") && e.contains("--window"),
+            "message must name the actual conflict: {e:?}"
+        );
     }
 }


### PR DESCRIPTION
Adds a fourth measurement mode to `eval_perplexity`: `--metal-model-dir <PATH>`, which runs the
Metal GPU forward on a BF16/F16/F32 safetensors checkpoint via `MetalQwen35State::new`.

Closes #1327.

## Why

The tool evaluated three configurations: the CPU forward on safetensors (`--model-dir`), and the
Metal Q4 forward on quantized directories (`--q4-dir`, `--quarot-q4-dir`). The Metal BF16 forward
is a configuration we serve, and it had no perplexity mode. Numerical drift specific to those
kernels (f16 accumulation, kernel-specific rounding) was therefore invisible to the eval tool,
because the only available approximation was the CPU path, which does not execute them.

## Reuse

No second perplexity loop was written. `MetalQwen35State::compute_perplexity` is already
loading-path-agnostic: it drives the shared `run_strided_perplexity` window walk with
`compute_token_nlls` as the per-window kernel, and does not depend on which constructor built the
state. The change widens the seam rather than duplicating the loop — the LoRA-attach, perplexity,
report and JSON-emit tail that used to live inline in `run_metal_q4` is now
`run_on_metal_state(&mut MetalQwen35State, ...)`, and both the Q4 path and the new safetensors
path construct their state and delegate to it.

Argument parsing and mode validation moved out of `main` into a pure `parse_args` returning
`Result<ArgsOutcome, String>`. That was required to make the validation rules testable at all;
previously they were reachable only by invoking `main()` against the real process argv.

## Two interface questions, answered from the code

`--metal-model-dir` does **not** require `--tokenizer-dir`. `Qwen35Model::from_safetensors` loads
`tokenizer.json` from the weights directory, which a full safetensors checkpoint always ships and
a quantizer output directory does not, which is why `--tokenizer-dir` exists for the Q4 modes.
The rule requiring it stays scoped to the Q4 flags, deliberately unwidened.

`--random-lora-rank` **is** valid with the new mode. `generate_random_lora_layers` needs only a
`&Qwen35Config`, and `load_lora_adapter` is an inherent method on `MetalQwen35State` with nothing
Q4-specific on the path. Its rule widened accordingly and its error message now names all three
Metal flags.

## Validation rules

Seven rules after the change, from five before. Two are new mutual-exclusion rules for the new
mode, three widened their condition from "Q4 modes" to "any Metal mode", and two are unchanged
byte-for-byte, including the tokenizer-dir rule above. The max-cache-len rule was widened because
`MetalQwen35State::new` takes `max_cache_len` exactly as `from_q4_dir` does; leaving it narrow
would have let an undersized cache reach construction instead of failing at the CLI.

12 new tests cover the new mode's parsing and every new and pre-existing rejection, with the two
unchanged messages asserted byte-for-byte.

## Mutation arm

Inverting the new `--model-dir` / `--metal-model-dir` mutual-exclusion condition reddened two
tests where one was predicted. The second failure is a real consequence of the same inversion: a
test supplying `--model-dir` with `--random-lora-rank` now trips the mutated rule before reaching
the rule it was asserting, so its message check fails. The unaffected rule stayed green, bounding
the blast radius to the two paths that route through that condition. Restored, 14 green.

## Verification

`cargo build`, `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` all clean under
both default features and `f16,metal-gpu`. `cargo test -p lattice-inference --bin eval_perplexity
--features f16,metal-gpu`: 14 passed, 0 failed. Full default-feature suite: 2506 passed, 0 failed.

The full crate suite under `f16,metal-gpu` was **not** run. It blocks on the machine-wide Metal
GPU test lock, which concurrent runs on the same host were holding. `cargo clippy --all-targets`
under that feature set compiles every one of those tests, and this binary's own tests executed
under it, but the Metal-hardware integration tests were not executed and no result is claimed for
them.

The new mode is not exercisable without a checkpoint, the same as the CPU and Q4 modes. No
perplexity evaluation was run.

## bench-compare disposition

Structural waiver, no A/B table.

Population searched: all 24 bench targets declared in `crates/inference/Cargo.toml`, including
those behind `required-features` (`f16`, `bench-internals`, `metal-gpu`). None reaches the changed
code, and none can: the diff is confined to `crates/inference/src/bin/eval_perplexity.rs`, a
`[[bin]]` target. Cargo compiles benches as separate crates that link the library, so no bench can
reach a binary target's source at all, whatever its feature set.

Build inputs are identical between base and head: no manifest, dependency, lockfile, feature,
profile, build-script, generated-source, bench-target-definition or harness change is in this diff.

Residual risk stated plainly: this change is unmeasured, not measured-safe. If the extracted
`run_on_metal_state` helper changed the cost of the Q4 path it drives, no bench in this repository
would show it, because the perplexity binary has no bench coverage.
