### PR TITLE
fix(grammar)!: reject malformed PDA and builder state instead of panicking

### DIFF
--- a/crates/inference/src/grammar/engine.rs
+++ b/crates/inference/src/grammar/engine.rs
@@ -256,6 +256,12 @@ impl From<crate::grammar::gbnf::GbnfError> for GrammarError {
     }
 }
 
+impl From<crate::grammar::pda::BuilderError> for GrammarError {
+    fn from(e: crate::grammar::pda::BuilderError) -> Self {
+        GrammarError(e.0)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // State enumeration
 // ---------------------------------------------------------------------------

--- a/crates/inference/src/grammar/gbnf.rs
+++ b/crates/inference/src/grammar/gbnf.rs
@@ -29,7 +29,7 @@
 //! - Character class negation `[^...]` generates alternatives for every
 //!   byte NOT in the set — correct but potentially many alternatives.
 
-use crate::grammar::pda::{Alt, CompiledGrammar, GrammarBuilder, Symbol};
+use crate::grammar::pda::{Alt, BuilderError, CompiledGrammar, GrammarBuilder, Symbol};
 use std::collections::HashSet;
 
 /// Error from parsing a GBNF string.
@@ -42,6 +42,12 @@ impl std::fmt::Display for GbnfError {
     }
 }
 impl std::error::Error for GbnfError {}
+
+impl From<BuilderError> for GbnfError {
+    fn from(e: BuilderError) -> Self {
+        GbnfError(e.0)
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Lexer
@@ -372,7 +378,7 @@ impl<'a> Parser<'a> {
         self.expect(&Token::Assign)?;
         let alts = self.parse_expr()?;
         let id = self.builder.reserve(&name);
-        self.builder.set_alts(id, alts);
+        self.builder.set_alts(id, alts)?;
         // Consume optional trailing newline(s)
         self.skip_newlines()?;
         Ok(())
@@ -418,7 +424,7 @@ impl<'a> Parser<'a> {
                     .cloned()
                     .chain(std::iter::once(Symbol::NonTerminal(id)))
                     .collect();
-                self.builder.set_alts(id, vec![rep_alt, vec![]]);
+                self.builder.set_alts(id, vec![rep_alt, vec![]])?;
                 Ok(vec![Symbol::NonTerminal(id)])
             }
             Token::Plus => {
@@ -434,7 +440,7 @@ impl<'a> Parser<'a> {
                     .cloned()
                     .chain(std::iter::once(Symbol::NonTerminal(tail_id)))
                     .collect();
-                self.builder.set_alts(tail_id, vec![tail_rec, vec![]]);
+                self.builder.set_alts(tail_id, vec![tail_rec, vec![]])?;
                 // rep = x tail
                 let rep_name = self.anon_rule_name();
                 let rep_id = self.builder.reserve(&rep_name);
@@ -443,7 +449,7 @@ impl<'a> Parser<'a> {
                     .cloned()
                     .chain(std::iter::once(Symbol::NonTerminal(tail_id)))
                     .collect();
-                self.builder.set_alts(rep_id, vec![rep_alt]);
+                self.builder.set_alts(rep_id, vec![rep_alt])?;
                 Ok(vec![Symbol::NonTerminal(rep_id)])
             }
             Token::Question => {
@@ -451,7 +457,7 @@ impl<'a> Parser<'a> {
                 // Desugar `x?` → `opt = x | ε`
                 let rule_name = self.anon_rule_name();
                 let id = self.builder.reserve(&rule_name);
-                self.builder.set_alts(id, vec![base, vec![]]);
+                self.builder.set_alts(id, vec![base, vec![]])?;
                 Ok(vec![Symbol::NonTerminal(id)])
             }
             _ => Ok(base),
@@ -486,7 +492,7 @@ impl<'a> Parser<'a> {
                     // Wrap in anon rule.
                     let rule_name = self.anon_rule_name();
                     let id = self.builder.reserve(&rule_name);
-                    self.builder.set_alts(id, alts);
+                    self.builder.set_alts(id, alts)?;
                     Ok(vec![Symbol::NonTerminal(id)])
                 } else {
                     unreachable!()
@@ -507,7 +513,7 @@ impl<'a> Parser<'a> {
                 }
                 let rule_name = self.anon_rule_name();
                 let id = self.builder.reserve(&rule_name);
-                self.builder.set_alts(id, alts);
+                self.builder.set_alts(id, alts)?;
                 Ok(vec![Symbol::NonTerminal(id)])
             }
             tok => Err(GbnfError(format!("unexpected token in item: {tok:?}"))),

--- a/crates/inference/src/grammar/json_schema.rs
+++ b/crates/inference/src/grammar/json_schema.rs
@@ -154,6 +154,12 @@ impl std::fmt::Display for SchemaError {
 
 impl std::error::Error for SchemaError {}
 
+impl From<crate::grammar::pda::BuilderError> for SchemaError {
+    fn from(e: crate::grammar::pda::BuilderError) -> Self {
+        SchemaError(e.0)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------
@@ -173,7 +179,7 @@ pub fn compile_json_schema(schema: &Value) -> Result<CompiledGrammar, SchemaErro
     // first in CompileCtx::new().
     let root_id = ctx.builder.reserve("root");
     let root_alts = ctx.compile_schema(schema, &[])?;
-    ctx.builder.set_alts(root_id, root_alts);
+    ctx.builder.set_alts(root_id, root_alts)?;
     // Ensure all deferred rules have been resolved.
     ctx.resolve_pending()?;
     let mut grammar = ctx.builder.build();
@@ -262,7 +268,7 @@ impl<'a> CompileCtx<'a> {
         }
         let mut builder = GrammarBuilder::new();
         // Pre-register built-in rules.
-        register_builtins(&mut builder);
+        register_builtins(&mut builder)?;
         Ok(Self {
             defs,
             builder,
@@ -1032,7 +1038,7 @@ impl<'a> CompileCtx<'a> {
         let id = self.builder.reserve(&rule_name);
         // Compile the target and set alts.
         let alts = self.compile_schema(target, &[])?;
-        self.builder.set_alts(id, alts);
+        self.builder.set_alts(id, alts)?;
         Ok(vec![vec![Symbol::NonTerminal(id)]])
     }
 
@@ -1222,7 +1228,7 @@ impl<'a> CompileCtx<'a> {
                             Some(schema) => self.compile_schema(schema, &[])?,
                             None => self.any_value_alts(),
                         };
-                        self.builder.set_alts(id, val_alts);
+                        self.builder.set_alts(id, val_alts)?;
                         id
                     };
 
@@ -1237,7 +1243,7 @@ impl<'a> CompileCtx<'a> {
                         pair_alt.push(Symbol::Terminal(b':'));
                         pair_alt.push(Symbol::NonTerminal(ws_id));
                         pair_alt.push(Symbol::NonTerminal(val_id));
-                        self.builder.set_alts(id, vec![pair_alt]);
+                        self.builder.set_alts(id, vec![pair_alt])?;
                         id
                     };
 
@@ -1273,7 +1279,7 @@ impl<'a> CompileCtx<'a> {
 
                 // Build right-nested tail-chain rules (issue #355).
                 // tail(0, false) is the entry point: no property emitted yet.
-                let tail_id = self.build_object_tail(obj_idx, &props_info, 0, false, ws_id);
+                let tail_id = self.build_object_tail(obj_idx, &props_info, 0, false, ws_id)?;
 
                 // Object rule: `{` ws tail(0, false) ws `}`
                 let main_alt = vec![
@@ -1353,21 +1359,21 @@ impl<'a> CompileCtx<'a> {
         i: usize,
         started: bool,
         ws_id: usize,
-    ) -> usize {
+    ) -> Result<usize, SchemaError> {
         let started_char = if started { 's' } else { 'f' };
         let rule_name = format!("obj_{obj_idx}_tail_{i}_{started_char}");
 
         // Memoization: if this (obj_idx, i, started) variant was already built,
         // return its id without rebuilding.
         if let Some(id) = self.builder.rule_id(&rule_name) {
-            return id;
+            return Ok(id);
         }
 
         // Base case: all properties processed → epsilon.
         if i == props.len() {
             let id = self.builder.reserve(&rule_name);
-            self.builder.set_alts(id, vec![vec![]]); // epsilon alternative
-            return id;
+            self.builder.set_alts(id, vec![vec![]])?; // epsilon alternative
+            return Ok(id);
         }
 
         // Reserve first so that any recursive call that would reference *this*
@@ -1379,7 +1385,7 @@ impl<'a> CompileCtx<'a> {
 
         let alts: Vec<Alt> = if is_required {
             // Required: one alternative (no choice).
-            let next_id = self.build_object_tail(obj_idx, props, i + 1, true, ws_id);
+            let next_id = self.build_object_tail(obj_idx, props, i + 1, true, ws_id)?;
             if started {
                 // "," ws pair_i tail(i+1, true)
                 // Leading "," is a terminal at sym_pos==0 of this alternative.
@@ -1400,8 +1406,8 @@ impl<'a> CompileCtx<'a> {
             // Optional: emit alt | skip alt.
             // next_started_id: tail after emitting P_i (started=true regardless).
             // next_same_id:    tail after skipping P_i (started unchanged).
-            let next_started_id = self.build_object_tail(obj_idx, props, i + 1, true, ws_id);
-            let next_same_id = self.build_object_tail(obj_idx, props, i + 1, started, ws_id);
+            let next_started_id = self.build_object_tail(obj_idx, props, i + 1, true, ws_id)?;
+            let next_same_id = self.build_object_tail(obj_idx, props, i + 1, started, ws_id)?;
 
             let emit_alt: Alt = if started {
                 // INLINED key for started=true optionals: instead of using
@@ -1458,8 +1464,8 @@ impl<'a> CompileCtx<'a> {
             vec![emit_alt, skip_alt]
         };
 
-        self.builder.set_alts(id, alts);
-        id
+        self.builder.set_alts(id, alts)?;
+        Ok(id)
     }
 
     /// Compile an `array` schema.
@@ -1549,7 +1555,7 @@ impl<'a> CompileCtx<'a> {
                     let pos_rule = format!("arr_{n}_prefix_{i}");
                     let pos_id = self.builder.reserve(&pos_rule);
                     let pos_alts = self.compile_schema(pos_schema, &[])?;
-                    self.builder.set_alts(pos_id, pos_alts);
+                    self.builder.set_alts(pos_id, pos_alts)?;
                     pos_ids.push(pos_id);
                 }
 
@@ -1572,11 +1578,11 @@ impl<'a> CompileCtx<'a> {
                     let item_rule = format!("arr_{n}_item");
                     let item_id = self.builder.reserve(&item_rule);
                     let item_alts = self.compile_schema(items_schema, &[])?;
-                    self.builder.set_alts(item_id, item_alts);
+                    self.builder.set_alts(item_id, item_alts)?;
 
                     // depth=1: leading-comma continuation after the fixed prefix.
                     let slack = max_items.map(|m| m - p);
-                    let tail_id = self.build_bounded_tail(n, 1, slack, item_id, ws_id);
+                    let tail_id = self.build_bounded_tail(n, 1, slack, item_id, ws_id)?;
                     alt.push(Symbol::NonTerminal(tail_id));
                 }
 
@@ -1596,9 +1602,9 @@ impl<'a> CompileCtx<'a> {
             let item_rule = format!("arr_{n}_item");
             let item_id = self.builder.reserve(&item_rule);
             let item_alts = self.compile_schema(items_schema, &[])?;
-            self.builder.set_alts(item_id, item_alts);
+            self.builder.set_alts(item_id, item_alts)?;
 
-            let alt = self.build_cardinality_array_alt(n, item_id, ws_id, min_items, max_items);
+            let alt = self.build_cardinality_array_alt(n, item_id, ws_id, min_items, max_items)?;
             return Ok(vec![alt]);
         }
 
@@ -1609,7 +1615,7 @@ impl<'a> CompileCtx<'a> {
         } else {
             let id = self.builder.reserve(any_val_rule);
             let any_alts = self.any_value_alts();
-            self.builder.set_alts(id, any_alts);
+            self.builder.set_alts(id, any_alts)?;
             id
         };
 
@@ -1617,7 +1623,7 @@ impl<'a> CompileCtx<'a> {
         if min_items > 0 || max_items.is_some() {
             let n = self.array_counter;
             self.array_counter += 1;
-            let alt = self.build_cardinality_array_alt(n, any_id, ws_id, min_items, max_items);
+            let alt = self.build_cardinality_array_alt(n, any_id, ws_id, min_items, max_items)?;
             return Ok(vec![alt]);
         }
 
@@ -1637,7 +1643,7 @@ impl<'a> CompileCtx<'a> {
                 ],
                 vec![],
             ];
-            self.builder.set_alts(id, tail_alts);
+            self.builder.set_alts(id, tail_alts)?;
             id
         };
 
@@ -1652,7 +1658,7 @@ impl<'a> CompileCtx<'a> {
                     vec![Symbol::NonTerminal(any_id), Symbol::NonTerminal(tail_id)],
                     vec![],
                 ],
-            );
+            )?;
             id
         };
 
@@ -1675,7 +1681,7 @@ impl<'a> CompileCtx<'a> {
         ws_id: usize,
         min_items: usize,
         max_items: Option<usize>,
-    ) -> Alt {
+    ) -> Result<Alt, SchemaError> {
         let mut alt: Alt = vec![Symbol::Terminal(b'[')];
         alt.push(Symbol::NonTerminal(ws_id));
 
@@ -1692,7 +1698,7 @@ impl<'a> CompileCtx<'a> {
                 if slack != Some(0) {
                     // Build optional body: first item is optional, subsequent
                     // items each carry a leading comma.
-                    let body_id = self.build_bounded_tail(n, 0, slack, item_id, ws_id);
+                    let body_id = self.build_bounded_tail(n, 0, slack, item_id, ws_id)?;
                     alt.push(Symbol::NonTerminal(body_id));
                 }
             }
@@ -1710,14 +1716,14 @@ impl<'a> CompileCtx<'a> {
 
                 // Append optional tail for additional items (up to slack more).
                 if slack != Some(0) {
-                    let tail_id = self.build_bounded_tail(n, 1, slack, item_id, ws_id);
+                    let tail_id = self.build_bounded_tail(n, 1, slack, item_id, ws_id)?;
                     alt.push(Symbol::NonTerminal(tail_id));
                 }
             }
         }
 
         alt.push(Symbol::Terminal(b']'));
-        alt
+        Ok(alt)
     }
 
     /// Build a rule representing "zero or more additional items (with leading commas),
@@ -1738,7 +1744,7 @@ impl<'a> CompileCtx<'a> {
         slack: Option<usize>,
         item_id: usize,
         ws_id: usize,
-    ) -> usize {
+    ) -> Result<usize, SchemaError> {
         match slack {
             None => {
                 // Unbounded tail: arr_{n}_tail_{depth} = (,? ws item ws arr_{n}_tail_{depth}) | ε
@@ -1762,7 +1768,7 @@ impl<'a> CompileCtx<'a> {
                         Symbol::NonTerminal(cont_id),
                     ];
                     self.builder
-                        .set_alts(cont_id, vec![cont_alt, vec![] /* epsilon */]);
+                        .set_alts(cont_id, vec![cont_alt, vec![] /* epsilon */])?;
                     vec![
                         Symbol::NonTerminal(item_id),
                         Symbol::NonTerminal(ws_id),
@@ -1779,15 +1785,15 @@ impl<'a> CompileCtx<'a> {
                     ]
                 };
                 self.builder
-                    .set_alts(id, vec![body_alt, vec![] /* epsilon */]);
-                id
+                    .set_alts(id, vec![body_alt, vec![] /* epsilon */])?;
+                Ok(id)
             }
             Some(0) => {
                 // No slack: epsilon rule (no additional items allowed).
                 let rule_name = format!("arr_{arr_n}_opt_{depth}_0");
                 let id = self.builder.reserve(&rule_name);
-                self.builder.set_alts(id, vec![vec![] /* epsilon */]);
-                id
+                self.builder.set_alts(id, vec![vec![] /* epsilon */])?;
+                Ok(id)
             }
             Some(k) => {
                 // Bounded tail: nested-optional chain of depth k.
@@ -1796,7 +1802,7 @@ impl<'a> CompileCtx<'a> {
                 let id = self.builder.reserve(&rule_name);
                 // Recursively build the inner optional (one fewer slot).
                 let inner_id =
-                    self.build_bounded_tail(arr_n, depth + 1, Some(k - 1), item_id, ws_id);
+                    self.build_bounded_tail(arr_n, depth + 1, Some(k - 1), item_id, ws_id)?;
                 let body_alt: Alt = if depth == 0 {
                     // Optional head: no leading comma on first item.
                     vec![
@@ -1815,8 +1821,8 @@ impl<'a> CompileCtx<'a> {
                     ]
                 };
                 self.builder
-                    .set_alts(id, vec![body_alt, vec![] /* epsilon */]);
-                id
+                    .set_alts(id, vec![body_alt, vec![] /* epsilon */])?;
+                Ok(id)
             }
         }
     }
@@ -1997,7 +2003,7 @@ impl<'a> CompileCtx<'a> {
 // ---------------------------------------------------------------------------
 
 /// Register primitive grammar rules into the builder.
-fn register_builtins(b: &mut GrammarBuilder) {
+fn register_builtins(b: &mut GrammarBuilder) -> Result<(), SchemaError> {
     // ws = (' ' | '\t' | '\n' | '\r')* (zero or more whitespace bytes)
     let ws_id = b.reserve("ws");
     let ws_tail = b.reserve("ws_tail");
@@ -2010,8 +2016,8 @@ fn register_builtins(b: &mut GrammarBuilder) {
             vec![Symbol::Terminal(b'\r'), Symbol::NonTerminal(ws_tail)],
             vec![], // epsilon
         ],
-    );
-    b.set_alts(ws_id, vec![vec![Symbol::NonTerminal(ws_tail)]]);
+    )?;
+    b.set_alts(ws_id, vec![vec![Symbol::NonTerminal(ws_tail)]])?;
 
     // json_string = '"' string_inner '"'
     // string_inner = char* where char is one of:
@@ -2033,7 +2039,7 @@ fn register_builtins(b: &mut GrammarBuilder) {
         (0x80u8..=0xBF)
             .map(|byte| vec![Symbol::Terminal(byte)])
             .collect(),
-    );
+    )?;
 
     // Hex digit for \uXXXX escapes: 0-9, A-F, a-f.
     let hex_id = b.reserve("json_hex_digit");
@@ -2042,7 +2048,7 @@ fn register_builtins(b: &mut GrammarBuilder) {
         .chain(b'a'..=b'f')
         .map(|byte| vec![Symbol::Terminal(byte)])
         .collect();
-    b.set_alts(hex_id, hex_alts);
+    b.set_alts(hex_id, hex_alts)?;
 
     // Legal escape body (the byte(s) following '\').
     let escape_id = b.reserve("json_escape");
@@ -2063,7 +2069,7 @@ fn register_builtins(b: &mut GrammarBuilder) {
         Symbol::NonTerminal(hex_id),
         Symbol::NonTerminal(hex_id),
     ]);
-    b.set_alts(escape_id, escape_alts);
+    b.set_alts(escape_id, escape_alts)?;
 
     let mut char_alts: Vec<Alt> = Vec::new();
 
@@ -2114,14 +2120,14 @@ fn register_builtins(b: &mut GrammarBuilder) {
         (0xA0u8..=0xBF)
             .map(|byte| vec![Symbol::Terminal(byte)])
             .collect(),
-    );
+    )?;
     let ed_second_id = b.reserve("json_utf8_ed_second");
     b.set_alts(
         ed_second_id,
         (0x80u8..=0x9F)
             .map(|byte| vec![Symbol::Terminal(byte)])
             .collect(),
-    );
+    )?;
     char_alts.push(vec![
         Symbol::Terminal(0xE0),
         Symbol::NonTerminal(e0_second_id),
@@ -2153,14 +2159,14 @@ fn register_builtins(b: &mut GrammarBuilder) {
         (0x90u8..=0xBF)
             .map(|byte| vec![Symbol::Terminal(byte)])
             .collect(),
-    );
+    )?;
     let f4_second_id = b.reserve("json_utf8_f4_second");
     b.set_alts(
         f4_second_id,
         (0x80u8..=0x8F)
             .map(|byte| vec![Symbol::Terminal(byte)])
             .collect(),
-    );
+    )?;
     char_alts.push(vec![
         Symbol::Terminal(0xF0),
         Symbol::NonTerminal(f0_second_id),
@@ -2182,7 +2188,7 @@ fn register_builtins(b: &mut GrammarBuilder) {
         ]);
     }
 
-    b.set_alts(str_char_id, char_alts);
+    b.set_alts(str_char_id, char_alts)?;
 
     // json_string_inner = (json_string_char json_string_inner) | ε
     b.set_alts(
@@ -2194,7 +2200,7 @@ fn register_builtins(b: &mut GrammarBuilder) {
             ],
             vec![], // epsilon
         ],
-    );
+    )?;
     b.set_alts(
         str_id,
         vec![vec![
@@ -2202,7 +2208,7 @@ fn register_builtins(b: &mut GrammarBuilder) {
             Symbol::NonTerminal(str_inner_id),
             Symbol::Terminal(b'"'),
         ]],
-    );
+    )?;
 
     // json_number = '-'? digit+ ('.' digit+)? (('e'|'E') ('+'|'-')? digit+)?
     // We approximate with a rule that matches the common case.
@@ -2211,7 +2217,7 @@ fn register_builtins(b: &mut GrammarBuilder) {
     let digit_alts: Vec<Alt> = (b'0'..=b'9')
         .map(|byte| vec![Symbol::Terminal(byte)])
         .collect();
-    b.set_alts(digit_id, digit_alts);
+    b.set_alts(digit_id, digit_alts)?;
 
     // json_digits = digit digit_tail
     // json_digit_tail = digit digit_tail | ε   (nullable tail ensures
@@ -2227,21 +2233,21 @@ fn register_builtins(b: &mut GrammarBuilder) {
             ],
             vec![], // epsilon
         ],
-    );
+    )?;
     b.set_alts(
         digits_id,
         vec![vec![
             Symbol::NonTerminal(digit_id),
             Symbol::NonTerminal(digit_tail_id),
         ]],
-    );
+    )?;
 
     // json_nonzero = '1' | '2' | ... | '9'
     let nonzero_id = b.reserve("json_nonzero");
     let nonzero_alts: Vec<Alt> = (b'1'..=b'9')
         .map(|byte| vec![Symbol::Terminal(byte)])
         .collect();
-    b.set_alts(nonzero_id, nonzero_alts);
+    b.set_alts(nonzero_id, nonzero_alts)?;
 
     // json_int_part = '0' | nonzero digit_tail
     // Strict JSON integer part: forbids leading zeros (e.g. "01" rejected).
@@ -2259,11 +2265,11 @@ fn register_builtins(b: &mut GrammarBuilder) {
                 Symbol::NonTerminal(digit_tail_id),
             ],
         ],
-    );
+    )?;
 
     // Optional sign
     let opt_sign_id = b.reserve("json_opt_sign");
-    b.set_alts(opt_sign_id, vec![vec![Symbol::Terminal(b'-')], vec![]]);
+    b.set_alts(opt_sign_id, vec![vec![Symbol::Terminal(b'-')], vec![]])?;
 
     // Optional fraction: '.' digits  (leading zeros legal here, e.g. 1.05)
     let opt_frac_id = b.reserve("json_opt_frac");
@@ -2273,7 +2279,7 @@ fn register_builtins(b: &mut GrammarBuilder) {
             vec![Symbol::Terminal(b'.'), Symbol::NonTerminal(digits_id)],
             vec![],
         ],
-    );
+    )?;
 
     // Optional exponent: (e|E) (sign?) digits  (leading zeros legal, e.g. 1e08)
     let exp_sign_id = b.reserve("json_exp_sign");
@@ -2284,7 +2290,7 @@ fn register_builtins(b: &mut GrammarBuilder) {
             vec![Symbol::Terminal(b'-')],
             vec![],
         ],
-    );
+    )?;
     let opt_exp_id = b.reserve("json_opt_exp");
     b.set_alts(
         opt_exp_id,
@@ -2301,7 +2307,7 @@ fn register_builtins(b: &mut GrammarBuilder) {
             ],
             vec![],
         ],
-    );
+    )?;
 
     // json_number = '-'? int_part ('.' digits)? (('e'|'E') sign? digits)?
     // Uses int_part (not digits) for the integer part to reject leading zeros.
