### PR TITLE
test(inference): key measurement-lock exemptions on program structure, not position

### DIFF
--- a/crates/inference/tests/metal_measurement_lock_contract.rs
+++ b/crates/inference/tests/metal_measurement_lock_contract.rs
@@ -152,47 +152,73 @@ const CONSTRUCTION_SELECTORS: &[CallSelector] = &[
     // every caller of it is a helper-mediated Metal construction site (#1274).
     CallSelector::Path(&["QwenModel", "from_directory"]),
 ];
-const CONSTRUCTION_EXEMPTIONS: &[(&str, &str)] = &[
-    (
-        "example:bench_concurrent:examples/bench_concurrent.rs=>examples/bench_concurrent.rs:444:27",
-        "run state1 construction is reached only below main's checked live guard; arbitrary call-graph proof is outside this lexical contract",
-    ),
-    (
-        "example:bench_concurrent:examples/bench_concurrent.rs=>examples/bench_concurrent.rs:474:27",
-        "run state2 construction is reached only below main's checked live guard; arbitrary call-graph proof is outside this lexical contract",
-    ),
-    (
-        "example:bench_embed_quality:examples/bench_embed_quality.rs=>examples/bench_embed_quality.rs:136:52",
-        "run_bench QwenModel::from_directory is reached only below main's checked live guard; arbitrary call-graph proof is outside this lexical contract",
-    ),
-    (
-        "bin:backfill_qwen3:src/bin/backfill_qwen3.rs=>src/bin/backfill_qwen3.rs:37:28",
-        "one-time DB embedding migration over an unbounded row count belongs to a long-running batch process outside the bounded measurement-harness contract",
-    ),
-    (
-        "bin:chat_metal:src/bin/chat_metal.rs=>src/bin/chat_metal.rs:770:39",
-        "run Q4 initialization belongs to a long-running interactive process outside the bounded measurement-harness contract",
-    ),
-    (
-        "bin:chat_metal:src/bin/chat_metal.rs=>src/bin/chat_metal.rs:795:39",
-        "run safetensors initialization belongs to a long-running interactive process outside the bounded measurement-harness contract",
-    ),
-    (
-        "bin:lattice:src/bin/lattice/main.rs=>src/bin/lattice/chat.rs:53:81",
-        "MetalChatBackend::load belongs to a long-running interactive process outside the bounded measurement-harness contract",
-    ),
-    (
-        "bin:lattice:src/bin/lattice/main.rs=>src/bin/lattice/serve.rs:400:81",
-        "MetalHandle::spawn_metal initializes a long-running server worker outside the bounded measurement-harness contract",
-    ),
-    (
-        "bin:lattice_serve:src/bin/lattice_serve.rs=>src/bin/lattice_serve.rs:1693:47",
-        "load_model Q4 initialization belongs to a long-running server outside the bounded measurement-harness contract",
-    ),
-    (
-        "bin:lattice_serve:src/bin/lattice_serve.rs=>src/bin/lattice_serve.rs:1713:47",
-        "load_model safetensors initialization belongs to a long-running server outside the bounded measurement-harness contract",
-    ),
+/// A construction site exempted from the live shared-lock requirement.
+///
+/// `site` is a stable key built from the enclosing `mod`/`impl`/`fn` path and
+/// the constructed selector (see `StructuredSource::stable_construction_key`),
+/// not from source line/column, so edits that shift line numbers without
+/// changing what is constructed or where it sits in the program structure do
+/// not invalidate the entry (#1357). `recorded_position` is a line:column
+/// snapshot taken when the entry was authored, kept only as a tripwire: if a
+/// site's current position no longer matches it, the site has moved and is
+/// worth a human look, even though its stable key still matches.
+struct ConstructionExemption {
+    site: &'static str,
+    recorded_position: &'static str,
+    reason: &'static str,
+}
+
+const CONSTRUCTION_EXEMPTIONS: &[ConstructionExemption] = &[
+    ConstructionExemption {
+        site: "example:bench_concurrent:examples/bench_concurrent.rs=>examples/bench_concurrent.rs::run::MetalQwen35State::from_q4_dir()#1",
+        recorded_position: "examples/bench_concurrent.rs:444:27",
+        reason: "run state1 construction is reached only below main's checked live guard; arbitrary call-graph proof is outside this lexical contract",
+    },
+    ConstructionExemption {
+        site: "example:bench_concurrent:examples/bench_concurrent.rs=>examples/bench_concurrent.rs::run::MetalQwen35State::from_q4_dir()#2",
+        recorded_position: "examples/bench_concurrent.rs:474:27",
+        reason: "run state2 construction is reached only below main's checked live guard; arbitrary call-graph proof is outside this lexical contract",
+    },
+    ConstructionExemption {
+        site: "example:bench_embed_quality:examples/bench_embed_quality.rs=>examples/bench_embed_quality.rs::run_bench::QwenModel::from_directory()#1",
+        recorded_position: "examples/bench_embed_quality.rs:136:52",
+        reason: "run_bench QwenModel::from_directory is reached only below main's checked live guard; arbitrary call-graph proof is outside this lexical contract",
+    },
+    ConstructionExemption {
+        site: "bin:backfill_qwen3:src/bin/backfill_qwen3.rs=>src/bin/backfill_qwen3.rs::main::QwenModel::from_directory()#1",
+        recorded_position: "src/bin/backfill_qwen3.rs:37:28",
+        reason: "one-time DB embedding migration over an unbounded row count belongs to a long-running batch process outside the bounded measurement-harness contract",
+    },
+    ConstructionExemption {
+        site: "bin:chat_metal:src/bin/chat_metal.rs=>src/bin/chat_metal.rs::run::MetalQwen35State::from_q4_dir()#1",
+        recorded_position: "src/bin/chat_metal.rs:770:39",
+        reason: "run Q4 initialization belongs to a long-running interactive process outside the bounded measurement-harness contract",
+    },
+    ConstructionExemption {
+        site: "bin:chat_metal:src/bin/chat_metal.rs=>src/bin/chat_metal.rs::run::MetalQwen35State::new()#1",
+        recorded_position: "src/bin/chat_metal.rs:795:39",
+        reason: "run safetensors initialization belongs to a long-running interactive process outside the bounded measurement-harness contract",
+    },
+    ConstructionExemption {
+        site: "bin:lattice:src/bin/lattice/main.rs=>src/bin/lattice/chat.rs::MetalChatBackend::load::MetalQwen35State::from_q4_dir()#1",
+        recorded_position: "src/bin/lattice/chat.rs:53:81",
+        reason: "MetalChatBackend::load belongs to a long-running interactive process outside the bounded measurement-harness contract",
+    },
+    ConstructionExemption {
+        site: "bin:lattice:src/bin/lattice/main.rs=>src/bin/lattice/serve.rs::ModelBackend::spawn_metal::MetalQwen35State::from_q4_dir()#1",
+        recorded_position: "src/bin/lattice/serve.rs:400:81",
+        reason: "ModelBackend::spawn_metal initializes a long-running server worker outside the bounded measurement-harness contract",
+    },
+    ConstructionExemption {
+        site: "bin:lattice_serve:src/bin/lattice_serve.rs=>src/bin/lattice_serve.rs::imp::load_model::MetalQwen35State::from_q4_dir()#1",
+        recorded_position: "src/bin/lattice_serve.rs:1693:47",
+        reason: "load_model Q4 initialization belongs to a long-running server outside the bounded measurement-harness contract",
+    },
+    ConstructionExemption {
+        site: "bin:lattice_serve:src/bin/lattice_serve.rs=>src/bin/lattice_serve.rs::imp::load_model::MetalQwen35State::new()#1",
+        recorded_position: "src/bin/lattice_serve.rs:1713:47",
+        reason: "load_model safetensors initialization belongs to a long-running server outside the bounded measurement-harness contract",
+    },
 ];
 
 fn rust_sources_under(root: &Path) -> Vec<PathBuf> {
@@ -864,6 +890,11 @@ struct StructuredSource {
     parents: Vec<Option<usize>>,
     macro_ranges: Vec<Range<usize>>,
     functions: Vec<FunctionSpec>,
+    /// Token-index body range paired with a `mod::...::Type::method` path,
+    /// for every free function and `impl` method in the file (nested modules
+    /// and `impl` blocks included). Used to name a construction site by the
+    /// program structure enclosing it instead of by source position.
+    function_paths: Vec<(Range<usize>, String)>,
     scopes: Vec<ScopeSpec>,
     file_attributes: Vec<AttributeSpec>,
     test_cfg: bool,
@@ -1143,6 +1174,18 @@ fn inline_modules<'ast>(items: &'ast [syn::Item], modules: &mut Vec<&'ast syn::I
             inline_modules(contents, modules);
         }
     }
+}
+
+/// The receiver type name for an `impl` block, used as a path segment so
+/// methods on different types with the same name (e.g. two `fn load`) do not
+/// collide in a construction site's stable key.
+fn impl_self_type_label(self_ty: &syn::Type) -> String {
+    if let syn::Type::Path(type_path) = self_ty
+        && let Some(segment) = type_path.path.segments.last()
+    {
+        return segment.ident.to_string();
+    }
+    "impl".to_string()
 }
 
 #[derive(Clone)]
