### PR TITLE
fix(inference): bound the grammar nullability walk without a per-call allocation

### DIFF
--- a/crates/inference/src/grammar/pda.rs
+++ b/crates/inference/src/grammar/pda.rs
@@ -480,7 +480,6 @@ fn is_accepting(state: &GrammarState, grammar: &CompiledGrammar) -> bool {
         if frame.alt_idx >= rule.alts.len() {
             return false;
         }
-        let alt = &rule.alts[frame.alt_idx];
         // Non-top frames: the child frame is handling the symbol at sym_pos,
         // so check nullable from sym_pos + 1.
         // Top frame: check nullable from sym_pos itself.
@@ -489,60 +488,139 @@ fn is_accepting(state: &GrammarState, grammar: &CompiledGrammar) -> bool {
         } else {
             frame.sym_pos + 1
         };
-        if !remaining_is_nullable(
-            grammar,
-            alt,
-            check_from,
-            &mut std::collections::HashSet::new(),
-        ) {
+        if !remaining_is_nullable(grammar, frame.rule_id, frame.alt_idx, check_from) {
             return false;
         }
     }
     true
 }
 
-/// Returns true if the symbols `alt[pos..]` can all derive the empty string.
+/// Returns true if `grammar.rules[rule_id].alts[alt_idx][pos..]` can derive
+/// the empty string, i.e. every remaining symbol is nullable.
+///
+/// This mirrors the natural mutually-recursive definition (an alt is nullable
+/// iff every remaining symbol is nullable; a non-terminal is nullable iff
+/// *some* alternative of the rule it names is nullable) but walks an explicit,
+/// heap-allocated worklist (`stack`) instead of native call frames. A cyclic
+/// grammar is bounded by the per-path `visited` guard below, same as before;
+/// an *acyclic* grammar is bounded by the number of distinct rules it can
+/// reference on one path (at most `grammar.rules.len()`), since `visited`
+/// forbids revisiting a rule id — either way the frames live on `stack`, not
+/// the native stack, so neither shape can overflow it. `MAX_PDA_DEPTH` is a
+/// different bound (the live PDA execution stack) and does not apply here.
 fn remaining_is_nullable(
     grammar: &CompiledGrammar,
-    alt: &[Symbol],
+    rule_id: usize,
+    alt_idx: usize,
     pos: usize,
-    visited: &mut std::collections::HashSet<usize>,
 ) -> bool {
-    for sym in &alt[pos..] {
-        match sym {
-            Symbol::Terminal(_) | Symbol::AnyByte => return false,
-            Symbol::NonTerminal(rid) => {
-                if !visited.insert(*rid) {
-                    // Already checking this rule (cycle): conservatively non-nullable.
-                    return false;
+    #[derive(Clone, Copy)]
+    enum Frame {
+        /// Checking whether `grammar.rules[rule_id].alts[alt_idx][pos..]` is nullable.
+        Alt {
+            rule_id: usize,
+            alt_idx: usize,
+            pos: usize,
+        },
+        /// Checking whether any of `grammar.rules[rule_id].alts[alt_idx..]` is nullable.
+        Rule { rule_id: usize, alt_idx: usize },
+    }
+
+    let mut visited: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let mut stack = vec![Frame::Alt {
+        rule_id,
+        alt_idx,
+        pos,
+    }];
+    // The boolean result of the frame that just finished, to be consumed by
+    // the frame now on top of `stack`.
+    let mut pending: Option<bool> = None;
+
+    loop {
+        let Some(&frame) = stack.last() else {
+            return pending.unwrap_or(true);
+        };
+        match frame {
+            Frame::Alt {
+                rule_id,
+                alt_idx,
+                mut pos,
+            } => {
+                let alt = &grammar.rules[rule_id].alts[alt_idx];
+                if let Some(sub) = pending.take() {
+                    // Resuming after the NonTerminal at `pos` was checked.
+                    if let Symbol::NonTerminal(rid) = alt[pos] {
+                        visited.remove(&rid);
+                    }
+                    if !sub {
+                        stack.pop();
+                        pending = Some(false);
+                        continue;
+                    }
+                    pos += 1;
                 }
-                if !rule_is_nullable(grammar, *rid, visited) {
-                    visited.remove(rid);
-                    return false;
+                match alt.get(pos) {
+                    None => {
+                        stack.pop();
+                        pending = Some(true);
+                    }
+                    Some(Symbol::Terminal(_)) | Some(Symbol::AnyByte) => {
+                        stack.pop();
+                        pending = Some(false);
+                    }
+                    Some(Symbol::NonTerminal(rid)) => {
+                        let rid = *rid;
+                        // Persist the (possibly advanced) `pos` before descending.
+                        *stack.last_mut().unwrap() = Frame::Alt {
+                            rule_id,
+                            alt_idx,
+                            pos,
+                        };
+                        if !visited.insert(rid) {
+                            // Already checking this rule on this path (cycle):
+                            // conservatively non-nullable.
+                            stack.pop();
+                            pending = Some(false);
+                        } else {
+                            stack.push(Frame::Rule {
+                                rule_id: rid,
+                                alt_idx: 0,
+                            });
+                        }
+                    }
                 }
-                visited.remove(rid);
+            }
+            Frame::Rule {
+                rule_id,
+                mut alt_idx,
+            } => {
+                if let Some(sub) = pending.take() {
+                    if sub {
+                        stack.pop();
+                        pending = Some(true);
+                        continue;
+                    }
+                    alt_idx += 1;
+                }
+                let Some(rule) = grammar.rules.get(rule_id) else {
+                    stack.pop();
+                    pending = Some(false);
+                    continue;
+                };
+                if alt_idx >= rule.alts.len() {
+                    stack.pop();
+                    pending = Some(false);
+                } else {
+                    *stack.last_mut().unwrap() = Frame::Rule { rule_id, alt_idx };
+                    stack.push(Frame::Alt {
+                        rule_id,
+                        alt_idx,
+                        pos: 0,
+                    });
+                }
             }
         }
     }
-    true
-}
-
-/// Returns true if rule `rule_id` has at least one alternative that can
-/// derive the empty string.
-fn rule_is_nullable(
-    grammar: &CompiledGrammar,
-    rule_id: usize,
-    visited: &mut std::collections::HashSet<usize>,
-) -> bool {
-    if rule_id >= grammar.rules.len() {
-        return false;
-    }
-    for alt in &grammar.rules[rule_id].alts {
-        if remaining_is_nullable(grammar, alt, 0, visited) {
-            return true;
-        }
-    }
-    false
 }
 
 /// Simulate advancing the PDA from `state` by consuming all bytes of `token`.
@@ -935,6 +1013,42 @@ mod tests {
             .expect("bounded-stack regression thread spawns")
             .join()
             .expect("iterative fallback must not overflow the bounded stack");
+    }
+
+    /// A long *acyclic* chain of distinct nullable wrapper rules has no cycle
+    /// for `remaining_is_nullable`'s `visited` guard to catch, so unlike the
+    /// cyclic case its only historical bound was call-frame depth.
+    /// `is_accepting` runs on `initial_grammar_state`, before any byte is
+    /// consumed — a single-frame state referencing the head of such a chain
+    /// must not overflow the native stack even though `state.stack.len()`
+    /// never leaves 1 (the nullability walk descends the *static* rule graph,
+    /// not the PDA execution stack `MAX_PDA_DEPTH` bounds).
+    #[test]
+    fn deeply_nested_nullable_chain_accepts_on_bounded_stack() {
+        let depth = MAX_PDA_DEPTH;
+        let mut rules = Vec::with_capacity(depth);
+        for rule_id in 0..depth - 1 {
+            rules.push(Rule {
+                name: String::new(),
+                alts: vec![vec![Symbol::NonTerminal(rule_id + 1)]],
+            });
+        }
+        // The chain's tail is epsilon, so the whole chain is nullable.
+        rules.push(Rule {
+            name: String::new(),
+            alts: vec![vec![]],
+        });
+        let grammar = CompiledGrammar { rules };
+
+        std::thread::Builder::new()
+            .stack_size(64 * 1024)
+            .spawn(move || {
+                let state = initial_grammar_state(&grammar);
+                assert!(state.is_complete());
+            })
+            .expect("bounded-stack regression thread spawns")
+            .join()
+            .expect("iterative nullability walk must not overflow the bounded stack");
     }
 
     fn nested_terminal_grammar(depth: usize, terminal: u8) -> CompiledGrammar {

--- a/crates/inference/src/grammar/pda.rs
+++ b/crates/inference/src/grammar/pda.rs
@@ -495,6 +495,43 @@ fn is_accepting(state: &GrammarState, grammar: &CompiledGrammar) -> bool {
     true
 }
 
+#[derive(Clone, Copy)]
+enum NullableFrame {
+    /// Checking whether `grammar.rules[rule_id].alts[alt_idx][pos..]` is nullable.
+    Alt {
+        rule_id: usize,
+        alt_idx: usize,
+        pos: usize,
+    },
+    /// Checking whether any of `grammar.rules[rule_id].alts[alt_idx..]` is nullable.
+    Rule { rule_id: usize, alt_idx: usize },
+}
+
+std::thread_local! {
+    /// Per-thread worklist + cycle-guard for `remaining_is_nullable`, reused
+    /// across calls instead of allocated fresh each time.
+    ///
+    /// `is_accepting` calls this function once per PDA stack frame, and
+    /// `is_accepting` itself runs after every accepted byte (`advance_byte`)
+    /// and at grammar-state construction (`initial_grammar_state`) — a
+    /// per-candidate-token hot path (see `grammar_mask_bench`). A fresh
+    /// `Vec`/`HashSet` per call put a guaranteed heap allocation on that path
+    /// even for the overwhelmingly common shallow (depth-1, no `NonTerminal`)
+    /// case. Reusing thread-local buffers keeps the walk itself unchanged —
+    /// still an explicit heap-backed worklist, never native recursion — while
+    /// making the allocation one-time-per-thread instead of one-time-per-call:
+    /// `clear()` retains capacity, so after the first call reaches a given
+    /// depth, subsequent calls (including calls as deep as
+    /// `deeply_nested_nullable_chain_accepts_on_bounded_stack`'s
+    /// `MAX_PDA_DEPTH`-length chain) reuse that capacity with zero further
+    /// allocation. `remaining_is_nullable` does not call itself or otherwise
+    /// re-enter this function while a borrow is live, so `borrow_mut` never
+    /// contends within one thread; each thread gets its own buffers, so
+    /// parallel-beam grammar tracking across threads never contends either.
+    static NULLABLE_SCRATCH: std::cell::RefCell<(Vec<NullableFrame>, std::collections::HashSet<usize>)> =
+        std::cell::RefCell::new((Vec::new(), std::collections::HashSet::new()));
+}
+
 /// Returns true if `grammar.rules[rule_id].alts[alt_idx][pos..]` can derive
 /// the empty string, i.e. every remaining symbol is nullable.
 ///
@@ -514,113 +551,108 @@ fn remaining_is_nullable(
     alt_idx: usize,
     pos: usize,
 ) -> bool {
-    #[derive(Clone, Copy)]
-    enum Frame {
-        /// Checking whether `grammar.rules[rule_id].alts[alt_idx][pos..]` is nullable.
-        Alt {
-            rule_id: usize,
-            alt_idx: usize,
-            pos: usize,
-        },
-        /// Checking whether any of `grammar.rules[rule_id].alts[alt_idx..]` is nullable.
-        Rule { rule_id: usize, alt_idx: usize },
-    }
+    use NullableFrame as Frame;
 
-    let mut visited: std::collections::HashSet<usize> = std::collections::HashSet::new();
-    let mut stack = vec![Frame::Alt {
-        rule_id,
-        alt_idx,
-        pos,
-    }];
-    // The boolean result of the frame that just finished, to be consumed by
-    // the frame now on top of `stack`.
-    let mut pending: Option<bool> = None;
+    NULLABLE_SCRATCH.with(|scratch| {
+        let mut scratch = scratch.borrow_mut();
+        let (stack, visited) = &mut *scratch;
+        stack.clear();
+        visited.clear();
+        stack.push(Frame::Alt {
+            rule_id,
+            alt_idx,
+            pos,
+        });
+        // The boolean result of the frame that just finished, to be consumed
+        // by the frame now on top of `stack`.
+        let mut pending: Option<bool> = None;
 
-    loop {
-        let Some(&frame) = stack.last() else {
-            return pending.unwrap_or(true);
-        };
-        match frame {
-            Frame::Alt {
-                rule_id,
-                alt_idx,
-                mut pos,
-            } => {
-                let alt = &grammar.rules[rule_id].alts[alt_idx];
-                if let Some(sub) = pending.take() {
-                    // Resuming after the NonTerminal at `pos` was checked.
-                    if let Symbol::NonTerminal(rid) = alt[pos] {
-                        visited.remove(&rid);
-                    }
-                    if !sub {
-                        stack.pop();
-                        pending = Some(false);
-                        continue;
-                    }
-                    pos += 1;
-                }
-                match alt.get(pos) {
-                    None => {
-                        stack.pop();
-                        pending = Some(true);
-                    }
-                    Some(Symbol::Terminal(_)) | Some(Symbol::AnyByte) => {
-                        stack.pop();
-                        pending = Some(false);
-                    }
-                    Some(Symbol::NonTerminal(rid)) => {
-                        let rid = *rid;
-                        // Persist the (possibly advanced) `pos` before descending.
-                        *stack.last_mut().unwrap() = Frame::Alt {
-                            rule_id,
-                            alt_idx,
-                            pos,
-                        };
-                        if !visited.insert(rid) {
-                            // Already checking this rule on this path (cycle):
-                            // conservatively non-nullable.
+        loop {
+            let Some(&frame) = stack.last() else {
+                return pending.unwrap_or(true);
+            };
+            match frame {
+                Frame::Alt {
+                    rule_id,
+                    alt_idx,
+                    mut pos,
+                } => {
+                    let alt = &grammar.rules[rule_id].alts[alt_idx];
+                    if let Some(sub) = pending.take() {
+                        // Resuming after the NonTerminal at `pos` was checked.
+                        if let Symbol::NonTerminal(rid) = alt[pos] {
+                            visited.remove(&rid);
+                        }
+                        if !sub {
                             stack.pop();
                             pending = Some(false);
-                        } else {
-                            stack.push(Frame::Rule {
-                                rule_id: rid,
-                                alt_idx: 0,
-                            });
+                            continue;
+                        }
+                        pos += 1;
+                    }
+                    match alt.get(pos) {
+                        None => {
+                            stack.pop();
+                            pending = Some(true);
+                        }
+                        Some(Symbol::Terminal(_)) | Some(Symbol::AnyByte) => {
+                            stack.pop();
+                            pending = Some(false);
+                        }
+                        Some(Symbol::NonTerminal(rid)) => {
+                            let rid = *rid;
+                            // Persist the (possibly advanced) `pos` before descending.
+                            *stack.last_mut().unwrap() = Frame::Alt {
+                                rule_id,
+                                alt_idx,
+                                pos,
+                            };
+                            if !visited.insert(rid) {
+                                // Already checking this rule on this path (cycle):
+                                // conservatively non-nullable.
+                                stack.pop();
+                                pending = Some(false);
+                            } else {
+                                stack.push(Frame::Rule {
+                                    rule_id: rid,
+                                    alt_idx: 0,
+                                });
+                            }
                         }
                     }
                 }
-            }
-            Frame::Rule {
-                rule_id,
-                mut alt_idx,
-            } => {
-                if let Some(sub) = pending.take() {
-                    if sub {
-                        stack.pop();
-                        pending = Some(true);
-                        continue;
+                Frame::Rule {
+                    rule_id,
+                    mut alt_idx,
+                } => {
+                    if let Some(sub) = pending.take() {
+                        if sub {
+                            stack.pop();
+                            pending = Some(true);
+                            continue;
+                        }
+                        alt_idx += 1;
                     }
-                    alt_idx += 1;
-                }
-                let Some(rule) = grammar.rules.get(rule_id) else {
-                    stack.pop();
-                    pending = Some(false);
-                    continue;
-                };
-                if alt_idx >= rule.alts.len() {
-                    stack.pop();
-                    pending = Some(false);
-                } else {
-                    *stack.last_mut().unwrap() = Frame::Rule { rule_id, alt_idx };
-                    stack.push(Frame::Alt {
-                        rule_id,
-                        alt_idx,
-                        pos: 0,
-                    });
+                    let Some(rule) = grammar.rules.get(rule_id) else {
+                        stack.pop();
+                        pending = Some(false);
+                        continue;
+                    };
+                    if alt_idx >= rule.alts.len() {
+                        stack.pop();
+                        pending = Some(false);
+                    } else {
+                        *stack.last_mut().unwrap() = Frame::Rule { rule_id, alt_idx };
+                        stack.push(Frame::Alt {
+                            rule_id,
+                            alt_idx,
+                            pos: 0,
+                        });
+                    }
                 }
             }
         }
-    }
+    })
 }
 
 /// Simulate advancing the PDA from `state` by consuming all bytes of `token`.


### PR DESCRIPTION
Fixes #1359.

`is_accepting` decided whether a grammar state was accepting by walking the rule-reference graph
through mutual recursion between `remaining_is_nullable` and `rule_is_nullable`, one native stack
frame per `NonTerminal` crossed. The only bound was a per-path `HashSet` cycle guard, which rejects
a rule id repeated on the current path and does nothing at all for a chain of distinct ids. A
grammar of the form `R[i] ::= R[i+1]` therefore recursed once per rule and overflowed the thread
stack. `MAX_PDA_DEPTH` does not cover this: it is checked against the live PDA execution stack in
`try_advance_stack`, which is a different quantity from the depth of the static rule graph.

This is on the byte-advance path, not a corner case: `advance_byte` calls `is_accepting` after every
accepted byte, and `initial_grammar_state` calls it once before any byte is consumed.

## Two commits, and why the second exists

The first commit removes the native-stack dependency by rewriting the two mutually recursive
functions as one iterative walk over an explicit worklist. Because the cycle guard already forbids
revisiting a rule id, the number of live frames on any path is bounded by `grammar.rules.len()`, so
moving the worklist off the call stack removes the overflow outright rather than capping it with a
tuned constant.

That commit is correct and it was measurably expensive. It opened with `vec![first_frame]`, which
allocates unconditionally, on a function that runs per accepted byte and per candidate token through
`simulate_token`. Measured on a dedicated measurement machine against this branch's parent, it cost:

| | `grammar_mask/state_sparse_context_rechecks` |
|---|---|
| run 1 | `[+16.770% +17.370% +17.970%]` (p = 0.10) |
| run 2 | `[+16.209% +16.338% +16.468%]` (p = 0.10) |

Criterion labelled both runs "No change in performance detected", because its p sat just above the
threshold. The label answers a threshold question; it is not the measurement. Both intervals lie
entirely above zero, two independent runs agree to about a percent, and there is a mechanism, so the
regression was treated as real.

The second commit gives the cost back by reusing a thread-local scratch buffer for the worklist and
the visited set, so the steady-state per-call path allocates nothing once capacity is reached. No new
external dependency: `thread_local!` and `RefCell` are both `std`. A `smallvec`-style inline-capacity
worklist would also have worked and was rejected for adding a dependency the in-tree option did not
need; threading a caller-owned buffer through `is_accepting`, `initial_grammar_state` and
`advance_byte` was rejected as widening three public-ish signatures for what is an implementation
detail of one leaf function.

## bench-compare disposition

Measured. No structural waiver is available: `crates/inference` declares 24 bench targets, and
`grammar_mask_bench` carries no `required-features` gate and reaches the changed code three ways —
`GrammarEngine::new` compiles a grammar through `initial_grammar_state`, `engine.advance` reaches
`advance_byte`, and `mask_logits`'s context-recheck path re-enters `is_accepting` per candidate token
inside the timed loop.

Net effect of both commits, base `b16d26f24a` (this branch's parent) against head:

| group | base | head | change |
|---|---|---|---|
| `grammar_mask/state_sparse_context_rechecks` | 21.217 µs | 20.831 µs | `[-2.0262% -1.8951% -1.7638%]` (p = 0.07) |

Run conditions for that table: idle 94.14% before the base arm, 96.94% between arms, 97.12% after
the head arm. A preceding run of the same comparison measured `[-2.8213% -2.3473% -1.8699%]` and
agrees on both direction and magnitude; it is not the quoted table because its after-head idle probe
read 84.23%, and a figure whose own conditions block records ambient load is not the one to put in a
description. The load in that run would have made the head arm slower, so it biases against the
conclusion rather than toward it.

The regression is gone. The small negative reading is at the edge of significance and is not claimed
as a speedup: the plausible mechanism is that the thread-local also amortizes the `HashSet`
allocation that the pre-change code performed per call, but that is an explanation offered for a
sub-3% shift, not a result.

Coverage limit, stated because it bounds what these numbers prove: the bench fixture's grammar is
flat, with no `NonTerminal` symbols, so this group exercises the shallow path where the per-call
allocation dominates. It does not exercise the deep chain that motivates the issue. The deep case is
covered by the regression test below, not by a benchmark.

## Test

`deeply_nested_nullable_chain_accepts_on_bounded_stack` builds a chain of `MAX_PDA_DEPTH` distinct
rules with the last one nullable and calls `initial_grammar_state` on a 64 KiB thread, reusing the
bounded-stack construction the neighbouring `deeply_nested_parent_fallback_accepts_on_bounded_stack`
test already uses.

Mutation arm, predicted before running: with the fix reverted and the test kept, it overflows the
bounded stack and aborts the process rather than reporting a clean failure, since a Rust stack
overflow is a guard-page abort and not a catchable panic. That is what happened — `fatal runtime
error: stack overflow, aborting`, SIGABRT — while the other 218 `grammar::` tests stayed green.
Restored byte-identically afterward.

`cargo test -p lattice-inference --lib grammar::` reports 219 passed. `cargo clippy -p
lattice-inference --all-targets -- -D warnings` clean, `cargo fmt --check` clean.