@@ -2313,7 +2319,7 @@ fn register_builtins(b: &mut GrammarBuilder) {
             Symbol::NonTerminal(opt_frac_id),
             Symbol::NonTerminal(opt_exp_id),
         ]],
-    );
+    )?;
 
     // json_integer = '-'? int_part  (rejects leading zeros)
     let int_id = b.reserve("json_integer");
@@ -2323,15 +2329,16 @@ fn register_builtins(b: &mut GrammarBuilder) {
             Symbol::NonTerminal(opt_sign_id),
             Symbol::NonTerminal(int_part_id),
         ]],
-    );
+    )?;
 
     // json_boolean = "true" | "false"
     let bool_id = b.reserve("json_boolean");
-    b.set_alts(bool_id, vec![bytes_to_alt(b"true"), bytes_to_alt(b"false")]);
+    b.set_alts(bool_id, vec![bytes_to_alt(b"true"), bytes_to_alt(b"false")])?;
 
     // json_null = "null"
     let null_id = b.reserve("json_null");
-    b.set_alts(null_id, vec![bytes_to_alt(b"null")]);
+    b.set_alts(null_id, vec![bytes_to_alt(b"null")])?;
+    Ok(())
 }
 
 fn bytes_to_alt(bytes: &[u8]) -> Alt {
@@ -2436,7 +2443,7 @@ fn build_trie_node(
         }
     }
 
