### PR TITLE
fix(serve): restore three vision error-taxonomy distinctions and make a vision-weight load failure retryable

### DIFF
--- a/crates/inference/src/serve/contract.rs
+++ b/crates/inference/src/serve/contract.rs
@@ -529,7 +529,9 @@ fn normalize_request_inner<C>(
             .as_ref()
             .is_some_and(|format| format.r#type == "json_schema")
     {
-        unsupported("json_schema response format is not supported for image requests")?;
+        image_unsupported_combination(
+            "json_schema response format is not supported for image requests",
+        )?;
     }
     // Resolved ahead of `check_context` (rather than in its pre-refactor spot
     // after `check_context`/`stop`) so the shared full-window formula
@@ -550,7 +552,7 @@ fn normalize_request_inner<C>(
             .filter(|&value| value > 0);
     }
     if has_image && reasoning_budget.is_some() {
-        unsupported("reasoning_budget is not supported for image requests")?;
+        image_unsupported_combination("reasoning_budget is not supported for image requests")?;
     }
 
     let context = check_context(&messages, max_tokens, reasoning_budget)?;
@@ -822,6 +824,20 @@ fn unsupported(message: impl Into<String>) -> Result<(), ApiError> {
     Err(ApiError::BadRequest {
         message: message.into(),
         code: "unsupported_feature",
+    })
+}
+
+/// Rejects an image combined with a specific incompatible request feature
+/// (`response_format.json_schema`, a nonzero `reasoning_budget`) with a
+/// stable, distinct code from the generic [`unsupported`] path, so a client
+/// can branch on "this combination is unsupported" without string-matching
+/// the message. Runs from [`normalize_request_inner`], ahead of worker
+/// dispatch on both server binaries -- a request that cannot be served never
+/// reaches the shared Metal worker.
+fn image_unsupported_combination(message: impl Into<String>) -> Result<(), ApiError> {
+    Err(ApiError::BadRequest {
+        message: message.into(),
+        code: "image_unsupported_combination",
     })
 }
 
@@ -1376,35 +1392,44 @@ mod tests {
             "unsupported_feature"
         );
 
+        // Pinned to the exact `BadRequest` variant (not just `.code()`), since
+        // that variant is what `ApiError`'s `IntoResponse` impl maps to HTTP
+        // 400 (`serve/mod.rs`, exercised there and in each binary's own
+        // envelope tests) -- this is the proof that `image_unsupported_combination`
+        // is a 400, not merely that some error carries that code string.
         let mut req = inline_image_request("user", &uri);
         req.reasoning_budget =
             Some(serde_json::value::RawValue::from_string("4".to_string()).unwrap());
-        assert_eq!(
+        assert!(matches!(
             normalize_request(
                 &req,
                 defaults(),
                 ServeProfile::lattice_serve("model", 32).with_vision_support(true),
             )
-            .unwrap_err()
-            .code(),
-            "unsupported_feature"
-        );
+            .unwrap_err(),
+            ApiError::BadRequest {
+                code: "image_unsupported_combination",
+                ..
+            }
+        ));
 
         let mut req = inline_image_request("user", &uri);
         req.response_format = Some(ResponseFormat {
             r#type: "json_schema".to_string(),
             json_schema: None,
         });
-        assert_eq!(
+        assert!(matches!(
             normalize_request(
                 &req,
                 defaults(),
                 ServeProfile::lattice_serve("model", 32).with_vision_support(true),
             )
-            .unwrap_err()
-            .code(),
-            "unsupported_feature"
-        );
+            .unwrap_err(),
+            ApiError::BadRequest {
+                code: "image_unsupported_combination",
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/inference/src/serve/metal_worker.rs
+++ b/crates/inference/src/serve/metal_worker.rs
@@ -60,6 +60,7 @@ use crate::model::qwen35_config::{
 use crate::serve::ApiError;
 use crate::tokenizer::Tokenizer as _;
 use crate::tokenizer::bpe::BpeTokenizer;
+use crate::vision::VisionError;
 use crate::vision::checkpoint::{
     Qwen35VisionWeights, load_qwen35_vision_weights_with_cancel,
     validate_qwen35_vision_weight_inventory,
@@ -637,7 +638,6 @@ enum VisionState {
         config: VisionModelConfig,
     },
     Loaded(Qwen35VisionWeights),
-    Failed(String),
 }
 
 #[derive(Debug)]
@@ -716,6 +716,14 @@ impl VisionRuntime {
         self.vision_supported.clone()
     }
 
+    /// Attempt the lazy vision-weight load, retrying on every call while it
+    /// keeps failing: a failed attempt leaves `self.state` at `Pending`
+    /// rather than caching a permanent failure, and leaves
+    /// `vision_supported` untouched (still advertised), so the next
+    /// admitted image request tries the load again instead of being
+    /// rejected forever from one transient failure. There is no
+    /// permanent-failure policy elsewhere in the runtime for this codebase
+    /// to honor instead.
     fn get_or_load(
         &mut self,
         should_cancel: &mut dyn FnMut() -> bool,
@@ -726,18 +734,12 @@ impl VisionRuntime {
             match load_qwen35_vision_weights_with_cancel(&model_dir, &config, should_cancel) {
                 Ok(Some(weights)) => self.state = VisionState::Loaded(weights),
                 Ok(None) => return Ok(VisionRuntimeLoad::Cancelled),
-                Err(err) => {
-                    let message = format!("vision weights failed to load: {err}");
-                    self.state = VisionState::Failed(message.clone());
-                    self.vision_supported.store(false, Ordering::Release);
-                    return Err(message);
-                }
+                Err(err) => return Err(format!("vision weights failed to load: {err}")),
             }
         }
         match &self.state {
             VisionState::Unsupported => Ok(VisionRuntimeLoad::Unsupported),
             VisionState::Loaded(weights) => Ok(VisionRuntimeLoad::Ready(weights)),
-            VisionState::Failed(message) => Err(message.clone()),
             VisionState::Pending { .. } => {
                 self.vision_supported.store(false, Ordering::Release);
                 Err("vision weights remained pending after a load attempt".to_string())
@@ -825,6 +827,7 @@ fn build_vision_prompt_ids(
     Ok(ids)
 }
 
+#[derive(Debug)]
 enum VisionRequestBuild {
     Ready {
         request: Qwen35VisionRequest,
@@ -868,9 +871,18 @@ fn build_vision_request(
 
     let (pixel_values, grid) = preprocess_qwen35_image_for_serve(&image.bytes, vision_config)
         .map_err(|err| {
+            // `DimensionsExceeded` is a well-formed image that is simply
+            // larger than this server will process (a client can resize and
+            // retry); every other `VisionError` here means the bytes
+            // themselves are not a decodable image, which stays on the
+            // generic `invalid_image` code.
+            let code = match &err {
+                VisionError::DimensionsExceeded(_) => "image_dimensions_exceeded",
+                _ => "invalid_image",
+            };
             WorkerFailure::Rejected(ApiError::BadRequest {
                 message: format!("image preprocessing failed: {err}"),
-                code: "invalid_image",
+                code,
             })
         })?;
     if should_cancel() {
@@ -905,10 +917,19 @@ fn build_vision_request(
         return Ok(VisionRequestBuild::Cancelled);
     }
 
-    let weights = match runtime
-        .get_or_load(should_cancel)
-        .map_err(WorkerFailure::Failed)?
-    {
+    let weights = match runtime.get_or_load(should_cancel).map_err(|detail| {
+        // `detail` (from `load_qwen35_vision_weights_with_cancel`) routinely
+        // names the checkpoint directory (e.g. a missing-manifest message
+        // naming `model_dir`); log the full detail server-side only and
+        // send the client a fixed, path-free message. The load is
+        // retryable (see `VisionRuntime::get_or_load`), so this is a client
+        // rejection (400), not a permanent server failure (500).
+        eprintln!("[metal-worker] {detail}");
+        WorkerFailure::Rejected(ApiError::BadRequest {
+            message: "vision weights failed to load; the request can be retried".to_string(),
+            code: "vision_load_failed",
+        })
+    })? {
         VisionRuntimeLoad::Ready(weights) => weights,
         VisionRuntimeLoad::Unsupported => {
             return Err(WorkerFailure::Rejected(ApiError::BadRequest {
@@ -1686,6 +1707,180 @@ mod tests {
         assert!(window_checked);
     }
 
+    /// The 21 `model.visual.*` tensor names `tiny_vision_config` (depth 1)
+    /// expects, matching `checkpoint.rs`'s `tensor_names` for the same
+    /// config shape.
+    fn tiny_vision_manifest_names() -> Vec<String> {
+        let mut names = vec![
+            "model.visual.patch_embed.proj.weight".to_string(),
+            "model.visual.patch_embed.proj.bias".to_string(),
+            "model.visual.pos_embed.weight".to_string(),
+            "model.visual.merger.linear_fc1.weight".to_string(),
+            "model.visual.merger.linear_fc1.bias".to_string(),
+            "model.visual.merger.linear_fc2.weight".to_string(),
+            "model.visual.merger.linear_fc2.bias".to_string(),
+            "model.visual.merger.norm.weight".to_string(),
+            "model.visual.merger.norm.bias".to_string(),
+        ];
+        for suffix in [
+            "attn.qkv.weight",
+            "attn.qkv.bias",
+            "attn.proj.weight",
+            "attn.proj.bias",
+            "mlp.linear_fc1.weight",
+            "mlp.linear_fc1.bias",
+            "mlp.linear_fc2.weight",
+            "mlp.linear_fc2.bias",
+            "norm1.weight",
+            "norm1.bias",
+            "norm2.weight",
+            "norm2.bias",
+        ] {
+            names.push(format!("model.visual.blocks.0.{suffix}"));
+        }
+        names
+    }
+
+    #[test]
+    fn vision_request_build_rejects_oversized_image_with_dimensions_exceeded_code() {
+        use axum::response::IntoResponse as _;
+
+        let mut runtime = VisionRuntime::unsupported();
+        let config = vision_build_config();
+        // A thin (1px tall) image keeps the fixture tiny while still
+        // tripping the serving-side hard pixel-dimension cap on width
+        // alone -- deterministic regardless of any `LATTICE_VISION_MAX_PATCHES`
+        // override in the test process's environment, unlike the
+        // patch-count budget.
+        let messages = vec![ChatMessage::user_with_image(
+            "beforeafter",
+            make_test_png(2049, 1),
+            "before".len(),
+        )];
+        let err = build_vision_request(
+            &mut runtime,
+            &config,
+            &tiny_tokenizer(),
+            &messages,
+            0,
+            &mut || false,
+            |_| Ok(()),
+        )
+        .expect_err("an oversized image must be rejected before any worker dispatch");
+        match err {
+            WorkerFailure::Rejected(api_err) => {
+                assert_eq!(api_err.code(), "image_dimensions_exceeded");
+                assert_eq!(
+                    api_err.into_response().status(),
+                    axum::http::StatusCode::BAD_REQUEST
+                );
+            }
+            other => panic!("expected Rejected(image_dimensions_exceeded), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vision_request_build_rejects_malformed_image_bytes_with_invalid_image_code() {
+        // Control: genuinely undecodable bytes must stay on the generic
+        // `invalid_image` code, not the new `image_dimensions_exceeded`
+        // code -- the split is scoped to well-formed-but-too-large images.
+        use axum::response::IntoResponse as _;
+
+        let mut runtime = VisionRuntime::unsupported();
+        let config = vision_build_config();
+        let messages = vec![ChatMessage::user_with_image(
+            "beforeafter",
+            b"not an image".to_vec(),
+            "before".len(),
+        )];
+        let err = build_vision_request(
+            &mut runtime,
+            &config,
+            &tiny_tokenizer(),
+            &messages,
+            0,
+            &mut || false,
+            |_| Ok(()),
+        )
+        .expect_err("malformed image bytes must be rejected");
+        match err {
+            WorkerFailure::Rejected(api_err) => {
+                assert_eq!(api_err.code(), "invalid_image");
+                assert_eq!(
+                    api_err.into_response().status(),
+                    axum::http::StatusCode::BAD_REQUEST
+                );
+            }
+            other => panic!("expected Rejected(invalid_image), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn vision_request_build_maps_a_lazy_load_failure_to_a_retryable_client_rejection() {
+        use axum::response::IntoResponse as _;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        // Every manifest entry points at the same file, and that file is
+        // not a valid tensor payload -- the capability preflight
+        // (`validate_qwen35_vision_weight_inventory`) only checks that
+        // every expected name occurs once and its file opens, so this
+        // still advertises vision support; the actual lazy load fails
+        // once a real image request triggers it.
+        std::fs::write(temp.path().join("visual.bin"), b"not a valid tensor file")
+            .expect("weight-source marker");
+        let config = vision_build_config();
+        let entries: Vec<_> = tiny_vision_manifest_names()
+            .iter()
+            .map(|name| serde_json::json!({"name": name, "file": "visual.bin"}))
+            .collect();
+        std::fs::write(
+            temp.path().join("quantize_index.json"),
+            serde_json::to_vec(&entries).expect("manifest fixture"),
+        )
+        .expect("test setup: write manifest");
+        let mut runtime = VisionRuntime::from_model_config(temp.path().to_path_buf(), &config);
+        assert!(
+            runtime.is_supported(),
+            "test setup: capability preflight must pass so the request reaches the lazy load"
+        );
+
+        let messages = vec![ChatMessage::user_with_image(
+            "beforeafter",
+            make_test_png(8, 8),
+            "before".len(),
+        )];
+        let err = build_vision_request(
+            &mut runtime,
+            &config,
+            &tiny_tokenizer(),
+            &messages,
+            0,
+            &mut || false,
+            |_| Ok(()),
+        )
+        .expect_err("a corrupt checkpoint must fail the lazy load");
+        match err {
+            WorkerFailure::Rejected(api_err) => {
+                assert_eq!(api_err.code(), "vision_load_failed");
+                let temp_path = temp.path().to_string_lossy().into_owned();
+                assert!(
+                    !api_err.message().contains(&temp_path),
+                    "client-visible message must not leak the checkpoint path: {}",
+                    api_err.message()
+                );
+                assert_eq!(
+                    api_err.into_response().status(),
+                    axum::http::StatusCode::BAD_REQUEST
+                );
+            }
+            other => panic!("expected Rejected(vision_load_failed), got {other:?}"),
+        }
+        assert!(
+            runtime.is_supported(),
+            "a lazy-load failure must stay retryable, not revoke capability permanently"
+        );
+    }
+
     #[test]
     fn vision_runtime_capability_requires_config_token_metadata_and_weight_source() {
         let temp = tempfile::tempdir().expect("tempdir");
@@ -1779,17 +1974,98 @@ mod tests {
             .get_or_load(&mut never_cancel)
             .expect_err("junk tensor payload must fail its first lazy load");
         assert!(first_error.contains("vision weights failed to load"));
-        assert!(!runtime.is_supported());
         assert!(
-            !client.supports_vision(),
-            "terminal lazy-load failure must revoke the shared client capability"
+            runtime.is_supported(),
+            "a lazy-load failure must stay retryable, not revoke capability permanently"
         );
-        std::fs::remove_file(temp.path().join("visual.bin"))
-            .expect("remove source after the first attempt");
-        let second_error = runtime
-            .get_or_load(&mut never_cancel)
-            .expect_err("terminal failure must be returned, not retried");
-        assert_eq!(second_error, first_error);
+        assert!(
+            client.supports_vision(),
+            "a lazy-load failure must not revoke the shared client capability -- the \
+             caller can retry"
+        );
+
+        // Fix the checkpoint in place: write a genuinely valid q4 tensor for
+        // every `model.visual.*` name `config`'s tiny vision config expects,
+        // then retry. Reaching `VisionRuntimeLoad::Ready` (not another
+        // error) is the proof the second call actually attempted the load
+        // again rather than replaying a cached failure.
+        let hidden = 8usize;
+        let qkv_out = 3 * hidden;
+        let mlp_intermediate = 4 * hidden;
+        let merge_in = 2 * 2 * hidden;
+        let out_hidden = config.hidden_size;
+        let mut valid_shapes: Vec<(String, Vec<usize>)> = vec![
+            (
+                "model.visual.patch_embed.proj.weight".to_string(),
+                vec![hidden, 3, 1, 2, 2],
+            ),
+            (
+                "model.visual.patch_embed.proj.bias".to_string(),
+                vec![hidden],
+            ),
+            (
+                "model.visual.pos_embed.weight".to_string(),
+                vec![16, hidden],
+            ),
+            (
+                "model.visual.merger.linear_fc1.weight".to_string(),
+                vec![merge_in, merge_in],
+            ),
+            (
+                "model.visual.merger.linear_fc1.bias".to_string(),
+                vec![merge_in],
+            ),
+            (
+                "model.visual.merger.linear_fc2.weight".to_string(),
+                vec![out_hidden, merge_in],
+            ),
+            (
+                "model.visual.merger.linear_fc2.bias".to_string(),
+                vec![out_hidden],
+            ),
+            ("model.visual.merger.norm.weight".to_string(), vec![hidden]),
+            ("model.visual.merger.norm.bias".to_string(), vec![hidden]),
+        ];
+        for (suffix, shape) in [
+            ("attn.qkv.weight", vec![qkv_out, hidden]),
+            ("attn.qkv.bias", vec![qkv_out]),
+            ("attn.proj.weight", vec![hidden, hidden]),
+            ("attn.proj.bias", vec![hidden]),
+            ("mlp.linear_fc1.weight", vec![mlp_intermediate, hidden]),
+            ("mlp.linear_fc1.bias", vec![mlp_intermediate]),
+            ("mlp.linear_fc2.weight", vec![hidden, mlp_intermediate]),
+            ("mlp.linear_fc2.bias", vec![hidden]),
+            ("norm1.weight", vec![hidden]),
+            ("norm1.bias", vec![hidden]),
+            ("norm2.weight", vec![hidden]),
+            ("norm2.bias", vec![hidden]),
+        ] {
+            valid_shapes.push((format!("model.visual.blocks.0.{suffix}"), shape));
+        }
+        let mut manifest_entries = Vec::new();
+        for (i, (name, shape)) in valid_shapes.iter().enumerate() {
+            let numel: usize = shape.iter().product();
+            let q4 = crate::weights::q4_weights::quantize_f64_to_q4(&vec![0.25_f64; numel], shape)
+                .expect("quantize succeeds");
+            let file_name = format!("retry{i}.q4");
+            crate::weights::q4_weights::save_q4_file(&temp.path().join(&file_name), &q4)
+                .expect("test setup: write valid q4 file");
+            manifest_entries.push(format!(
+                r#"{{"name":"{name}","file":"{file_name}","quantized":true}}"#
+            ));
+        }
+        std::fs::write(
+            temp.path().join("quantize_index.json"),
+            format!("[{}]", manifest_entries.join(",")),
+        )
+        .expect("test setup: overwrite manifest with a valid checkpoint");
+
+        let retried = runtime.get_or_load(&mut never_cancel).expect(
+            "a fixed checkpoint must load successfully on retry, not replay the cached failure",
+        );
+        assert!(matches!(retried, VisionRuntimeLoad::Ready(_)));
+        assert!(runtime.is_supported());
+        assert!(client.supports_vision());
         assert!(
             !VisionRuntime::from_model_config(PathBuf::from("/unused"), &config).is_supported(),
             "config metadata alone must not advertise vision without a supported weight source"

--- a/crates/inference/src/vision/mod.rs
+++ b/crates/inference/src/vision/mod.rs
@@ -107,6 +107,14 @@ pub enum VisionError {
     },
     /// A configuration value is invalid (zero dimension, indivisible sizes, etc.).
     InvalidConfig(String),
+    /// The decoded image's declared pixel dimensions, pre-merge patch grid,
+    /// or resulting preprocessed buffer exceed a serving-side budget --
+    /// distinct from [`Self::ImageDecode`] (the image itself is well-formed,
+    /// just larger than this server will process) and from
+    /// [`Self::InvalidConfig`] (a checkpoint/config problem, not a
+    /// per-request one). Callers map this to a client-safe, retriable
+    /// rejection rather than the generic image-decode error.
+    DimensionsExceeded(String),
     /// I/O error during weight loading.
     Io(std::io::Error),
 }
@@ -124,6 +132,7 @@ impl std::fmt::Display for VisionError {
                 "Vision shape mismatch ({context}): expected {expected}, got {actual}"
             ),
             Self::InvalidConfig(msg) => write!(f, "Vision invalid config: {msg}"),
+            Self::DimensionsExceeded(msg) => write!(f, "Vision dimensions exceeded: {msg}"),
             Self::Io(e) => write!(f, "Vision I/O error: {e}"),
         }
     }

--- a/crates/inference/src/vision/mod.rs
+++ b/crates/inference/src/vision/mod.rs
@@ -95,7 +95,13 @@ use preprocess::PreprocessConfig;
 use vit::{ViT, VisionWeights};
 
 /// Errors produced by the vision encoder pipeline.
+///
+/// Marked `#[non_exhaustive]` so that distinguishing a new failure mode is a
+/// minor change rather than a major one. Adding `DimensionsExceeded` was a
+/// breaking change only because this enum was exhaustive; that cost is paid
+/// once here.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum VisionError {
     /// Raw image bytes could not be decoded (unsupported format, corrupt data).
     ImageDecode(String),

--- a/crates/inference/src/vision/qwen35_vit.rs
+++ b/crates/inference/src/vision/qwen35_vit.rs
@@ -105,6 +105,15 @@ pub fn preprocess_qwen35_image(
 /// grids above 256 pre-merge patches, and caps the preprocessed f32 patch
 /// buffer at 16 MiB, before decoding pixel data. The public embedding entry
 /// point above keeps its existing, checkpoint-defined scope.
+///
+/// # Errors
+///
+/// [`VisionError::DimensionsExceeded`] if the declared pixel dimensions,
+/// pre-merge patch grid, or preprocessed buffer size exceed the serving
+/// budgets above. [`VisionError::ImageDecode`] if the bytes are genuinely
+/// malformed (unrecognized format, corrupt data). [`VisionError::InvalidConfig`]
+/// if the decoded image's dimensions are not exact multiples of
+/// `patch_size * spatial_merge_size` (see [`preprocess_qwen35_image`]).
 pub fn preprocess_qwen35_image_for_serve(
     image_bytes: &[u8],
     cfg: &VisionModelConfig,
@@ -133,9 +142,21 @@ fn preprocess_qwen35_image_inner(
             .with_guessed_format()
             .map_err(|e| VisionError::ImageDecode(format!("format detection failed: {e}")))?;
         header_reader.limits(limits.clone());
-        let (header_width, header_height) = header_reader
-            .into_dimensions()
-            .map_err(|e| VisionError::ImageDecode(format!("dimension read failed: {e}")))?;
+        let (header_width, header_height) = header_reader.into_dimensions().map_err(|e| {
+            // `image::Limits::check_dimensions` reports an over-budget
+            // declared size as `ImageError::Limits`, distinct from every
+            // other reason header parsing can fail (corrupt/truncated
+            // header, unrecognized format) -- only the former is a
+            // dimension-budget rejection rather than a malformed image.
+            if matches!(e, image::ImageError::Limits(_)) {
+                VisionError::DimensionsExceeded(format!(
+                    "image dimensions exceed the serving maximum of \
+                     {MAX_IMAGE_DIMENSION_PIXELS}px per side: {e}"
+                ))
+            } else {
+                VisionError::ImageDecode(format!("dimension read failed: {e}"))
+            }
+        })?;
         let patches = (header_width as usize)
             .div_ceil(cfg.patch_size)
             .checked_mul((header_height as usize).div_ceil(cfg.patch_size))
@@ -143,7 +164,7 @@ fn preprocess_qwen35_image_inner(
                 VisionError::InvalidConfig("serving image patch count overflowed".to_string())
             })?;
         if patches > max_patches {
-            return Err(VisionError::InvalidConfig(format!(
+            return Err(VisionError::DimensionsExceeded(format!(
                 "image {header_width}x{header_height} produces {patches} patches; serving \
                  maximum is {max_patches}"
             )));
@@ -156,7 +177,7 @@ fn preprocess_qwen35_image_inner(
                 )
             })?;
         if preprocessed_bytes > MAX_SERVE_PREPROCESSED_BYTES {
-            return Err(VisionError::InvalidConfig(format!(
+            return Err(VisionError::DimensionsExceeded(format!(
                 "serving image preprocessing requires {preprocessed_bytes} bytes; maximum is \
                  {MAX_SERVE_PREPROCESSED_BYTES}"
             )));
@@ -675,11 +696,25 @@ mod tests {
         let err =
             preprocess_qwen35_image_inner(&over, &cfg, Some(MAX_SERVE_VISION_PATCHES)).unwrap_err();
         assert!(
-            matches!(err, VisionError::InvalidConfig(message) if message.contains("serving maximum is 256"))
+            matches!(err, VisionError::DimensionsExceeded(message) if message.contains("serving maximum is 256"))
         );
         assert!(
             preprocess_qwen35_image(&over, &cfg).is_ok(),
             "the serving-only latency budget must not narrow the embedding API"
+        );
+    }
+
+    #[test]
+    fn serving_preprocess_rejects_declared_pixel_dimensions_over_the_hard_cap() {
+        // A thin (1px tall) image keeps the PNG fixture tiny while still
+        // tripping `image::Limits::check_dimensions` on width alone, before
+        // any pixel data is decoded.
+        let cfg = tiny_cfg();
+        let over_width = make_test_png(MAX_IMAGE_DIMENSION_PIXELS + 1, 1);
+        let err = preprocess_qwen35_image_for_serve(&over_width, &cfg).unwrap_err();
+        assert!(
+            matches!(&err, VisionError::DimensionsExceeded(message) if message.contains("2048px")),
+            "expected DimensionsExceeded naming the 2048px cap, got: {err}"
         );
     }
 
@@ -717,7 +752,7 @@ mod tests {
         assert!(preprocess_qwen35_image_inner(&boundary, &cfg, Some(256)).is_ok());
         let err = preprocess_qwen35_image_inner(&boundary, &cfg, Some(200)).unwrap_err();
         assert!(
-            matches!(err, VisionError::InvalidConfig(message) if message.contains("serving maximum is 200"))
+            matches!(err, VisionError::DimensionsExceeded(message) if message.contains("serving maximum is 200"))
         );
     }
 
@@ -730,7 +765,7 @@ mod tests {
         let image = make_test_png(128, 128);
         let err = preprocess_qwen35_image_for_serve(&image, &cfg).unwrap_err();
         assert!(
-            matches!(err, VisionError::InvalidConfig(message) if message.contains("preprocessing requires"))
+            matches!(err, VisionError::DimensionsExceeded(message) if message.contains("preprocessing requires"))
         );
     }
 

--- a/docs/serve-http-api.md
+++ b/docs/serve-http-api.md
@@ -213,13 +213,20 @@ use `{"type": "text", "text": "..."}`. A vision-capable Metal checkpoint also ac
 `{"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}` part on a user
 message; JPEG uses `data:image/jpeg;base64,...`. The image may appear between text parts and keeps
 that position in the rendered multimodal prompt. The decoded payload is capped at 48,000 bytes,
-and each serving image is capped at 256 pre-merge patches (overridable via the
-`LATTICE_VISION_MAX_PATCHES` environment variable, which falls back to 256 for any unset, empty,
-malformed, zero, or negative value) and 16 MiB of preprocessed patch data.
+the declared pixel dimensions are capped at 2048px per side, and each serving image is capped at
+256 pre-merge patches (overridable via the `LATTICE_VISION_MAX_PATCHES` environment variable,
+which falls back to 256 for any unset, empty, malformed, zero, or negative value) and 16 MiB of
+preprocessed patch data — an image over any of those three budgets is rejected with 400
+`image_dimensions_exceeded` rather than the generic `invalid_image` (which stays reserved for a
+payload that genuinely isn't a decodable PNG or JPEG).
 Image requests must use `stream: false` (or omit `stream`) until the multimodal decoder supports
 incremental deltas. Remote URLs are never fetched, multi-image requests are rejected, and a
-text-only/CPU model returns 400 `vision_unsupported`. Audio/file parts remain unsupported rather
-than being silently dropped.
+text-only/CPU model returns 400 `vision_unsupported`. An image combined with
+`response_format.json_schema` or a nonzero `reasoning_budget` is rejected with 400
+`image_unsupported_combination` before the request reaches the shared Metal worker. A transient
+failure loading the vision checkpoint's weights returns 400 `vision_load_failed`; the load is
+retried on the next image request rather than failing every subsequent request for the life of the
+process. Audio/file parts remain unsupported rather than being silently dropped.
 
 `messages[].role` must be `"system"`, `"user"`, or `"assistant"`; `"tool"` and `"developer"` are
 explicitly named and rejected (`"role 'tool' is not supported by this server"`); anything else


### PR DESCRIPTION
Restores three distinctions on the image-serving path that the current error taxonomy collapses,
and makes a vision-weight load failure retryable instead of permanently disabling image support
for the process.

Closes #1335.

All three changes land in the shared contract and worker path, so both server binaries pick them
up: `serve/contract.rs`'s `normalize_request_inner`, and the `MetalWorker` that both binaries
spawn and submit to. Neither binary carries its own copy of the vision error mapping.

## 1. A vision-weight load failure no longer poisons the process

`VisionRuntime::get_or_load` cached a load failure in `VisionState::Failed(message)` for the
lifetime of the process and permanently cleared the `vision_supported` flag both binaries read
when admitting image requests. One transient failure therefore rejected every subsequent image
request, and the failing request itself surfaced as a generic 500 `internal_error`.

`VisionState::Failed` is gone. On a load error `get_or_load` returns `Err(detail)` for that one
call and leaves the state `Pending` with `vision_supported` untouched, so the next admitted image
request retries the load. The call site maps it to a 400 `vision_load_failed` with a fixed,
path-free client message; the underlying detail, which routinely names the checkpoint directory,
is logged server-side only.

On whether a load failure should ever be permanent: a search for an existing permanent-failure
policy for this runtime found none, so none was invented. The lazy load is unconditionally
retryable.

## 2. `image_dimensions_exceeded` split out of `invalid_image`

Every failure out of `preprocess_qwen35_image_for_serve` was flattened into `invalid_image` — a
genuinely malformed payload and a request that merely exceeds a serving budget were
indistinguishable to a client deciding whether to resize and retry.

A new `VisionError::DimensionsExceeded` now covers the three serving budgets: the 2048px hard cap
per side, the pre-merge patch-count budget, and the preprocessed-byte budget. The hard-cap case is
distinguished from an unparsable header by matching `image::ImageError::Limits(_)` specifically,
which `into_dimensions()` returns only when the declared size exceeds the configured limits.

The "dimensions not a multiple of `patch_size * spatial_merge_size`" check deliberately stays
`InvalidConfig`. It is a structural resize-scope limitation shared with the non-serving embedding
path, not a serving budget.

## 3. `image_unsupported_combination` split out of `unsupported_feature`

An image combined with `response_format.json_schema` or a nonzero `reasoning_budget` reported the
generic `unsupported_feature`, the same code an unrelated unimplemented feature would produce.
Both checks already ran inside `normalize_request_inner`, ahead of worker submission in both
binaries, so only the code changed.

The pre-existing `image` + `stream` and `image` + `logprobs` checks keep `unsupported_feature`;
the issue names only the two above.

## Consumers

`ApiError::BadRequest`'s `IntoResponse` maps every `code` string to the same envelope and HTTP 400
with no per-code match, so a new code cannot land in an unhandled arm at the HTTP layer.
`serve/metrics.rs`'s `record_error` takes an arbitrary string. No client binding or JSON schema in
the repository enumerates these codes. `docs/serve-http-api.md` documents them in prose and is
updated to name all three new codes and which old code each one narrows. Existing test fixtures
that hard-coded the old code for a now-split case were updated rather than left beside the new
expectation.

`docs/releases/v0.8.0.md` records the original v0.8.0 code set as a historical release note and is
deliberately unchanged.

## Tests

Five, four new and one rewritten:

- an oversized image at the hard cap produces `DimensionsExceeded` naming 2048px, deterministically
  regardless of the patch-count environment override;
- the same image through the real `build_vision_request` produces `image_dimensions_exceeded` and
  status 400;
- a control arm: `b"not an image"` still produces `invalid_image` and 400;
- a checkpoint that passes the capability preflight but carries an undecodable tensor produces
  `vision_load_failed` and 400, with a positive assertion that the message does not contain the
  test's real temporary path, and `is_supported()` still true afterwards;
- the existing capability test, which previously asserted the permanent-failure behaviour, now
  asserts the failure stays retryable, repairs the checkpoint in place with genuinely valid q4
  tensors for all 21 expected vision weights, retries, and asserts the load reaches `Ready`.
  Reaching `Ready` rather than a second error is what proves the retry re-attempted the load
  instead of replaying a cached failure.

The path-leak assertion exists only where a leak was possible. The other two codes build their
messages from image and request field values and never touch a filesystem path, so an equivalent
check there would assert that a static literal contains no path, which reading the code already
settles.

## Verification

Scoped `lattice-inference` tests covering every module this diff touches: green.

The unscoped `--features metal-gpu` run was **not** completed and no result is claimed for it. The
host was running several concurrent `cargo test` and `cargo build` invocations across other
worktrees for the duration; one attempt exceeded 45 minutes and was killed. Its partial output
showed three failures, all in `forward::metal_qwen35::inner::tests` (MRoPE logit injection, f16 KV
Metal dispatch), a module this diff does not touch, consistent with real-GPU contention from the
concurrent processes. That was not chased down; it is outside an error-taxonomy change.

## bench-compare disposition

Structural waiver, no A/B table.

Population searched: all 24 bench targets declared in `crates/inference/Cargo.toml`, including
those gated behind `required-features` (`f16`, `bench-internals`, `metal-gpu`). None reaches the
changed code. The diff touches the HTTP request-normalization and vision-preprocessing error
paths — `serve/contract.rs`, `serve/metal_worker.rs`, `vision/mod.rs`, `vision/qwen35_vit.rs` —
and no declared bench group constructs a serve request or drives image preprocessing.

Build inputs are identical between base and head: no manifest, dependency, lockfile, feature,
profile, build-script, generated-source, bench-target-definition or harness change.

Residual risk: this change is unmeasured rather than measured-safe. The error paths it edits are
by construction the paths a successful request does not take, so the throughput risk is low, but
no bench in this repository would show it either way.
