### PR TITLE
bench(inference): add a direct Metal prefill bench group

### DIFF
--- a/crates/inference/benches/metal_decode_bench.rs
+++ b/crates/inference/benches/metal_decode_bench.rs
@@ -1,16 +1,20 @@
-//! Metal Qwen3.5 decode throughput benchmark.
+//! Metal Qwen3.5 decode and prefill throughput benchmarks.
 //!
-//! Measures single-token decode tok/s on M2 Max with both QuaRot Q4 and naive Q8 weights.
+//! Measures single-token decode tok/s on M2 Max with both QuaRot Q4 and naive Q8 weights, and
+//! Metal prefill latency directly (prompt-length parameterized) rather than diluted inside
+//! `metal_decode_q4`'s `forward_step` iterations, where the one-time prefill cost sits below
+//! the decode group's per-token noise floor (#1301).
 //! Requires:
 //! - Q4 model at `~/.lattice/models/qwen3.5-0.8b-q4-quarot/`
 //! - Q8/safetensors at `~/.lattice/models/qwen3.5-0.8b/`
 //! - tokenizer at `~/.lattice/models/qwen3.5-0.8b/tokenizer.json`
 //!
 //! Run: `cargo bench -p lattice-inference --features metal-gpu,f16 -- metal_decode`
+//! Run (prefill only): `cargo bench -p lattice-inference --features metal-gpu,f16 -- metal_prefill`
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 use lattice_inference::forward::metal_qwen35::{LoraLayerData, MetalQwen35State};
@@ -285,5 +289,87 @@ fn bench_metal_decode_q8(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_metal_decode_q4, bench_metal_decode_q8);
+/// Prompt lengths swept by `metal_prefill_q4`, matching issue #1301's suggestion.
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+const PREFILL_PROMPT_LENGTHS: &[usize] = &[128, 512, 1024];
+
+/// Deterministic in-vocab token ids; content doesn't matter for a latency bench, only
+/// that every id is a valid embedding row (vocab_size is in the hundreds of thousands,
+/// so a small fixed range comfortably avoids the tokenizer's special-token ids near 0).
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+fn synthetic_prompt_tokens(len: usize) -> Vec<u32> {
+    (0..len as u32).map(|i| 1000 + (i % 4096)).collect()
+}
+
+fn bench_metal_prefill_q4(c: &mut Criterion) {
+    #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
+    {
+        eprintln!("SKIP: metal_prefill bench requires macOS + metal-gpu feature");
+        let _ = c;
+        return;
+    }
+
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+    {
+        let (mut state, _cfg) = match load_q4_state() {
+            Ok(loaded) => loaded,
+            Err(error @ Q4SetupError::ModelDirectoryMissing(_)) => {
+                eprintln!(
+                    "SKIP: {error}\n\
+                     (tokenizer expected at ~/.lattice/models/qwen3.5-0.8b/tokenizer.json)"
+                );
+                return;
+            }
+            // Same absent-vs-broken classification as bench_metal_decode_q4 above.
+            Err(error @ (Q4SetupError::HomeUnset | Q4SetupError::TokenizerMissing(_))) => {
+                eprintln!("SKIP: {error}");
+                return;
+            }
+            Err(error @ (Q4SetupError::Config(_) | Q4SetupError::State(_))) => {
+                panic!("Q4 setup failed on a present model: {error}");
+            }
+        };
+
+        let mut group = c.benchmark_group("metal_prefill_q4");
+        group.warm_up_time(Duration::from_secs(2));
+        group.measurement_time(Duration::from_secs(8));
+        group.sample_size(20);
+
+        for &prompt_len in PREFILL_PROMPT_LENGTHS {
+            let prompt_tokens = synthetic_prompt_tokens(prompt_len);
+            group.throughput(Throughput::Elements(prompt_len as u64));
+            group.bench_with_input(
+                BenchmarkId::new("forward_prefill", prompt_len),
+                &prompt_tokens,
+                |b, tokens| {
+                    // iter_custom keeps state.reset_state() (fresh KV cache + initial
+                    // GDN state) and Instant::now() bracketing outside the callback
+                    // Criterion measures: only forward_prefill itself is timed, so a
+                    // leaked cache/state from a prior iteration or from the one-time
+                    // model load above cannot show up in the reported duration.
+                    b.iter_custom(|iters| {
+                        let mut elapsed = Duration::ZERO;
+                        for _ in 0..iters {
+                            state.reset_state();
+                            let start = Instant::now();
+                            let logits = state.forward_prefill(std::hint::black_box(tokens));
+                            elapsed += start.elapsed();
+                            std::hint::black_box(logits);
+                        }
+                        elapsed
+                    });
+                },
+            );
+        }
+
+        group.finish();
+    }
+}
+
+criterion_group!(
+    benches,
+    bench_metal_decode_q4,
+    bench_metal_decode_q8,
+    bench_metal_prefill_q4
+);
 criterion_main!(benches);