-    builder.set_alts(id, alts);
+    builder.set_alts(id, alts)?;
     Ok(id)
 }
 

--- a/crates/inference/src/grammar/pda.rs
+++ b/crates/inference/src/grammar/pda.rs
@@ -269,7 +269,9 @@ fn try_advance_stack(stack: &mut Vec<StackFrame>, grammar: &CompiledGrammar, b: 
             continue;
         }
 
-        let alt = &rule.alts[frame.alt_idx];
+        let Some(alt) = rule.alts.get(frame.alt_idx) else {
+            return false;
+        };
 
         if frame.sym_pos >= alt.len() {
             // Current alternative exhausted: pop frame, advance parent.
@@ -387,7 +389,10 @@ fn try_next_alt(
 
         let rule_id = stack[frame_idx].rule_id;
         let next_alt = stack[frame_idx].alt_idx + 1;
-        let num_alts = grammar.rules[rule_id].alts.len();
+        let Some(rule) = grammar.rules.get(rule_id) else {
+            return false;
+        };
+        let num_alts = rule.alts.len();
 
         if next_alt < num_alts {
             // Switch to the next alternative in the same rule (reset position and the
@@ -429,7 +434,13 @@ fn collapse_exhausted(stack: &mut Vec<StackFrame>, grammar: &CompiledGrammar) {
         match stack.last() {
             None => break,
             Some(frame) => {
-                let rule = &grammar.rules[frame.rule_id];
+                let Some(rule) = grammar.rules.get(frame.rule_id) else {
+                    // Invalid rule id: cannot determine whether this frame is
+                    // exhausted. Stop collapsing rather than index out of
+                    // bounds; the next operation on this state re-validates
+                    // the frame through the same guarded path and rejects.
+                    break;
+                };
                 // No alts: already dead-ended; pop.
                 if rule.alts.is_empty() {
                     stack.pop();
@@ -438,7 +449,9 @@ fn collapse_exhausted(stack: &mut Vec<StackFrame>, grammar: &CompiledGrammar) {
                     }
                     continue;
                 }
-                let alt = &rule.alts[frame.alt_idx];
+                let Some(alt) = rule.alts.get(frame.alt_idx) else {
+                    break;
+                };
                 if frame.sym_pos < alt.len() {
                     break;
                 }
@@ -587,6 +600,17 @@ pub fn simulate_token(
 // Grammar builders for use by json_schema.rs and gbnf.rs
 // ---------------------------------------------------------------------------
 
+/// Error from a `GrammarBuilder` operation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BuilderError(pub String);
+
+impl std::fmt::Display for BuilderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "grammar builder error: {}", self.0)
+    }
+}
+impl std::error::Error for BuilderError {}
+
 /// Builder for assembling a `CompiledGrammar`.
 pub struct GrammarBuilder {
     rules: Vec<Rule>,
@@ -617,14 +641,27 @@ impl GrammarBuilder {
     }
 
     /// Add alternatives to an already-reserved rule.
-    pub fn set_alts(&mut self, id: usize, alts: Vec<Alt>) {
-        self.rules[id].alts = alts;
+    ///
+    /// Returns an error rather than panicking when `id` was never returned by
+    /// `reserve` on this builder (e.g. a foreign or stale id).
+    pub fn set_alts(&mut self, id: usize, alts: Vec<Alt>) -> Result<(), BuilderError> {
+        let Some(rule) = self.rules.get_mut(id) else {
+            return Err(BuilderError(format!(
+                "set_alts: rule id {id} was not reserved on this builder ({} rule(s) reserved)",
+                self.rules.len()
+            )));
+        };
+        rule.alts = alts;
+        Ok(())
     }
 
     /// Reserve and immediately set alternatives.
+    ///
+    /// `id` is always freshly reserved above, so this can never hit the
+    /// unreserved-id case `set_alts` guards against.
     pub fn add_rule(&mut self, name: &str, alts: Vec<Alt>) -> usize {
         let id = self.reserve(name);
-        self.set_alts(id, alts);
+        self.rules[id].alts = alts;
         id
     }
 
@@ -682,7 +719,7 @@ mod tests {
         let digit_alts: Vec<Alt> = (b'0'..=b'9')
             .map(|byte| vec![Symbol::Terminal(byte)])
             .collect();
-        b.set_alts(digit_id, digit_alts);
+        b.set_alts(digit_id, digit_alts).unwrap();
 
         // root = digit digit_rest
         // digit_rest = digit digit_rest | ε  (implemented as digit_rest = [empty alt])
@@ -693,7 +730,8 @@ mod tests {
                 vec![Symbol::NonTerminal(digit_id), Symbol::NonTerminal(rest_id)],
                 vec![], // epsilon
             ],
-        );
+        )
+        .unwrap();
 
         let root_id = b.reserve("root");
         b.set_alts(
@@ -702,7 +740,8 @@ mod tests {
                 Symbol::NonTerminal(digit_id),
                 Symbol::NonTerminal(rest_id),
             ]],
-        );
+        )
+        .unwrap();
         // Ensure root is at index 0.
         let mut grammar = b.build();
         // Swap root to position 0.
@@ -745,7 +784,8 @@ mod tests {
         let body_id = b.reserve("body");
         let tail_id = b.reserve("tail");
         let elem_id = b.reserve("elem");
-        b.set_alts(elem_id, vec![vec![Symbol::Terminal(b'x')]]);
+        b.set_alts(elem_id, vec![vec![Symbol::Terminal(b'x')]])
+            .unwrap();
         b.set_alts(
             tail_id,
             vec![
@@ -756,14 +796,16 @@ mod tests {
                 ],
                 vec![], // epsilon
             ],
-        );
+        )
+        .unwrap();
         b.set_alts(
             body_id,
             vec![
                 vec![Symbol::NonTerminal(elem_id), Symbol::NonTerminal(tail_id)],
                 vec![], // epsilon
             ],
-        );
+        )
+        .unwrap();
         b.set_alts(
             root_id,
             vec![vec![
@@ -771,7 +813,8 @@ mod tests {
                 Symbol::NonTerminal(body_id),
                 Symbol::Terminal(b']'),
             ]],
-        );
+        )
+        .unwrap();
         b.build()
     }
 
@@ -842,11 +885,13 @@ mod tests {
         b.set_alts(
             child_id,
             vec![vec![Symbol::Terminal(b'b'), Symbol::Terminal(b'c')]],
-        );
+        )
+        .unwrap();
         b.set_alts(
             root_id,
             vec![vec![Symbol::Terminal(b'a'), Symbol::NonTerminal(child_id)]],
-        );
+        )
+        .unwrap();
         let g = b.build();
 
         let mut state = GrammarState::initial();
