### PR TITLE
chore(release)!: mark public enums non_exhaustive and bump to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,7 +1581,7 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lattice-embed"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "blake3",
@@ -1606,7 +1606,7 @@ dependencies = [
 
 [[package]]
 name = "lattice-fann"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "approx",
  "bytemuck",
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "lattice-inference"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "approx",
  "axum",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "lattice-transport"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "criterion",
  "proptest",
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "lattice-tune"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "arc-swap",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 # MSRV, verified end-to-end (workspace + deps) on 1.93.1 and guarded by the msrv CI
 # job (aarch64 macOS, f16,metal-gpu, --all-targets) so a newer-toolchain-only API

--- a/crates/embed/Cargo.toml
+++ b/crates/embed/Cargo.toml
@@ -53,7 +53,7 @@ tracing = "0.1"
 # its own ureq/download stack to non-wasm targets, so a plain `--features wasm`
 # build stays download-free; edge/cross builds drop it with
 # `--no-default-features --features native`. See issue #1095.
-lattice-inference = { version = "0.8.0", path = "../inference", optional = true, default-features = false, features = [
+lattice-inference = { version = "0.9.0", path = "../inference", optional = true, default-features = false, features = [
     "std",
     "f16",
 ] }

--- a/crates/embed/src/service/mod.rs
+++ b/crates/embed/src/service/mod.rs
@@ -55,6 +55,7 @@ pub const MAX_TEXT_CHARS: usize = MAX_TEXT_BYTES;
 /// Selects query, passage, or generic preparation and cache-key namespace.
 /// See [`docs/service.md`](../../docs/service.md#trait-api-details) for retrieval-role semantics.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum EmbeddingRole {
     /// Query / question text — may receive a query-side prompt prefix.
     Query,

--- a/crates/embed/src/simd/tier.rs
+++ b/crates/embed/src/simd/tier.rs
@@ -16,6 +16,7 @@ use crate::error::{EmbedError, Result};
 /// When both query and stored vectors carry `UnitNorm`, cosine similarity equals
 /// the dot product — the norm division can be skipped entirely.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum NormalizationHint {
     /// No guarantee — full cosine (with norm division) is required.
     Unknown,
@@ -27,6 +28,7 @@ pub enum NormalizationHint {
 ///
 /// Quantization precision tier, ordered from highest to lowest fidelity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
 pub enum QuantizationTier {
     /// Full f32 precision (4 bytes/dim, 1x baseline).
     Full,
@@ -90,6 +92,7 @@ impl QuantizationTier {
 /// Wraps the tier-specific vector types into a single enum for
 /// uniform storage and distance dispatch.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum QuantizedData {
     /// Full-precision f32 vector.
     Full(Vec<f32>),
@@ -166,6 +169,7 @@ impl QuantizedData {
 
 /// **Unstable**: pre-quantized query for repeated same-tier distance computation.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum PreparedQuery {
     /// Full f32 query.
     Full(Vec<f32>),

--- a/crates/fann/src/activation.rs
+++ b/crates/fann/src/activation.rs
@@ -9,6 +9,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum Activation {
     /// Linear activation (identity function): f(x) = x
     Linear,

--- a/crates/fann/src/error.rs
+++ b/crates/fann/src/error.rs
@@ -53,6 +53,7 @@ pub fn validate_layer_dimensions(num_inputs: usize, num_outputs: usize) -> FannR
 
 /// Errors that can occur in neural network operations
 #[derive(Error, Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum FannError {
     /// Input size does not match network's expected input size
     #[error("Input size mismatch: expected {expected}, got {actual}")]

--- a/crates/fann/src/gpu/buffer.rs
+++ b/crates/fann/src/gpu/buffer.rs
@@ -16,6 +16,7 @@ use wgpu::BufferUsages;
 
 /// Buffer size categories
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum BufferCategory {
     /// < 1MB - biases, small activations
     Small,

--- a/crates/fann/src/gpu/circuit_breaker.rs
+++ b/crates/fann/src/gpu/circuit_breaker.rs
@@ -11,6 +11,7 @@ use std::time::{Duration, Instant};
 
 /// Memory pressure levels
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum MemoryPressure {
     /// < 60% usage - normal operation
     None,

--- a/crates/fann/src/gpu/error.rs
+++ b/crates/fann/src/gpu/error.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 
 /// GPU operation errors
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum GpuError {
     /// GPU device not available
     #[error("GPU not available: {0}")]

--- a/crates/fann/src/gpu/shader_manager.rs
+++ b/crates/fann/src/gpu/shader_manager.rs
@@ -12,6 +12,7 @@ use wgpu::ComputePipeline;
 
 /// Types of shader operations
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum ShaderType {
     /// Matrix-vector multiplication (y = Wx + b)
     MatrixVectorMultiply,

--- a/crates/fann/src/training/gradient.rs
+++ b/crates/fann/src/training/gradient.rs
@@ -54,6 +54,7 @@ pub fn sanitize_gradients(grads: &mut [f32]) -> usize {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum GradientGuardStrategy {
     /// Return an error immediately when NaN/Inf detected
     #[default]

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -96,7 +96,7 @@ bytemuck = { version = "1", features = ["derive"], optional = true }
 ort = { version = "2.0.0-rc.12", optional = true }
 tokenizers = { version = "0.22", optional = true, default-features = false, features = ["progressbar", "onig"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
-lattice-fann = { version = "0.8.0", path = "../fann", optional = true }
+lattice-fann = { version = "0.9.0", path = "../fann", optional = true }
 
 # Two independent unix-only uses: (1) `fcntl(F_GETPATH)` for `weights/f32_weights.rs`'s
 # `real_path_of_open_file`, which reports the real path of an already-open shard descriptor

--- a/crates/inference/benches/attention_dispatch_bench.rs
+++ b/crates/inference/benches/attention_dispatch_bench.rs
@@ -29,6 +29,9 @@ fn dispatch_kind(kind: &AttentionKind) -> f32 {
         AttentionKind::Differential => 7.0f32,
         AttentionKind::NativeSparse => 8.0f32,
         AttentionKind::Decode => 9.0f32,
+        // Future variants aren't part of the measured dispatch set yet;
+        // any sentinel is fine since this bench only measures match cost.
+        _ => 10.0f32,
     }
 }
 

--- a/crates/inference/src/attention/mod.rs
+++ b/crates/inference/src/attention/mod.rs
@@ -22,6 +22,7 @@ pub use self::standard::*;
 /// `CalibrationObserver`) use instead of the lossy string `name()`. Tag values
 /// are stable; variant names here match ADR-059's `AttentionTag` identifiers.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum AttentionTag {
     Mha,
     Gqa,
@@ -55,6 +56,7 @@ pub enum AttentionTag {
 /// in subsequent phases (P2+). The enum is intentionally dead from a call-site
 /// perspective in P1; see ADR-059 §Implementation Phases.
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum AttentionKind {
     /// Standard multi-head attention (BERT-style bidirectional encoder).
     ///

--- a/crates/inference/src/bin/chat_metal.rs
+++ b/crates/inference/src/bin/chat_metal.rs
@@ -803,6 +803,12 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         ModelFormat::Unknown => {
             return Err(model_format::unrecognized_format_message(dir).into());
         }
+        // Any format this binary doesn't yet know how to load is handled
+        // the same way as `Unknown`: report it rather than silently
+        // guessing a loader.
+        _ => {
+            return Err(model_format::unrecognized_format_message(dir).into());
+        }
     }
 
     // ── Load LoRA adapter (if requested) ────────────────────────────────────

--- a/crates/inference/src/bin/lattice/chat.rs
+++ b/crates/inference/src/bin/lattice/chat.rs
@@ -135,6 +135,13 @@ pub(crate) fn run_chat(
             eprintln!("Error: {}", backend::unrecognized_format_message(path));
             std::process::exit(1);
         }
+        // Any format this binary doesn't yet know how to load is handled
+        // the same way as `Unknown`: report it and exit, rather than
+        // silently guessing a loader.
+        _ => {
+            eprintln!("Error: {}", backend::unrecognized_format_message(path));
+            std::process::exit(1);
+        }
     };
     eprintln!("Model loaded. Type 'exit' or 'quit' to stop.\n");
 

--- a/crates/inference/src/bin/lattice/doctor.rs
+++ b/crates/inference/src/bin/lattice/doctor.rs
@@ -820,6 +820,12 @@ pub fn build_report(
         crate::backend::ModelFormat::Unknown => {
             return Err(crate::backend::unrecognized_format_message(model_dir));
         }
+        // Any format this binary doesn't yet know how to inspect is handled
+        // the same way as `Unknown`: report it as an error rather than
+        // silently guessing an inventory shape.
+        _ => {
+            return Err(crate::backend::unrecognized_format_message(model_dir));
+        }
     };
 
     let tokenizer_path = tokenizer_dir.unwrap_or(model_dir).join("tokenizer.json");

--- a/crates/inference/src/bin/lattice/main.rs
+++ b/crates/inference/src/bin/lattice/main.rs
@@ -219,6 +219,16 @@ async fn main() {
                     );
                     std::process::exit(1);
                 }
+                // Any format this binary doesn't yet know how to serve is
+                // handled the same way as `Unknown`: report it and exit,
+                // rather than silently guessing a backend.
+                _ => {
+                    eprintln!(
+                        "Error: {}",
+                        backend::unrecognized_format_message(model_path)
+                    );
+                    std::process::exit(1);
+                }
             };
             eprintln!("Model loaded. Serving as '{served_model_id}'.");
 

--- a/crates/inference/src/bin/lattice/serve.rs
+++ b/crates/inference/src/bin/lattice/serve.rs
@@ -240,6 +240,15 @@ impl MetalHandle {
                 WorkerEvent::Cancelled => {
                     unreachable!("normalize_cancelled already rewrote Cancelled into Complete")
                 }
+                // Unrecognized future event kind: mirror the
+                // `Failed`/`ConstraintBlocked` arm above and fail the
+                // request with a generic internal error rather than
+                // guessing.
+                _ => {
+                    return Err(ApiError::Internal {
+                        message: "generation failed: unrecognized worker event".to_string(),
+                    });
+                }
             }
         }
     }
@@ -433,6 +442,10 @@ impl ModelBackend {
             // for exhaustiveness and as defense in depth against any
             // other future `spawn_metal` caller.
             err @ StartupError::InvalidMaxPending { .. } => err.to_string(),
+            // Unrecognized future startup-failure kind: fall back to its
+            // `Display` text rather than guessing at a more specific
+            // wording, same as `InvalidMaxPending` above.
+            err => err.to_string(),
         })?;
         // The explicit owner is not needed by this binary: every
         // production `MetalWorkerClient` retains an owner clone. The

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -1721,6 +1721,10 @@ mod imp {
                 })
             }
             ModelFormat::Unknown => Err(model_format::unrecognized_format_message(model_dir)),
+            // Any format this binary doesn't yet know how to load is handled
+            // the same way as `Unknown`: report it rather than silently
+            // guessing a loader.
+            _ => Err(model_format::unrecognized_format_message(model_dir)),
         }
     }
 
@@ -2114,6 +2118,28 @@ mod imp {
                 WorkerEvent::Cancelled => {
                     unreachable!("normalize_cancelled already rewrote Cancelled into Complete")
                 }
+                // Unrecognized future event kind as the very FIRST event:
+                // nothing has been committed to the client yet, so fail
+                // closed the same way the `Failed`/`ConstraintBlocked` arm
+                // above does rather than guessing at a status code.
+                _ => {
+                    emit_serve_event(
+                        &s.metrics,
+                        "POST",
+                        "/v1/chat/completions",
+                        500,
+                        None,
+                        None,
+                        timer.elapsed().as_secs_f64() * 1000.0,
+                        true,
+                        Some("internal_error"),
+                    );
+                    return err_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "inference failed",
+                        "internal_error",
+                    );
+                }
             };
             let metrics = s.metrics.clone();
             let stream = futures::stream::unfold(
@@ -2267,6 +2293,35 @@ mod imp {
                                 Some(WorkerEvent::Cancelled) => unreachable!(
                                     "normalize_cancelled already rewrote Cancelled into Complete"
                                 ),
+                                // Unrecognized future event kind mid-stream: the
+                                // wire status was already committed to 200 SSE,
+                                // so mirror the `Failed`/`ConstraintBlocked` arm
+                                // above and fail the stream closed with a
+                                // generic internal error rather than guessing.
+                                Some(_) => {
+                                    let error = json!({
+                                        "error": {
+                                            "message": "inference failed",
+                                            "type": "server_error",
+                                            "code": "internal_error",
+                                            "param": null,
+                                        }
+                                    });
+                                    Some((
+                                        Ok(Event::default().data(error.to_string())),
+                                        (
+                                            rx,
+                                            Phase::Done(
+                                                completion_tokens,
+                                                0,
+                                                Some((500, "internal_error")),
+                                            ),
+                                            cancel_guard,
+                                            None,
+                                            metrics,
+                                        ),
+                                    ))
+                                }
                                 None => {
                                     let error = json!({
                                         "error": {
@@ -2477,6 +2532,28 @@ mod imp {
                     }
                     WorkerEvent::Cancelled => {
                         unreachable!("normalize_cancelled already rewrote Cancelled into Complete")
+                    }
+                    // Unrecognized future event kind: the response has not
+                    // been committed yet, so mirror the `Failed` arm above
+                    // and fail closed with a generic internal error rather
+                    // than guessing.
+                    _ => {
+                        emit_serve_event(
+                            &s.metrics,
+                            "POST",
+                            "/v1/chat/completions",
+                            500,
+                            None,
+                            None,
+                            timer.elapsed().as_secs_f64() * 1000.0,
+                            false,
+                            Some("internal_error"),
+                        );
+                        return lattice_inference::serve::ApiError::ServerError {
+                            message: "inference failed".to_string(),
+                            code: "internal_error",
+                        }
+                        .into_response();
                     }
                 }
             }
@@ -2816,6 +2893,7 @@ mod imp {
                 ModelFormat::Q4 => "q4",
                 ModelFormat::Safetensors => "bf16",
                 ModelFormat::Unknown => "unknown",
+                _ => "unknown",
             }
         );
         // #832: `load_model` (unchanged) runs INSIDE this loader closure, on
@@ -2870,6 +2948,12 @@ mod imp {
             // #939: zero, or above `Semaphore::MAX_PERMITS` -- a
             // configuration error caught before `Semaphore::new` panics.
             Err(err @ StartupError::InvalidMaxPending { .. }) => {
+                return Err(err.to_string().into());
+            }
+            // Unrecognized future startup-failure kind: fall back to its
+            // `Display` text rather than guessing at a more specific
+            // wording, same as `InvalidMaxPending` above.
+            Err(err) => {
                 return Err(err.to_string().into());
             }
         };
@@ -5697,6 +5781,10 @@ mod imp {
                                     lattice_inference::forward::metal_qwen35::ChatRole::Assistant => {
                                         "assistant"
                                     }
+                                    // This fixture only ever constructs the
+                                    // three known roles; a future role isn't
+                                    // yet exercised by this test.
+                                    _ => "unknown",
                                 };
                                 (role.to_string(), m.content.clone())
                             })

--- a/crates/inference/src/bin/qwen35_generate.rs
+++ b/crates/inference/src/bin/qwen35_generate.rs
@@ -367,6 +367,9 @@ fn run_emit_phase_events(args: &[String]) -> i32 {
                 raw_token_count += 1;
                 emit_token_available(t0, index);
             }
+            // Future event kinds are trace-only; this bench harness ignores
+            // ones it doesn't recognize rather than failing to build.
+            _ => {}
         },
     );
 

--- a/crates/inference/src/error.rs
+++ b/crates/inference/src/error.rs
@@ -5,6 +5,7 @@ use std::fmt::{Display, Formatter};
 /// code can match it exhaustively, adding, removing, or renaming variants is
 /// SemVer-breaking.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum InferenceError {
     ModelNotFound(String),
     UnsupportedModel(String),

--- a/crates/inference/src/forward/cpu_f16.rs
+++ b/crates/inference/src/forward/cpu_f16.rs
@@ -1353,6 +1353,7 @@ pub fn generate_multimodal_f16(
 /// vector. Picking (or fine-tuning) a checkpoint for retrieval quality is a
 /// separate, later decision.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum PoolingStrategy {
     /// Mean over the hidden states at the request's `<|image_pad|>`
     /// positions (the visual tokens). For a text-only request — no image

--- a/crates/inference/src/forward/gpu/inner/api.rs
+++ b/crates/inference/src/forward/gpu/inner/api.rs
@@ -6,6 +6,7 @@ pub type Result<T> = std::result::Result<T, GpuForwardError>;
 
 /// **Unstable**: GPU forward pass error; variants may expand with new GPU backends.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum GpuForwardError {
     NoAdapter,
     RequestDevice(wgpu::RequestDeviceError),

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -370,6 +370,7 @@ mod route_predicate_tests {
 ///
 /// Role in a chat conversation.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum ChatRole {
     System,
     User,
@@ -34733,6 +34734,7 @@ pub fn mtp_greedy_round(
 
 /// Which logical traffic bucket a GDN state access belongs to.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum GdnStateTrafficScope {
     /// Normal single-token decode (`forward_step`, self-spec draft/fallback).
     Decode,

--- a/crates/inference/src/grammar/spec.rs
+++ b/crates/inference/src/grammar/spec.rs
@@ -12,6 +12,7 @@
 /// with the model vocabulary to obtain a `GrammarEngine` that can be embedded
 /// in a `GenerateConfig`.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum GrammarSpec {
     /// JSON Schema (draft 2020-12 subset).
     ///

--- a/crates/inference/src/kv_cache/cross_turn.rs
+++ b/crates/inference/src/kv_cache/cross_turn.rs
@@ -78,6 +78,7 @@ pub struct CrossTurnPrefixEntry {
 
 /// How the next turn should build on (or discard) the cached entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum PrefixReuseMode {
     /// No usable overlap: reset state and prefill the whole prompt.
     FullRefill,

--- a/crates/inference/src/kv_cache/paged.rs
+++ b/crates/inference/src/kv_cache/paged.rs
@@ -28,6 +28,7 @@ use crate::error::InferenceError;
 
 /// **Unstable**: element format used by paged KV storage.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum CacheType {
     /// Store every KV element as an f32 value.
     #[default]
@@ -157,6 +158,7 @@ impl PagedKVCacheConfig {
 
 /// **Unstable**: eviction strategy for the paged KV cache.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum EvictionPolicy {
     /// Panic when out of pages (fail-fast for debugging).
     None,

--- a/crates/inference/src/metrics.rs
+++ b/crates/inference/src/metrics.rs
@@ -6,6 +6,7 @@
 
 /// Controls what metrics are collected during inference.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum MetricsMode {
     /// Zero overhead — no metrics collected.
     #[default]

--- a/crates/inference/src/mixture.rs
+++ b/crates/inference/src/mixture.rs
@@ -23,6 +23,7 @@ pub type AdapterId = String;
 
 /// Error type for routing operations.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum RouterError {
     /// The fann network forward pass failed.
     #[error("gate network error: {0}")]

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -1155,6 +1155,7 @@ impl Qwen35Model {
 /// sampled token, and measuring `prefill_end` off the first delta fires it
 /// after sampling instead of before.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum RawGenEvent {
     /// Fired exactly once, after the prefill forward pass has produced
     /// logits and before the first token is sampled -- the true

--- a/crates/inference/src/model_format.rs
+++ b/crates/inference/src/model_format.rs
@@ -32,6 +32,7 @@ use std::path::Path;
 
 /// The on-disk format of a model directory, decided before any tensor I/O.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ModelFormat {
     /// `model.safetensors` or `model.safetensors.index.json` present.
     Safetensors,

--- a/crates/inference/src/pool.rs
+++ b/crates/inference/src/pool.rs
@@ -16,6 +16,7 @@ use crate::forward::cpu::simd_config;
 /// Qwen3-Embedding models use `last_token_pool` (decoder-style) and do not use
 /// this enum — they have a separate inference path in `QwenModel`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum BertPooling {
     /// Masked mean pooling (attention-mask-weighted average over all real tokens).
     ///

--- a/crates/inference/src/quant/q4_manifest.rs
+++ b/crates/inference/src/quant/q4_manifest.rs
@@ -56,6 +56,7 @@ pub const MAX_QUANTIZE_INDEX_LEN: u64 = 16 * 1024 * 1024; // 16 MiB
 /// existing call sites that propagate errors as `String` via `?` are
 /// unaffected — the conversion happens automatically at the `?` site.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Q4ManifestError {
     /// The manifest path exists (as a directory entry — including a
     /// dangling symlink) but could not be stat'd, opened, or read: a
@@ -123,6 +124,7 @@ pub struct Q4ManifestEntry {
 /// same tensor entry list; only [`ManifestFlavor::QuaRot`] can carry a
 /// rotation seed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ManifestFlavor {
     /// `bin/quantize_q4.rs`: bare top-level JSON array of tensor entries.
     QuantizeQ4,

--- a/crates/inference/src/quant/quarot/convert.rs
+++ b/crates/inference/src/quant/quarot/convert.rs
@@ -142,6 +142,7 @@ struct IndexEntry {
 /// [`PromotionState::Promoted`] or [`PromotionState::Rejected`].
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum PromotionState {
     /// The PPL acceptance gate has not been recorded against this
     /// artifact. Default state for every artifact `convert_quarot_qwen35`

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -62,6 +62,7 @@ use crate::weights::{contained_shard_path, parse_index};
 /// record provenance in its output metadata. The converter always promotes
 /// to f64 internally; this is informational, not a control knob.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SourceDType {
     F32,
     F16,
@@ -374,6 +375,7 @@ impl Backing {
 /// [`OnlineRotationSpec`] — that combination cannot occur from a real v0
 /// artifact and is evidence of a corrupted or hand-edited index.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub enum ArtifactVersion {
     #[serde(rename = "v0-residual")]
     V0Residual,

--- a/crates/inference/src/quant/quarot/plan.rs
+++ b/crates/inference/src/quant/quarot/plan.rs
@@ -207,6 +207,7 @@ pub struct TensorRotation {
 /// no online (runtime) rotation is wired yet — see [`OnlineRotationSpec`]
 /// for the artifact-level metadata these identifiers carry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[non_exhaustive]
 pub enum RotationId {
     /// `R_res` of dimension `hidden_size`.
     ResidualStream,
@@ -247,6 +248,7 @@ impl RotationId {
 /// attaches to. Distinct from [`AbsorptionSide`], which describes which side
 /// of the *weight matrix* absorbs the offline counter-rotation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum OnlineTransformSite {
     /// R3: full-attention gated context, immediately before `o_proj`.
     AttentionOutputPreOProj,

--- a/crates/inference/src/serve/contract.rs
+++ b/crates/inference/src/serve/contract.rs
@@ -150,6 +150,7 @@ pub struct Message {
 
 /// Validated role carried by a normalized serving-contract message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum NormalizedChatRole {
     /// System instruction.
     System,
@@ -194,6 +195,7 @@ pub struct NormalizedChatImage {
 /// Message content represented as a string or a list of typed parts.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum MessageContent {
     /// Plain text content.
     Text(String),
@@ -203,6 +205,7 @@ pub enum MessageContent {
 
 /// One typed OpenAI message-content part.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ContentPart {
     /// A text content part.
     Text { text: String },

--- a/crates/inference/src/serve/metal_worker.rs
+++ b/crates/inference/src/serve/metal_worker.rs
@@ -101,6 +101,7 @@ enum WorkerShutdown {
 /// Selects the context-window formula enforced before Metal generation.
 /// Each serve adapter supplies the policy matching its pre-worker contract.
 #[derive(Debug, Clone, Copy)]
+#[non_exhaustive]
 pub enum ContextWindowPolicy {
     /// Enforce `prompt_tokens + max_new_tokens <= model_max_context`.
     PromptAndMaxTokens,
@@ -123,6 +124,7 @@ pub struct WorkerMetadata {
 /// Replaces `lattice.rs`'s oneshot-reply `MetalJob` contract and
 /// `lattice_serve.rs`'s private `Ev` enum with a single shared shape.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum WorkerEvent {
     /// One streamed token delta.
     Delta(String),
@@ -194,6 +196,7 @@ impl From<crate::error::InferenceError> for WorkerFailure {
 /// before ever sending a readiness signal, or the requested admission cap
 /// (issue #939) was outside `Semaphore::new`'s valid range.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum StartupError {
     Load(String),
     ThreadExited,

--- a/crates/inference/src/serve/mod.rs
+++ b/crates/inference/src/serve/mod.rs
@@ -270,6 +270,7 @@ async fn shutdown_signal() -> std::io::Result<()> {
 /// Structured HTTP error shared by both binaries, serializing to the OpenAI
 /// error envelope: `{"error": {"message", "type", "code", "param"}}`.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ApiError {
     /// Caller mistake — HTTP 400.
     BadRequest { message: String, code: &'static str },

--- a/crates/inference/src/stop_reason.rs
+++ b/crates/inference/src/stop_reason.rs
@@ -4,6 +4,7 @@
 /// `None` is reserved for non-generation returns (empty prompt, stub code paths) that do not
 /// correspond to any of these causes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum StopReason {
     /// EOS token, configured stop-token id, or stop-string match.
     Eos,

--- a/crates/inference/src/tokenizer/sentencepiece.rs
+++ b/crates/inference/src/tokenizer/sentencepiece.rs
@@ -24,6 +24,7 @@ const META_SPACE: char = '\u{2581}';
 ///
 /// SentencePiece piece type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SentencePieceType {
     Unknown,
     Normal,

--- a/crates/inference/src/vision/mod.rs
+++ b/crates/inference/src/vision/mod.rs
@@ -96,6 +96,7 @@ use vit::{ViT, VisionWeights};
 
 /// Errors produced by the vision encoder pipeline.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum VisionError {
     /// Raw image bytes could not be decoded (unsupported format, corrupt data).
     ImageDecode(String),

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -1148,6 +1148,7 @@ fn read_f16_header(
 /// Why loading a `.f16` failed, when the caller needs to distinguish a shape
 /// disagreement from every other failure in order to report it well.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum F16LoadError {
     /// The header's declared shape disagreed with the shape the caller required.
     /// The payload was not read.

--- a/crates/inference/tests/metal_measurement_lock_contract.rs
+++ b/crates/inference/tests/metal_measurement_lock_contract.rs
@@ -206,7 +206,7 @@ const CONSTRUCTION_EXEMPTIONS: &[ConstructionExemption] = &[
     },
     ConstructionExemption {
         site: "bin:lattice:src/bin/lattice/main.rs=>src/bin/lattice/serve.rs::ModelBackend::spawn_metal::MetalQwen35State::from_q4_dir()#1",
-        recorded_position: "src/bin/lattice/serve.rs:400:81",
+        recorded_position: "src/bin/lattice/serve.rs:409:81",
         reason: "ModelBackend::spawn_metal initializes a long-running server worker outside the bounded measurement-harness contract",
     },
     ConstructionExemption {

--- a/crates/inference/tests/metal_measurement_lock_contract.rs
+++ b/crates/inference/tests/metal_measurement_lock_contract.rs
@@ -182,7 +182,7 @@ const CONSTRUCTION_EXEMPTIONS: &[(&str, &str)] = &[
         "MetalChatBackend::load belongs to a long-running interactive process outside the bounded measurement-harness contract",
     ),
     (
-        "bin:lattice:src/bin/lattice/main.rs=>src/bin/lattice/serve.rs:400:81",
+        "bin:lattice:src/bin/lattice/main.rs=>src/bin/lattice/serve.rs:409:81",
         "MetalHandle::spawn_metal initializes a long-running server worker outside the bounded measurement-harness contract",
     ),
     (

--- a/crates/transport/src/cost.rs
+++ b/crates/transport/src/cost.rs
@@ -13,6 +13,7 @@ use super::math::sqrt;
 ///
 /// **Stable** (provisional): error type paired with the `Stable` cost API; changes only if the cost trait surface changes.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum CostError {
     /// Point set has no elements.
     EmptyPointSet,

--- a/crates/transport/src/drift.rs
+++ b/crates/transport/src/drift.rs
@@ -79,6 +79,7 @@ pub trait MemoryLike {
 /// **Stable** (provisional): two-variant enum; a `Custom` variant may be added but existing variants are stable.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum DriftWeighting {
     /// Equal weight for all entries.
     Uniform,
@@ -91,6 +92,7 @@ pub enum DriftWeighting {
 /// **Stable** (provisional): two standard metrics; new entries (e.g., L1) would be additive.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum DriftMetricKind {
     /// Squared Euclidean distance (Wasserstein-2).
     SquaredEuclidean,

--- a/crates/transport/src/online_drift.rs
+++ b/crates/transport/src/online_drift.rs
@@ -67,6 +67,7 @@ impl OnlineDriftConfig {
 /// **Stable** (provisional): four-variant status enum; new variants would be additive.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum OnlineDriftSignal {
     /// Not enough samples have been observed to fill both windows.
     Warming {

--- a/crates/transport/src/sinkhorn.rs
+++ b/crates/transport/src/sinkhorn.rs
@@ -141,6 +141,7 @@ impl SinkhornWorkspace {
 ///
 /// **Stable** (provisional): error variants reflect the documented failure modes; new variants would be additive.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum SinkhornError {
     /// The problem has zero rows or columns.
     EmptyProblem,

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -32,7 +32,7 @@ mixture = ["lattice-fann/online-router"]
 simulated-teacher = []
 
 [dependencies]
-lattice-fann = { version = "0.8.0", path = "../fann" }
+lattice-fann = { version = "0.9.0", path = "../fann" }
 thiserror.workspace = true
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -53,7 +53,7 @@ safetensors = { workspace = true, optional = true }
 rusqlite = { workspace = true, optional = true }
 
 # Inference hook and training backward pass (optional — for LoRA adapter injection and gradients)
-lattice-inference = { version = "0.8.0", path = "../inference", optional = true, features = ["f16"] }
+lattice-inference = { version = "0.9.0", path = "../inference", optional = true, features = ["f16"] }
 
 [[bin]]
 name = "generate_lora"

--- a/crates/tune/src/distill/teacher/mod.rs
+++ b/crates/tune/src/distill/teacher/mod.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum TeacherProvider {
     /// Anthropic Claude models
     Claude,

--- a/crates/tune/src/error.rs
+++ b/crates/tune/src/error.rs
@@ -12,6 +12,7 @@ pub type Result<T> = std::result::Result<T, TuneError>;
 
 /// Error types for lattice-tune training infrastructure
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum TuneError {
     /// Dataset error
     #[error("Dataset error: {0}")]

--- a/crates/tune/src/lora/manifest.rs
+++ b/crates/tune/src/lora/manifest.rs
@@ -20,6 +20,7 @@ pub type AdapterId = String;
 /// Governance status of a LoRA adapter.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum AdapterStatus {
     /// Adapter may participate in a mixture.
     Approved,

--- a/crates/tune/src/lora/router_update.rs
+++ b/crates/tune/src/lora/router_update.rs
@@ -30,6 +30,7 @@ pub use lattice_fann::training::DiagonalFisher;
 /// Implicit signals (dwell time, follow-up rate) carry half magnitude.
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum PreferenceSignal {
     /// Explicit positive: the selected adapter produced a useful response.
     Positive,

--- a/crates/tune/src/registry/shadow.rs
+++ b/crates/tune/src/registry/shadow.rs
@@ -105,6 +105,7 @@ impl ShadowConfig {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum ShadowState {
     /// Shadow evaluation is in progress, collecting samples.
     Running {

--- a/crates/tune/src/train/config/optimizer.rs
+++ b/crates/tune/src/train/config/optimizer.rs
@@ -9,6 +9,7 @@ use crate::error::{Result, TuneError};
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[non_exhaustive]
 pub enum Optimizer {
     /// Stochastic Gradient Descent
     SGD,


### PR DESCRIPTION
Marks public enums `#[non_exhaustive]` across all five crates, so that adding a variant later is a
minor release rather than a breaking one. This is a breaking change and belongs in 0.9.0; the
version bump itself lands in the release change, not here.

The immediate motivation is that refining a public error enum — splitting one variant into a
more precise pair — is currently a major-version change for every one of these types. Paying that
cost once, deliberately, is cheaper than paying it per refinement.

## Scope

104 public enums were classified across `lattice-transport`, `lattice-fann`, `lattice-tune`,
`lattice-embed`, and `lattice-inference`. The population came from a per-crate search of
`crates/*/src` for `pub enum`, run with ignore-file handling disabled so that nothing inside a
crate's `src/` could be hidden from the sweep.

- **57** enums newly marked `#[non_exhaustive]`
- **10** were already marked before this change
- **32** deliberately left exhaustive
- **5** are not public API (binary-target-only)

`#[non_exhaustive]` was applied where the variant set describes something that can grow: error
taxonomies, model and format identifiers, device and backend kinds, state and status values. It
was *not* applied where the set is closed by nature (a boolean-like pair, a fixed mathematical
enumeration) or where exhaustiveness is load-bearing for downstream callers. Three enums whose
struct variants are plausibly constructed by outside code were left unmarked rather than marked
on a close call.

15 cross-crate `match` sites needed wildcard arms. Each was given a behaviour-preserving `_` arm;
no arm's behaviour changed.

## Verification

`cargo semver-checks check-release` on each of the five crates reports:

```
196 checks: 195 pass, 1 fail, 0 warn, 57 skip
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---
Summary semver requires new major version: 1 major and 0 minor checks failed
```

The executed-check count is stated deliberately: a run that executes zero checks and a run that
executes and passes all of them both print an untroubled summary and both exit zero, so the count
is what distinguishes a gate that ran from a gate that was switched off. 196 checks executed on
every crate.

`enum_marked_non_exhaustive` is the only failing category on any crate — no other breaking change
is present. For `lattice-transport` the enums the check names were compared one by one against the
enums the diff marks, and the two sets are identical (`SinkhornError`, `DriftWeighting`,
`CostError`, `DriftMetricKind`, `OnlineDriftSignal`).

Also green: `cargo build --workspace`, `cargo clippy`, `cargo fmt --check`, doc lint, and every
crate's library test suite (3138 tests) plus the affected binary targets' own suites (262 tests).

### Read the semver-checks green on this PR as vacuous, not as evidence

This change also bumps the workspace and the four internal path-dep pins from `0.8.0` to `0.9.0`,
which is what lets the `semver-checks` job pass. It passes by **not running**. Measured here, with
both arms in one session and only the manifest version differing between them:

| manifest version | semver-checks output | exit |
|---|---|---|
| `0.8.0` (before the bump) | `196 checks: 195 pass, 1 fail, 0 warn, 57 skip` | 1 |
| `0.9.0` (after the bump) | `0 checks: 0 pass, 253 skip` — `Summary no semver update required` | 0 |

For a `0.x` crate a minor bump is already the breaking-change bump, so once the version moves,
cargo-semver-checks concludes the new version permits anything and skips every lint. Zero executed
checks and all-checks-passed both print an untroubled summary and both exit zero, so the green on
this PR carries no information about whether the API change is what it claims to be.

The evidence that the change is exactly one category of break is the **pre-bump** run above, which
executed 196 checks per crate and failed only `enum_marked_non_exhaustive`. Any future review that
wants to re-establish that must pin the manifest back to `0.8.0` first; running the gate at `0.9.0`
will report success without looking.

## Note on a bug this change nearly shipped

The mechanical insertion step checked whether the line immediately above `pub enum X` already read
`#[non_exhaustive]`. For three enums in `crates/embed/src/types.rs` a `#[repr(u8)]` sat between the
existing attribute and the enum, so the check missed it and inserted a second `#[non_exhaustive]` —
a duplicate attribute, which does not compile. It was caught by re-deriving the already-marked set
from a full search of the pre-change tree rather than trusting the insertion step's own report,
which had logged a plausible and complete-looking summary of what it did.

## bench-compare disposition

Structural waiver, no A/B table.

The diff is 57 files, +204/-11 against current main. Fifty-one of those files change only attributes,
wildcard `match` arms, or imports. No function body's executed instructions change in them: a `_` arm
added to a `match` that previously covered every variant is unreachable, and `#[non_exhaustive]` has
no runtime representation.

One file is a test-harness update, described in the section below.

The remaining five are build inputs — `Cargo.toml`, `crates/embed/Cargo.toml`,
`crates/inference/Cargo.toml`, `crates/tune/Cargo.toml`, and `Cargo.lock` — and they are called out
separately because a build-input change is exactly the case where a structural waiver does not apply
on its own. A build input has no absent call path to name and no `cfg` gate to close: it changes what
gets compiled, or how the runner is invoked, before any function body executes.

Here those hunks are version strings and nothing else: `version = "0.8.0"` becomes `version =
"0.9.0"` in the workspace package, the `version =` field of each internal path dependency is bumped
in lockstep to match, and `Cargo.lock` records the same bump for the five workspace members. No
external dependency is added, removed, or repointed, and no external version in the lockfile moves;
no feature list, default-feature set, profile, `[[bench]]` table, or `required-features` entry
changes. Because these are path dependencies, the bumped `version =` fields do not change which code
is resolved. The only compiled artifact of a version bump is the `CARGO_PKG_VERSION` string, and no
bench target reads it. So the build inputs that could move a benchmark are identical between base and
head, which is the claim the waiver actually needs — not the broader claim that no manifest changed,
which is false here.

An earlier revision of this section asserted that broader claim and stated file and line counts that
did not match the diff. Both are corrected above, and the counts are re-derived against current main
rather than carried forward.

## Interaction with the lock contract, and why a test file is in this diff

`crates/inference/tests/metal_measurement_lock_contract.rs` changes by one field, and it is worth
explaining because the mechanism is easy to misread as a locking change.

That contract now keys construction-site exemptions by program structure rather than by line and
column, so line shifts no longer invalidate an entry. It also keeps a `recorded_position` snapshot
as a deliberate tripwire: if a site's current position stops matching, the site moved and is worth a
human look. This change adds 13 lines above the `ModelBackend::spawn_metal` construction site in
`crates/inference/src/bin/lattice/serve.rs`, moving it from 400:81 to 409:81, so the tripwire fires.

The update records the new position. The site's stable key is unchanged, the exemption still
describes the same work, and nothing about the locking requirement moves. Confirmed by reading the
construction line at both refs: it is the same call, nine lines lower.

Residual risk: the wildcard arms are new reachable code if a variant is ever added to one of these
enums from outside the current set, which is precisely what the change is for. Those arms preserve
current behaviour today and are unmeasured, not measured-as-free.

