### PR TITLE
fix(inference): correct the MTP cache cursor after a K=1 draft reject

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -7738,6 +7738,14 @@ mod inner {
                 }
 
                 // --- MTP draft phase ---
+                // `mtp_forward_one` writes exactly one MTP KV cache row (for
+                // `pending_token`) and advances `mtp.cache.seq_len` past it before this
+                // round's verify/rollback machinery runs. Snapshot the pre-draft cursor
+                // so a rejection restores the MTP cache to its state as of the top of
+                // this round, not as of after the draft's own write — `verify_tokens_batched`/
+                // `verify_tokens_batch_gemm` capture `mtp_base_seq_len` from whatever the
+                // cursor reads when *they* run, which is already past that row (#1341).
+                let mtp_seq_len_pre_draft = self.session.mtp.as_ref().map(|m| m.cache.seq_len);
                 let t_mtp = std::time::Instant::now();
                 let draft = self.mtp_forward_one(pending_token, pos);
                 metrics.mtp_ms += t_mtp.elapsed().as_secs_f64() * 1000.0;
@@ -7768,6 +7776,13 @@ mod inner {
                 };
                 metrics.verify_ms += t_verify.elapsed().as_secs_f64() * 1000.0;
                 metrics.verify_calls += 1;
+                // Correct the base the verifier just captured: it read the MTP cursor
+                // after the draft phase already advanced it by one row, so restoring
+                // `base_mtp + slot` on rejection would double-count that row and leave
+                // the cursor one slot past the last one `mtp_forward_one` actually wrote.
+                if let Some(ref mut p) = self.session.gdn_checkpoints {
+                    p.mtp_base_seq_len = mtp_seq_len_pre_draft;
+                }
 
                 // Route the accept/reject decision through `rejection_sample_draft` so
                 // the live MTP loop and the trait-level `mtp_verify_draft` share the