@@ -879,14 +924,18 @@ mod tests {
         let mut builder = GrammarBuilder::new();
         let root_id = builder.reserve("root");
         let dead_id = builder.reserve("dead");
-        builder.set_alts(dead_id, vec![vec![Symbol::Terminal(b'y')]]);
-        builder.set_alts(
-            root_id,
-            vec![
-                vec![Symbol::NonTerminal(dead_id)],
-                vec![Symbol::Terminal(b'x')],
-            ],
-        );
+        builder
+            .set_alts(dead_id, vec![vec![Symbol::Terminal(b'y')]])
+            .unwrap();
+        builder
+            .set_alts(
+                root_id,
+                vec![
+                    vec![Symbol::NonTerminal(dead_id)],
+                    vec![Symbol::Terminal(b'x')],
+                ],
+            )
+            .unwrap();
         let grammar = builder.build();
         let mut state = GrammarState::initial();
 
@@ -978,14 +1027,16 @@ mod tests {
         b.set_alts(
             nt_id,
             vec![vec![Symbol::Terminal(b'c'), Symbol::Terminal(b'd')]],
-        );
+        )
+        .unwrap();
         b.set_alts(
             root_id,
             vec![
                 vec![Symbol::Terminal(b'a'), Symbol::NonTerminal(nt_id)],
                 vec![Symbol::Terminal(b'x')],
             ],
-        );
+        )
+        .unwrap();
         b.build()
     }
 