@@ -1554,6 +1597,7 @@ impl StructuredSource {
             parents,
             macro_ranges: Vec::new(),
             functions: Vec::new(),
+            function_paths: Vec::new(),
             scopes: Vec::new(),
             file_attributes: Vec::new(),
             test_cfg,
@@ -1562,6 +1606,7 @@ impl StructuredSource {
         };
         parsed.macro_ranges = parsed.find_macro_ranges(&syntax)?;
         parsed.functions = parsed.find_functions(&syntax)?;
+        parsed.function_paths = parsed.find_function_paths(&syntax)?;
         parsed.scopes = parsed.find_scopes(&syntax)?;
         parsed.file_attributes = parsed.inner_attributes_at(0).0;
         parsed.unclassifiable_test_scope = unclassifiable_include(&syntax, test_cfg);
@@ -1756,6 +1801,100 @@ impl StructuredSource {
             });
         }
         Ok(functions)
+    }
+
+    /// Maps a `syn::Block`'s brace pair to the token-index range between
+    /// them, the same convention `FunctionSpec::body` uses.
+    fn token_range_for_block(
+        &self,
+        block: &syn::Block,
+        label: &str,
+    ) -> Result<Range<usize>, String> {
+        let opening_offset = block.brace_token.span.open().byte_range().start;
+        let opening = self
+            .tokens
+            .iter()
+            .position(|token| token.offset == opening_offset && token.is_punct('{'))
+            .ok_or_else(|| {
+                format!(
+                    "{}: function `{label}` body could not be mapped to parsed source",
+                    self.context
+                )
+            })?;
+        let closing = self.pairs[opening].ok_or_else(|| {
+            format!(
+                "{}: function `{label}` has no brace-balanced body",
+                self.context
+            )
+        })?;
+        Ok(opening + 1..closing)
+    }
+
+    fn collect_function_paths(
+        &self,
+        items: &[syn::Item],
+        path: &mut Vec<String>,
+        out: &mut Vec<(Range<usize>, String)>,
+    ) -> Result<(), String> {
+        for item in items {
+            match item {
+                syn::Item::Fn(function) => {
+                    path.push(function.sig.ident.to_string());
+                    let label = path.join("::");
+                    out.push((self.token_range_for_block(&function.block, &label)?, label));
+                    path.pop();
+                }
+                syn::Item::Mod(module) => {
+                    if let Some((_, contents)) = &module.content {
+                        path.push(module.ident.to_string());
+                        self.collect_function_paths(contents, path, out)?;
+                        path.pop();
+                    }
+                }
+                syn::Item::Impl(item_impl) => {
+                    path.push(impl_self_type_label(&item_impl.self_ty));
+                    for impl_item in &item_impl.items {
+                        if let syn::ImplItem::Fn(method) = impl_item {
+                            path.push(method.sig.ident.to_string());
+                            let label = path.join("::");
+                            out.push((self.token_range_for_block(&method.block, &label)?, label));
+                            path.pop();
+                        }
+                    }
+                    path.pop();
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    /// Every free function and `impl` method in the file, keyed by its
+    /// token-index body range and named by the `mod`/`impl` path enclosing
+    /// it (e.g. `MetalChatBackend::load`). Construction sites are named by
+    /// looking up which of these ranges contains them, rather than by their
+    /// source line and column, so a site's identity survives edits that
+    /// shift line numbers without changing the program structure (#1357).
+    fn find_function_paths(
+        &self,
+        syntax: &syn::File,
+    ) -> Result<Vec<(Range<usize>, String)>, String> {
+        let mut out = Vec::new();
+        let mut path = Vec::new();
+        self.collect_function_paths(&syntax.items, &mut path, &mut out)?;
+        Ok(out)
+    }
+
+    /// The innermost `mod`/`impl`/`fn` path enclosing `token`, or
+    /// `"<module scope>"` when the token sits outside every recorded
+    /// function (e.g. in a `static` initializer).
+    fn enclosing_function_path(&self, token: usize) -> String {
+        self.function_paths
+            .iter()
+            .filter(|(range, _)| range.contains(&token))
+            .min_by_key(|(range, _)| range.end.saturating_sub(range.start))
+            .map(|(_, path)| path.clone())
+            .unwrap_or_else(|| "<module scope>".to_string())
     }
 
     fn find_scopes(&self, syntax: &syn::File) -> Result<Vec<ScopeSpec>, String> {
@@ -2433,16 +2572,42 @@ impl StructuredSource {
         self.validate_work_sites(&work_sites, lock_selector, requirement)
     }
 
-    fn construction_sites(&self, range: Range<usize>) -> Result<Vec<usize>, String> {
+    fn construction_sites(
+        &self,
+        range: Range<usize>,
+    ) -> Result<Vec<(usize, CallSelector)>, String> {
         if let Some(reason) = &self.unclassifiable_test_scope {
             return Err(format!("{}: {reason}", self.context));
         }
         let mut sites = Vec::new();
         for selector in CONSTRUCTION_SELECTORS {
-            sites.extend(self.call_sites(range.clone(), *selector, true)?);
+            for token in self.call_sites(range.clone(), *selector, true)? {
+                sites.push((token, *selector));
+            }
         }
-        sites.sort_unstable();
+        sites.sort_unstable_by_key(|(token, _)| *token);
         Ok(sites)
+    }
+
+    /// A key naming a construction site by the program structure enclosing
+    /// it (`mod`/`impl`/`fn` path + constructed selector + an ordinal
+    /// disambiguating repeated calls to the same selector in the same
+    /// function) instead of by source line and column, so an edit that
+    /// shifts line numbers without changing what is constructed or where it
+    /// sits in the call graph does not invalidate an exemption keyed on it
+    /// (#1357).
+    fn stable_construction_key(
+        &self,
+        token: usize,
+        selector: CallSelector,
+        ordinal: usize,
+    ) -> String {
+        format!(
+            "{}::{}::{}#{ordinal}",
+            self.context,
+            self.enclosing_function_path(token),
+            selector.label()
+        )
     }
 
     fn source_site_label(&self, token: usize) -> String {
@@ -3514,17 +3679,73 @@ fn measurement() {
     assert_guard_fixture_rejected(source, "a match-derived guard binding");
 }
 
+/// Accumulates the construction-site inventory for
+/// `metal_qwen35_state_construction_tests_use_function_lifetime_lock_bindings`,
+/// keeping the exemption bookkeeping (discovered/classified/used/moved) in
+/// one place instead of duplicating it across the lib and non-lib scan
+/// branches.
+struct ConstructionTally<'a> {
+    exemptions: &'a BTreeMap<String, &'a ConstructionExemption>,
+    discovered: BTreeSet<String>,
+    classified: BTreeSet<String>,
+    used_exemptions: BTreeSet<String>,
+    moved_exemptions: Vec<String>,
+}
+
+impl<'a> ConstructionTally<'a> {
+    /// Records one discovered construction site under its stable key. When
+    /// the site matches a recorded exemption, classifies it, marks the
+    /// exemption used, checks the position tripwire, and returns `None` (the
+    /// caller must skip the live-lock check). Otherwise returns `Some(site)`
+    /// for the caller to run the live-lock check against.
+    fn record(
+        &mut self,
+        parsed: &StructuredSource,
+        site_prefix: &str,
+        construction: usize,
+        selector: CallSelector,
+        ordinals: &mut BTreeMap<(String, String), usize>,
+    ) -> Option<String> {
+        let function_path = parsed.enclosing_function_path(construction);
+        let counter = ordinals
+            .entry((function_path, selector.label()))
+            .or_insert(0);
+        *counter += 1;
+        let site = format!(
+            "{site_prefix}=>{}",
+            parsed.stable_construction_key(construction, selector, *counter)
+        );
+        self.discovered.insert(site.clone());
+        let Some(exemption) = self.exemptions.get(&site) else {
+            return Some(site);
+        };
+        self.classified.insert(site.clone());
+        self.used_exemptions.insert(site.clone());
+        let current_position = parsed.source_site_label(construction);
+        if current_position != exemption.recorded_position {
+            self.moved_exemptions.push(format!(
+                "{site}: recorded position `{}` no longer matches current position \
+                 `{current_position}`; confirm this exemption still describes the same work \
+                 (this is not a locking violation)",
+                exemption.recorded_position
+            ));
+        }
+        None
+    }
+}
+
 #[test]
 fn metal_qwen35_state_construction_tests_use_function_lifetime_lock_bindings() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let exemptions = CONSTRUCTION_EXEMPTIONS
         .iter()
-        .map(|(path, reason)| {
+        .map(|exemption| {
             assert!(
-                !reason.trim().is_empty(),
-                "construction exemption {path} needs a justification"
+                !exemption.reason.trim().is_empty(),
+                "construction exemption {} needs a justification",
+                exemption.site
             );
-            ((*path).to_string(), *reason)
+            (exemption.site.to_string(), exemption)
         })
         .collect::<std::collections::BTreeMap<_, _>>();
     assert_eq!(
@@ -3533,9 +3754,13 @@ fn metal_qwen35_state_construction_tests_use_function_lifetime_lock_bindings() {
         "construction exemptions must not contain duplicate sites"
     );
 
-    let mut discovered = BTreeSet::new();
-    let mut classified = BTreeSet::new();
-    let mut used_exemptions = BTreeSet::new();
+    let mut tally = ConstructionTally {
+        exemptions: &exemptions,
+        discovered: BTreeSet::new(),
+        classified: BTreeSet::new(),
+        used_exemptions: BTreeSet::new(),
+        moved_exemptions: Vec::new(),
+    };
     let mut violations = Vec::new();
     for target in cargo_targets(manifest_dir, &["bench", "example", "bin", "test", "lib"])
         .unwrap_or_else(|reason| panic!("{reason}"))
@@ -3553,28 +3778,29 @@ fn metal_qwen35_state_construction_tests_use_function_lifetime_lock_bindings() {
         )
         .unwrap_or_else(|reason| panic!("{reason}"));
         for source in &sources {
+            let site_prefix = format!("{}:{}:{}", target.kind, target.name, target_relative);
+            let mut ordinals: BTreeMap<(String, String), usize> = BTreeMap::new();
+
             if target.kind == "lib" {
                 for function in source
                     .parsed
                     .test_functions()
                     .unwrap_or_else(|reason| panic!("{reason}"))
                 {
-                    for construction in source
+                    for (construction, selector) in source
                         .parsed
                         .construction_sites(function.body.clone())
                         .unwrap_or_else(|reason| panic!("{reason}"))
                     {
-                        let source_site = source.parsed.source_site_label(construction);
-                        let site = format!(
-                            "{}:{}:{}=>{}",
-                            target.kind, target.name, target_relative, source_site
-                        );
-                        discovered.insert(site.clone());
-                        if exemptions.contains_key(&site) {
-                            classified.insert(site.clone());
-                            used_exemptions.insert(site);
+                        let Some(site) = tally.record(
+                            &source.parsed,
+                            &site_prefix,
+                            construction,
+                            selector,
+                            &mut ordinals,
+                        ) else {
                             continue;
-                        }
+                        };
                         match source.parsed.validate_work_sites(
                             &[construction],
                             LOCAL_LOCK_SELECTOR,
@@ -3583,7 +3809,7 @@ fn metal_qwen35_state_construction_tests_use_function_lifetime_lock_bindings() {
                             },
                         ) {
                             Ok(()) => {
-                                classified.insert(site);
+                                tally.classified.insert(site);
                             }
                             Err(reason) => violations.push(format!("{site}: {reason}")),
                         }
@@ -3592,29 +3818,27 @@ fn metal_qwen35_state_construction_tests_use_function_lifetime_lock_bindings() {
                 continue;
             }
 
-            for construction in source
+            for (construction, selector) in source
                 .parsed
                 .construction_sites(0..source.parsed.tokens.len())
                 .unwrap_or_else(|reason| panic!("{reason}"))
             {
-                let source_site = source.parsed.source_site_label(construction);
-                let site = format!(
-                    "{}:{}:{}=>{}",
-                    target.kind, target.name, target_relative, source_site
-                );
-                discovered.insert(site.clone());
-                if exemptions.contains_key(&site) {
-                    classified.insert(site.clone());
-                    used_exemptions.insert(site);
+                let Some(site) = tally.record(
+                    &source.parsed,
+                    &site_prefix,
+                    construction,
+                    selector,
+                    &mut ordinals,
+                ) else {
                     continue;
-                }
+                };
                 match source.parsed.validate_work_sites(
                     &[construction],
                     SHARED_LOCK_SELECTOR,
                     GuardRequirement::Lexical,
                 ) {
                     Ok(()) => {
-                        classified.insert(site);
+                        tally.classified.insert(site);
                     }
                     Err(reason) => violations.push(format!("{site}: {reason}")),
                 }
@@ -3627,13 +3851,19 @@ fn metal_qwen35_state_construction_tests_use_function_lifetime_lock_bindings() {
         "MetalQwen35State construction sites without a live shared-lock binding:\n{}",
         violations.join("\n")
     );
+    assert!(
+        tally.moved_exemptions.is_empty(),
+        "construction exemptions recorded a position that no longer matches (not a locking \
+         violation — update recorded_position once the move is confirmed intentional):\n{}",
+        tally.moved_exemptions.join("\n")
+    );
 
     let expected_exemptions = exemptions.keys().cloned().collect::<BTreeSet<_>>();
     assert_eq!(
-        used_exemptions, expected_exemptions,
+        tally.used_exemptions, expected_exemptions,
         "construction exemptions must identify current exact sites"
     );
-    assert_construction_inventory_classified(&discovered, &classified);
+    assert_construction_inventory_classified(&tally.discovered, &tally.classified);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1357.

The Metal measurement-lock contract recorded its construction-site exemptions by source position.
An edit anywhere above an exempted site shifted its line number, the recorded position stopped
matching, and the contract reported the site as a locking violation — for a file whose locking had
not changed at all.

The repair for that false firing is to renumber the exemptions until the suite is green, which is
also exactly what silences a real violation. A guard whose false-positive repair and whose
suppression are the same motion cannot be trusted the next time it fires, so its false-firing rate
is a soundness property rather than an ergonomics complaint.

## Change

Exemptions are now keyed on program structure — the enclosing item path and the construction call,
disambiguated by occurrence — instead of on `file:line`. Position is still recorded, but it is
demoted to advisory: when the stable key matches and only the position has moved, the contract
reports a distinct "moved position" notice that names the old and new positions and says in its own
text that it is not a locking violation. A site whose stable key does not resolve is still a
violation, and the top-level assertion is unchanged.

One file, `crates/inference/tests/metal_measurement_lock_contract.rs`. No library source is touched.

## Verification

53/53 contract tests pass.

Two mutation arms, both run against the built harness rather than reasoned about:

- **A real violation is still caught.** An unguarded `MetalQwen35State::from_q4_dir` call added in a
  new free function outside any lock scope fails the contract, and the failure names the offending
  item path and reports that no live shared-lock binding encloses it. Reverted byte-identically
  afterward, confirmed with `git status --porcelain`.
- **A pure position shift is no longer a violation, and that arm was first shown to fail against the
  pre-fix harness.** Inserting blank lines above an exempted site fails as a locking violation on
  the old implementation and, with the same mutation still in place, produces only the moved-position
  notice on the new one. Pointing the arm at the pre-fix code first is what makes it evidence about
  the change rather than about the test.

## bench-compare disposition

Structural waiver, and the population it searched is stated rather than assumed.

`crates/inference` declares 24 `[[bench]]` targets. None of them can reach this change, and the
reason is not a call-path argument that could be wrong about reachability: the changed file is an
integration-test target under `tests/`, which Cargo compiles as its own crate. A bench target is
likewise its own crate and links the library, not the test crate, so no bench target can name a
symbol defined here regardless of what any call graph looks like. The library and its public surface
are unchanged by this diff, and the diff's build inputs — manifest, dependency and lockfile versions,
feature set, profile, and the bench target definitions themselves — are identical between base and
head, so there is no build-input path by which it could move a benchmark either.

Residual risk, stated because an unreachable change is unmeasured rather than safe: this waiver says
no benchmark executes the changed code. It says nothing about whether the contract's own runtime in
CI moved, which is not something the bench suite measures in either direction.