@@ -16570,6 +16585,128 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             assert!(
                 max_abs_diff < 0.05,
                 "MTP draft logits diverged after QuaRot counter-rotation: max_abs_diff={max_abs_diff}"
+            );
+        }
+
+        // Issue #1341: a K=1 draft rejection must leave the MTP KV cache cursor at the
+        // row `mtp_forward_one` actually wrote, not one row past it. `mtp_forward_one`
+        // writes exactly one row (for `pending_token`) and advances `mtp.cache.seq_len`
+        // by 1 before verification even starts; `verify_tokens_batched` then snapshots
+        // that already-advanced value into `mtp_base_seq_len`. On rejection,
+        // `rollback_speculative_state_to` adds the verifier's accepted-token `slot` on
+        // top of that snapshot, double-counting the draft's own advance.
+        //
+        // A zeroed `fc` projection collapses the MTP head's output to the zero vector
+        // for any input, so `mtp_forward_one` always drafts token 0 (all-zero logits,
+        // first-wins argmax). `tiny_metal_qwen35_fixture`'s target stack has zero
+        // attention/FFN weights too, so its prediction after processing token `X` is
+        // driven entirely by `RMSNorm(embed_tokens[X])` through the tied lm_head — for
+        // `X == 2` (`embed_tokens[2] `'s only nonzero component is `+1`, and index 2 is
+        // the first vocab entry in that residue class) that prediction is token 2
+        // itself, which never equals the constant draft token 0. Round 1 is therefore
+        // a deterministic reject, driven through the real `generate_greedy_mtp` path.
+        fn constant_zero_draft_mtp_weights_for_test(
+            device: &Device,
+            cfg: &Qwen35Config,
+        ) -> MetalMtpWeights {
+            let mut weights = synthetic_mtp_weights_for_test(device, cfg);
+            weights.fc = make_buffer_f16(
+                device,
+                &vec![0.0f32; cfg.hidden_size * 2 * cfg.hidden_size],
+                "test.mtp.fc.constant_zero_draft",
+            );
+            weights
+        }
+
+        fn metal_state_with_constant_zero_draft_mtp_for_test(
+            weights: &ModelWeights,
+            cfg: &Qwen35Config,
+        ) -> MetalQwen35State {
+            let mut engine = MetalQwen35Engine::new(weights, cfg)
+                .expect("tiny MetalQwen35Engine with constant-draft MTP fixture constructs");
+            engine.mtp_weights = Some(constant_zero_draft_mtp_weights_for_test(
+                &engine.device,
+                cfg,
+            ));
+            let session = engine.new_session(16).expect("tiny MTP session constructs");
+            MetalQwen35State {
+                engine,
+                session,
+                lora: None,
+                use_gdn_chunked: true,
+                use_kv_f16: false,
+                cross_turn_prefix_cache: MetalCrossTurnPrefixCache::default(),
+                path_proof_enabled: false,
+                path_proof: PathProofCounters::default(),
+            }
+        }
+
+        #[test]
+        fn rollback_speculative_state_to_preserves_mtp_cursor_after_k1_reject() {
+            let _gpu_guard = gpu_test_lock();
+            let Some(_) = Device::system_default() else {
+                return;
+            };
+            use crate::model::qwen35_config::GenerateConfig;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (mut cfg, weights) = tiny_metal_qwen35_fixture();
+            cfg.mtp_num_hidden_layers = 1;
+            let mut state = metal_state_with_constant_zero_draft_mtp_for_test(&weights, &cfg);
+            assert!(
+                state.session.mtp.is_some(),
+                "constant-draft MTP fixture must populate session.mtp"
+            );
+
+            let gen_cfg = GenerateConfig {
+                max_new_tokens: 1,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(42),
+                stop_token_ids: vec![],
+                enable_thinking: false,
+                enable_mtp: Some(true),
+                grammar: None,
+                stop_strings: vec![],
+                reasoning_budget: None,
+                logprobs: None,
+            };
+
+            // Force `pending_first == 2` directly rather than relying on a real
+            // prefill: index 2 is the token whose real-model next-token prediction
+            // (token 2 itself, see above) is guaranteed to mismatch the constant
+            // draft (token 0).
+            let mut prefill_logits = vec![-1.0f32; cfg.vocab_size];
+            prefill_logits[2] = 100.0;
+
+            let pos_before = state.session.kv_cache.seq_len;
+            assert_eq!(pos_before, 0);
+            let out = state.generate_greedy_mtp(&prefill_logits, 0, &tokenizer, &gen_cfg);
+            assert!(
+                !out.stopped,
+                "test assumes round 1 does not hit EOS; got {out:?}"
+            );
+
+            // K=1 reject keeps only `pending_token` (2), advancing the KV cache by 1;
+            // a K=1 accept would keep `pending_token` + the draft, advancing by 2.
+            let kv_seq_len = state.session.kv_cache.seq_len;
+            assert_eq!(
+                kv_seq_len, 1,
+                "test setup assumption violated: expected round 1 to reject the \
+                 constant draft (token 0) in favor of the target's own prediction \
+                 (token 2), advancing the KV cache by 1; got {kv_seq_len}, meaning \
+                 the draft was accepted instead"
+            );
+
+            let mtp_seq_len = state.session.mtp.as_ref().unwrap().cache.seq_len;
+            assert_eq!(
+                mtp_seq_len, 1,
+                "K=1 rejection must leave the MTP cursor at the single row \
+                 `mtp_forward_one` wrote this round; got {mtp_seq_len}, which means the \
+                 next `mtp_forward_one` call will skip a slot and the attention window \
+                 will read a never-written row"
             );
         }
 


### PR DESCRIPTION
Fixes #1341.

On the Metal MTP path, a K=1 draft rejection left the MTP KV cache cursor one row past the last row that was physically written, so the next draft forward skipped a slot and that round's attention window covered a row nothing had written.

## Mechanism

`mtp_forward_one` writes exactly one MTP KV cache row per call, using `mtp.cache.seq_len` **read at function entry** as the GPU write offset, then unconditionally advances `mtp.cache.seq_len` by one. The cursor is therefore not bookkeeping: it determines where the next draft's K/V lands, and `cur_mtp_seq = mtp_seq_len + 1` sets the attention window's upper bound for that write.

Per round in `generate_greedy_mtp`:

1. `mtp_forward_one(pending_token, pos)` writes one row and advances the cursor `X` -> `X+1`, before any accept/reject decision exists.
2. `verify_tokens_batched` captures `mtp_base_seq_len` from the cursor as it reads when *it* runs, which is `X+1` — already past the draft's own row.
3. On rejection, `rollback_speculative_state_to(pos + 1)` resolves `slot = 1` and restores `mtp.cache.seq_len = mtp_base_seq_len(X+1) + slot(1) = X+2`.