@@ -1143,5 +1194,143 @@ mod tests {
         assert_eq!(state.stack, before.stack);
         assert_eq!(state.partial_token_bytes, before.partial_token_bytes);
         assert_eq!(state.complete, before.complete);
+    }
+
+    #[test]
+    fn set_alts_out_of_range_id_returns_err() {
+        let mut b = GrammarBuilder::new();
+        let root_id = b.reserve("root");
+        assert_eq!(root_id, 0);
+
+        // No rule was ever reserved at id 5: out of range for a 1-rule builder.
+        let err = b
+            .set_alts(5, vec![vec![Symbol::Terminal(b'x')]])
+            .expect_err("set_alts on an unreserved id must return Err, not panic");
+        assert!(err.0.contains('5'), "error should name the bad id: {err:?}");
+    }
+
+    #[test]
+    fn set_alts_in_range_id_succeeds() {
+        let mut b = GrammarBuilder::new();
+        let id = b.reserve("root");
+        b.set_alts(id, vec![vec![Symbol::Terminal(b'x')]])
+            .expect("set_alts on a freshly reserved id must succeed");
+        let g = b.build();
+        assert!(accepts_str(&g, b"x"));
+    }
+
+    #[test]
+    fn out_of_range_alt_idx_rejects_without_panicking() {
+        // A directly-constructed StackFrame (public fields) can carry an
+        // alt_idx past the rule's alternative count even though the rule id
+        // itself is valid and non-empty. The main advance loop must reject
+        // this the same way it already rejects an out-of-range rule id,
+        // rather than indexing `rule.alts[alt_idx]` unchecked.
+        let grammar = CompiledGrammar {
+            rules: vec![Rule {
+                name: "root".to_string(),
+                alts: vec![vec![Symbol::Terminal(b'x')]], // exactly one alt
+            }],
+        };
+        let mut state = GrammarState {
+            stack: vec![StackFrame {
+                rule_id: 0,
+                alt_idx: 7, // no alt at index 7
+                sym_pos: 0,
+                consumed: false,
+            }],
+            partial_token_bytes: Vec::new(),
+            complete: false,
+        };
+        let before = state.clone();
+
+        assert_eq!(
+            advance_byte(&mut state, &grammar, b'x'),
+            StepResult::Rejected
+        );
+        assert_eq!(state.stack, before.stack);
+        assert_eq!(state.partial_token_bytes, before.partial_token_bytes);
+        assert_eq!(state.complete, before.complete);
+    }
+
+    #[test]
+    fn dangling_ancestor_rule_id_rejects_during_backtrack_without_panicking() {
+        // A non-top (ancestor) frame can carry a rule id that no longer
+        // exists in the grammar — the state a dangling NonTerminal reference
+        // would leave behind. The top frame is valid but its only alt
+        // mismatches the incoming byte, forcing `try_next_alt` to exhaust the
+        // top frame and walk into the invalid ancestor. That ancestor walk
+        // must reject, not index `grammar.rules[rule_id]` unchecked.
+        let grammar = CompiledGrammar {
+            rules: vec![Rule {
+                name: "child".to_string(),
+                alts: vec![vec![Symbol::Terminal(b'z')]],
+            }],
+        };
+        let mut state = GrammarState {
+            stack: vec![
+                StackFrame {
+                    rule_id: 999, // dangling: no such rule
+                    alt_idx: 0,
+                    sym_pos: 0,
+                    consumed: false,
+                },
+                StackFrame {
+                    rule_id: 0, // valid, but its only alt won't match b'x'
+                    alt_idx: 0,
+                    sym_pos: 0,
+                    consumed: false,
+                },
+            ],
+            partial_token_bytes: Vec::new(),
+            complete: false,
+        };
+        let before = state.clone();
+
+        assert_eq!(
+            advance_byte(&mut state, &grammar, b'x'),
+            StepResult::Rejected
+        );
+        assert_eq!(state.stack, before.stack);
+        assert_eq!(state.partial_token_bytes, before.partial_token_bytes);
+        assert_eq!(state.complete, before.complete);
+    }
+
+    #[test]
+    fn dangling_ancestor_rule_id_stops_collapse_without_panicking() {
+        // Same dangling-ancestor shape as above, but reached via the
+        // post-match `collapse_exhausted` walk instead of `try_next_alt`:
+        // the top frame's byte DOES match and exhausts its only alt, so
+        // popping it advances into the invalid ancestor while collapsing.
+        let grammar = CompiledGrammar {
+            rules: vec![Rule {
+                name: "child".to_string(),
+                alts: vec![vec![Symbol::Terminal(b'x')]],
+            }],
+        };
+        let mut state = GrammarState {
+            stack: vec![
+                StackFrame {
+                    rule_id: 999, // dangling: no such rule
+                    alt_idx: 0,
+                    sym_pos: 0,
+                    consumed: false,
+                },
+                StackFrame {
+                    rule_id: 0, // valid; matches b'x' and then exhausts
+                    alt_idx: 0,
+                    sym_pos: 0,
+                    consumed: false,
+                },
+            ],
+            partial_token_bytes: Vec::new(),
+            complete: false,
+        };
+
+        // Must not panic. The byte match itself still succeeds (the top
+        // frame's own terminal matched); what must not panic is the
+        // subsequent collapse into the dangling ancestor.
+        let result = advance_byte(&mut state, &grammar, b'x');
+        assert_eq!(result, StepResult::Accepted);
     }
 }