### PR DESCRIPTION
Closes #1301.

There was no bench group that timed Metal prefill directly. Prefill cost was only ever observed
folded into end-to-end decode measurements, where a prefill regression is diluted by the decode
tokens that follow it and can sit under the noise floor entirely.

This adds `metal_prefill_q4` to `crates/inference/benches/metal_decode_bench.rs`, parameterized by
prompt length 128/512/1024, timing `forward_prefill` on the QuaRot Q4 path.

Selecting it:

```
make bench-compare \
  BENCHES_INFERENCE=metal_decode_bench \
  CARGO_FEATURES_INFERENCE=metal-gpu,f16 \
  BENCH_GROUPS_INFERENCE=metal_prefill_q4
```

`BENCH_GROUPS_INFERENCE` is a Criterion filter applied within whichever binary `BENCHES_INFERENCE`
names, and that defaults to `elementwise_cpu_bench` with no features. So the group filter alone does
not reach this group; the binary and feature overrides above are both required. That is the same
override pattern the existing `metal_decode_q4` and `metal_decode_q8` groups already need, not a new
requirement introduced here.

## Why this extends the existing bench file rather than adding a new one

Two mechanisms in the repo enumerate the bench surface, and extending an already-classified target
satisfies both without amending either:

- `scripts/bench-measurements.toml` globs `crates/*/benches/*.rs` and the supervision test fails
  closed on any unclassified path. `metal_decode_bench.rs` is already classified there; a new file
  would need a new entry.
- `crates/inference/tests/metal_measurement_lock_contract.rs` requires every `MetalQwen35State`
  construction site to sit under a live `gpu_test_lock()` binding or carry a justified exemption.
  The new group calls the file's existing `load_q4_state()` helper, whose construction site is
  already lock-guarded, so it adds zero new construction sites and needs no exemption. That contract
  file is unmodified by this change.

## Instrument correctness

The group uses `iter_custom` rather than `iter`, so the timed span is exactly `forward_prefill`.
Within each repetition, `reset_state()` runs before the clock starts, which means every sample
measures prefill from a clean KV cache and freshly constructed GDN state rather than from whatever
the previous repetition left behind. Model load, tokenizer resolution, and config parse happen once,
before the group is created, so they are outside every sample at all three prompt lengths. Prompt
token ids are precomputed, so no tokenization runs inside the timed closure.

The reset path itself is not new code introduced here: the existing decode group already calls the
same `reset_state()` at its token wraparound.

## bench-compare disposition

No A/B table, and this is not a structural waiver over runtime source — it is the narrower case that
the entire diff lives inside a bench target's own definition.

Every hunk is either in the file's header comments and imports, in the `criterion_group!`
registration line, or in the newly added `bench_metal_prefill_q4` function appended after the
existing ones. No hunk lands inside `bench_metal_decode_q4` or `bench_metal_decode_q8`, so the code
those two groups time is byte-identical to main and their numbers are not affected by this change.
The target is `required-features = ["metal-gpu", "f16"]`-gated and is not among the targets the
default `bench-compare` invocation builds, so the default A/B has nothing to say about it either way.

The new group's own numbers are deliberately not reported here. This PR adds the instrument; the
first measured run belongs on the measurement machine, and reporting a figure taken anywhere else
would be the exact failure the group exists to prevent.

## Residual risks

The sample count and measurement time for the new group (`sample_size = 20`, `measurement_time = 8s`)
were chosen on the reasoning that prefill over up to 1024 tokens does far more work per call than a
single decode token and should resolve with fewer repeats. That is a judgment, not a calibration
against a same-machine A/A null. If the first paired run shows a wide interval, the correction is to
raise those values in place.

Only the Q4 path has a prefill group; the Q8 path still has decode coverage only.

Prompt content is synthetic and deterministic per length, matching what the existing decode groups
already use. If this checkpoint's forward path has content-dependent dispatch cost, the synthetic
prompt may not represent typical routing cost. That does not affect the timed-region correctness
above, which is a property of where the clock starts and stops.

## Checks

`cargo bench --no-run -p lattice-inference --bench metal_decode_bench --features metal-gpu,f16`
builds, and the built binary's `--list` shows the three new ids
(`metal_prefill_q4/forward_prefill/{128,512,1024}`) alongside the unchanged decode ids.
`cargo test -p lattice-inference --test metal_measurement_lock_contract` passes.
`cargo fmt --check` is clean.

One note on lint coverage worth stating rather than leaving implicit: `cargo clippy -p
lattice-inference --all-targets -- -D warnings` does not lint this file, because the target is
feature-gated off by default and cargo silently skips it. The command that actually covers the new
code is `cargo clippy -p lattice-inference --all-targets --features metal-gpu,f16 -- -D warnings`,
which is also clean.