`pending_token` is emitted regardless of accept or reject, so the row written for it is never invalidated by a rejection. Restoring to `X+2` rather than `X+1` leaves the cursor one row past the last written row.

## Fix

Snapshot the cursor at the top of the round, and after verification correct the base the verifier just captured, before the accept/reject decision can read it.

This is scoped to `generate_greedy_mtp`. `verify_tokens_batched` and `verify_tokens_batch_gemm` are unchanged: their capture-current-cursor line is correct for a caller that has not mutated `mtp.cache` since the round began, and `generate_greedy_mtp` is the only caller that has (by running a draft forward first), so it alone carries the correction. `generate_greedy_self_spec` sets `mtp_base_seq_len = None` explicitly and never calls `mtp_forward_one`; it is untouched.

Two alternatives were considered and rejected. Removing the `mtp_base_seq_len` assignment from the verifiers also fixes the K=1 case, but leaves the `base + slot` restore in `rollback_speculative_state_to` permanently dead, since no live caller would set it to `Some` again. Clearing it to `None` in `generate_greedy_mtp` is numerically equivalent for the current K=1 design, but special-cases this caller out of the general mechanism rather than keeping it self-consistent.

## Test

`rollback_speculative_state_to_preserves_mtp_cursor_after_k1_reject` drives a genuine K=1 rejection through the real `generate_greedy_mtp` entry point rather than a hand-rolled replica of its internals.

Forcing a real rejection required breaking a coincidence in the existing fixture: with the tiny fixture's zeroed attention/FFN weights and the identity-on-embedding MTP `fc`, the draft and the target's own prediction both reduce to `RMSNorm(embed_tokens[X])` through the same tied `lm_head` and always agree — an earlier version of this test produced an ACCEPT, not a reject. The test therefore zeroes the MTP head's `fc` projection so the draft is always token 0, and drives a prompt token whose target prediction is provably itself. The precondition (`kv_cache.seq_len == 1`) is asserted rather than assumed.

Before the fix:

```
assertion `left == right` failed: K=1 rejection must leave the MTP cursor at the
single row `mtp_forward_one` wrote this round; got 2, which means the next
`mtp_forward_one` call will skip a slot and the attention window will read a
never-written row
  left: 2
 right: 1
```

Mutation arm: with the restore disabled the test fails with exactly that output; with it applied it passes. Predicted blast radius before mutating was this test alone, and that is what happened — `--lib mtp` (78 tests) and `--lib self_spec` (30 tests) are green either way, run under the shared Metal lock with `--test-threads=1`.

`cargo clippy -p lattice-inference --features f16,metal-gpu --all-targets -- -D warnings` is clean.

## bench-compare disposition

Measured. No structural waiver is claimed: `crates/inference` declares 24 bench targets, and `mtp_decode` (`required-features = ["metal-gpu", "f16"]`) drives `chat_completion` with `enable_mtp: true`, so it reaches the changed code and a reachability waiver is not available.

A/B on the parent commit vs this head — `92134bb53f` -> `cbb18c8bdc`. The parent is the base deliberately rather than current `main`, which has since gained a change to the same file; comparing against `main` would have measured this fix plus the absence of that change.

| group | base | head | change (p) |
|---|---|---|---|
| `mtp_decode/greedy/baseline` | 284.41 ms | 284.14 ms | [-0.35%, -0.14%, +0.07%] (p = 0.50) |
| `mtp_decode/greedy/mtp` | 708.60 ms | 705.19 ms | [-0.53%, -0.40%, -0.27%] (p = 0.07) |

Neither group shows a significant change. Reading past the label on the second row, since a significance label is not the measurement: the point estimate is -0.40% with a confidence interval entirely below zero and p just above the threshold. The diff adds one `Option<usize>` read and one conditional field write per decode round on a path dominated by GPU forwards, and contains no mechanism that would make anything faster, so a sub-1% negative shift at the edge of significance is consistent with noise rather than with an effect.

Run conditions: executed on a dedicated Apple silicon measurement machine, not the development box. Machine-quiet probes at all three arm boundaries read 96.67%, 96.95%, and 97.39% idle, load average 1.87/1.89/2.73, with no process above 7.4% CPU at any checkpoint. `--quick`.