### PR DESCRIPTION
Addresses the F5 hardening item tracked in #322: the grammar PDA panics on malformed state that can
be constructed through the public API. It also settles the F4 item, which turns out to be already
closed, and surfaces a different unbounded recursion that is not.

**This changes a public API signature and is being treated as major, on cost asymmetry rather than
on a measured break.** `GrammarBuilder::set_alts` changes from `-> ()` to
`-> Result<(), BuilderError>`, and `pda::BuilderError(pub String)` is new. `add_rule` is unaffected,
so callers using it need no change.

Whether that is breaking is UNVERIFIED, and this section previously asserted it as fact. Adding a
`Result` return where there was none is the minor-but-risky class in Rust's own compatibility rules:
an existing `builder.set_alts(a, b);` statement still compiles, with a `must_use` warning. That is
consistent with what the semver gate reports, which is that 196 lints ran against this change and
none of them fired. It is neither established as breaking nor established as safe.

It rides the 0.9.0 lane anyway, alongside #1356, because the costs are asymmetric: a major bump is
already happening, so treating this as major costs nothing, while treating it as minor and being
wrong costs a yank.

## The population, and why it is larger than the issue says

A search of `pda.rs` for indexing into `rules`/`alts` found 11 sites, of which 5 were already
bounds-checked. Of the remaining 6:

| Site | Indexes | Disposition |
|---|---|---|
| `try_advance_stack` | `rule.alts[frame.alt_idx]` | fixed |
| `try_next_alt` | `grammar.rules[rule_id]` (ancestor frame) | fixed |
| `collapse_exhausted` | `grammar.rules[frame.rule_id]` | fixed |
| `collapse_exhausted` | `rule.alts[frame.alt_idx]` | fixed |
| `GrammarBuilder::set_alts` | `self.rules[id]` | fixed |
| `CompiledGrammar::root()` | `self.rules[0]` | **not fixed**, reported |

`root()` is a different bug class — an empty grammar rather than a dangling reference — and has zero
callers anywhere in `crates/` outside its own definition. It is listed so the enumeration is honest,
not because this change addresses it.

## The issue's severity premise was half wrong

#322 justified low severity with "the GBNF parser and the JSON-schema compiler never emit dangling
references, so the only route in is direct construction through the builder."

The first clause holds. Every `Symbol::NonTerminal(..)` argument in `gbnf.rs` and `json_schema.rs`
is a variable bound by `.reserve(..)` or guarded by `if let Some(id) = .rule_id(..)`, never a
literal; and `rules` is only ever appended to (no `remove`/`truncate`/`retain`/`drain`/`pop`/`clear`
and no reassignment anywhere in those three files), so an id valid at reserve time stays valid.

The conclusion does not follow. `GrammarBuilder::set_alts` only writes `Rule.alts`, and every
`NonTerminal` push in the matcher already validates through `grammar.rules.get(rid)` before a frame
reaches the stack. The actual route to an invalid `rule_id` or `alt_idx` on the stack is direct
construction of `GrammarState`/`StackFrame`, whose fields are `pub` — no builder and no `unsafe`
involved. This matters for scope: hardening `set_alts` alone, which is what the issue names, closes
one of the five sites and leaves the four matcher sites open.

## F4 is already closed, and a different recursion is not

`try_next_alt` does not recurse. Its body is a single `loop` walking `frame_idx` down to 0, and it
calls nothing that could re-enter it. Its callers and the sibling functions on the same path
(`try_advance_stack`, `mark_consumed`, `collapse_exhausted`) are likewise iterative. Two
pre-existing, unmodified tests already pin this behaviourally, including one that completes a
4096-deep chain inside a 64 KiB stack — consistent with a heap-based walk rather than native frames.

Asking the second question literally rather than scoping it to `try_next_alt`'s call graph found a
real one. `advance_byte` calls `is_accepting` after every accepted byte; `is_accepting` calls
`remaining_is_nullable`, which calls `rule_is_nullable`, which calls back into
`remaining_is_nullable`. That is genuine mutual recursion, and its only bound is a `visited` set
that stops *cycles*. A long acyclic chain of distinct nullable wrapper rules is unbounded, and its
depth is independent of `MAX_PDA_DEPTH`, which bounds `state.stack.len()` and not static rule
depth. Confirmed reachable with a throwaway 8192-rule chain on a 64 KiB stack; that probe was
deleted and is not part of this diff. Filed separately — it is a different fix and does not belong
in a panic-hardening change.

## Tests

Four new tests, each driving the malformed state through the public API and asserting on the
returned error rather than on the absence of a crash. Reverse-applying the five guards while keeping
the tests and the `Result` plumbing makes all four fail, each with the index-out-of-bounds panic at
the exact line its guard protects:

```
dangling_ancestor_rule_id_rejects_during_backtrack_without_panicking  pda.rs:390  len is 1, index is 999
dangling_ancestor_rule_id_stops_collapse_without_panicking            pda.rs:432  len is 1, index is 999
out_of_range_alt_idx_rejects_without_panicking                        pda.rs:272  len is 1, index is 7
set_alts_out_of_range_id_returns_err                                  pda.rs:635  len is 1, index is 5
```

`cargo test -p lattice-inference --lib grammar::` — 223 passed, 0 failed.
`cargo clippy -p lattice-inference --all-targets -- -D warnings` — clean.

## bench-compare disposition

Structural waiver, no A/B table.

The change replaces unchecked indexing with `.get(..)` plus an early return on five sites, all on
error paths that previously panicked. On every input that did not panic before, the guards add a
bounds check the indexing operation was already performing — the executed work on the accepting
path is unchanged.

Reachability: `crates/inference/benches/grammar_mask_bench.rs` is the one declared bench target that
exercises grammar code, and it drives mask computation over compiler-produced grammars, which by the
argument above cannot construct the malformed states these guards catch. Build inputs are identical
between base and head — no manifest, lockfile, feature, profile, build script, generated source,
bench-target definition, or harness change.

Residual risk: the per-byte path now goes through `.get(..)` on sites that previously indexed
directly. That is not measured here, and "the compiler should elide the duplicate bounds check" is a
prediction rather than a measurement.

