### PR TITLE
fix(inference): prefill the MTP layer cache so the first draft attends over the prompt

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -1621,6 +1621,14 @@ mod inner {
         pub(crate) mtp: Option<MetalMtpSession>,
         pub(crate) gdn_checkpoints: Option<MetalGdnCheckpointPool>,
         pub(crate) last_pre_final_hidden: Vec<f32>,
+        /// Raw (pre-final-RMSNorm) target hidden states captured by
+        /// `forward_prefill_batched_chunk` for every prompt position in the most
+        /// recent `forward_prefill`/`forward_prefill_all_logits` call, laid out as
+        /// `n * hidden_size` f32 values in prompt order (#1340). Cleared at the top
+        /// of `forward_prefill_impl` and drained by `mtp_prefill`, which rebuilds
+        /// the MTP draft head's KV cache from it so the first draft attends to the
+        /// prompt prefix instead of a single row.
+        pub(crate) mtp_prefill_hidden: Vec<f32>,
         /// Opt-in: when set, every forward path that applies the final RMSNorm
         /// also copies the last token's normed hidden state into
         /// `activations.final_hidden`. Off by default so the decode loop pays
@@ -3409,6 +3417,7 @@ mod inner {
                 mtp,
                 gdn_checkpoints,
                 last_pre_final_hidden: vec![0.0f32; hidden],
+                mtp_prefill_hidden: Vec::new(),
                 capture_final_hidden: false,
                 final_hidden_captured: std::sync::atomic::AtomicBool::new(false),
                 position: 0,
@@ -5452,6 +5461,232 @@ mod inner {
             }
         }
 
+        /// Rebuilds the MTP draft head's KV cache from the prompt just processed by
+        /// `forward_prefill`/`forward_prefill_all_logits` (#1340).
+        ///
+        /// Without this, `reset_state` zeroes the MTP cache and the only prefill on
+        /// the Metal path fills the *target* model's cache, so the first
+        /// `mtp_forward_one` call of a generation dispatches attention with
+        /// `cache_len = 1` — the draft can only ever attend to the row it just
+        /// wrote, independent of the prompt.
+        ///
+        /// `mtp_forward_one(pending_token, pos)` pairs `pending_token`'s embedding
+        /// with `last_pre_final_hidden` — the target's pre-final hidden state from
+        /// the position *before* `pending_token`, i.e. the hidden state that
+        /// predicted it. This mirrors that pairing across the whole prompt: for each
+        /// position `p` in `1..prompt_ids.len()`, it pairs `prompt_ids[p]` with the
+        /// target's pre-final hidden state at position `p - 1`, captured into
+        /// `self.session.mtp_prefill_hidden` by `forward_prefill_batched_chunk`.
+        /// Position 0 has no predecessor hidden state (nothing came before the first
+        /// prompt token) and is intentionally not represented in the MTP cache, so a
+        /// prompt of length `L` yields `L - 1` prefilled entries; the live call for
+        /// the first generated token then appends the `L`-th, giving that call's
+        /// attention dispatch `cache_len == L` instead of `1`.
+        ///
+        /// No-op when the session has no MTP head, when the prompt is too short to
+        /// yield a pair, or when `mtp_prefill_hidden` was not populated for this
+        /// exact prompt (e.g. the LoRA-active prefill path, which forwards token by
+        /// token via `forward_step` and does not feed the accumulator) — captured
+        /// length is asserted against `prompt_ids.len() * hidden_size` and anything
+        /// else is treated as "nothing to prefill" rather than misinterpreted.
+        fn mtp_prefill(&mut self, prompt_ids: &[u32]) {
+            let captured = std::mem::take(&mut self.session.mtp_prefill_hidden);
+            if self.session.mtp.is_none() {
+                return;
+            }
+            let hidden = self.engine.config.hidden_size;
+            let n = prompt_ids.len();
+            if n < 2 || captured.len() != n * hidden {
+                return;
+            }
+            for p in 1..n {
+                let hidden_in = &captured[(p - 1) * hidden..p * hidden];
+                self.mtp_prefill_append(prompt_ids[p], hidden_in, p);
+            }
+        }
+
+        /// Appends one MTP cache entry (K/V only — no Q, attention, MLP, or logits)
+        /// for `token_id` at absolute position `position`, using `hidden_in` as the
+        /// target's pre-final hidden state input in place of
+        /// `self.session.last_pre_final_hidden`. Mirrors the CPU phase and GPU
+        /// dispatch sequence of `mtp_forward_one` up through the KV cache append —
+        /// everything after that point (attention, gating, MLP, logits) only matters
+        /// for a position acting as a *query*, and a prefilled position is only ever
+        /// a future *key*.
+        fn mtp_prefill_append(&mut self, token_id: u32, hidden_in: &[f32], position: usize) {
+            let cfg = self.engine.config.clone();
+            let hidden = cfg.hidden_size;
+            let kv_dim = cfg.full_kv_dim();
+            let num_kv_heads = cfg.num_key_value_heads;
+            let head_dim = cfg.head_dim as u32;
+            let half_rope_dim = (cfg.rope_dim() / 2) as u32;
+
+            // ---- Phase 1: CPU (mirrors mtp_forward_one's embedding + hidden norm + fuse) ----
+            let mut normed_embed = vec![0.0f32; hidden];
+            assert!((token_id as usize) < cfg.vocab_size);
+            unsafe {
+                let src = (self.engine.embed_tokens.contents() as *const u16)
+                    .add(token_id as usize * hidden);
+                // SAFETY: embed_tokens row has hidden u16 values; normed_embed has hidden f32 values.
+                convert_f16_row(src, normed_embed.as_mut_ptr(), hidden);
+            }
+            if let Some(ref rot) = self.engine.quarot_rotation {
+                debug_assert_eq!(rot.dim(), normed_embed.len());
+                let _ = rot.apply_inverse(&mut normed_embed);
+            }
+            {
+                let mtp_weights = self.engine.mtp_weights.as_ref().unwrap();
+                let gamma = unsafe {
+                    std::slice::from_raw_parts(
+                        mtp_weights.pre_fc_norm_embedding.contents() as *const f32,
+                        hidden,
+                    )
+                };
+                let mut sum_sq = 0.0f32;
+                for &v in normed_embed.iter() {
+                    sum_sq += v * v;
+                }
+                let inv_rms = 1.0 / (sum_sq / hidden as f32 + cfg.rms_norm_eps).sqrt();
+                for (v, &g) in normed_embed.iter_mut().zip(gamma.iter()) {
+                    *v = *v * inv_rms * g;
+                }
+            }
+
+            let mut normed_hidden = hidden_in.to_vec();
+            if let Some(ref rot) = self.engine.quarot_rotation {
+                debug_assert_eq!(rot.dim(), normed_hidden.len());
+                let _ = rot.apply_inverse(&mut normed_hidden);
+            }
+            {
+                let mtp_weights = self.engine.mtp_weights.as_ref().unwrap();
+                let gamma = unsafe {
+                    std::slice::from_raw_parts(
+                        mtp_weights.pre_fc_norm_hidden.contents() as *const f32,
+                        hidden,
+                    )
+                };
+                let mut sum_sq = 0.0f32;
+                for &v in normed_hidden.iter() {
+                    sum_sq += v * v;
+                }
+                let inv_rms = 1.0 / (sum_sq / hidden as f32 + cfg.rms_norm_eps).sqrt();
+                for (v, &g) in normed_hidden.iter_mut().zip(gamma.iter()) {
+                    *v = *v * inv_rms * g;
+                }
+            }
+
+            {
+                let mtp = self.session.mtp.as_ref().unwrap();
+                let dst = mtp.activations.fused.contents() as *mut f32;
+                unsafe {
+                    for (i, &v) in normed_embed.iter().enumerate() {
+                        *dst.add(i) = v;
+                    }
+                    for (i, &v) in normed_hidden.iter().enumerate() {
+                        *dst.add(hidden + i) = v;
+                    }
+                }
+            }
+
+            // ---- Phase 2: GPU (K/V-only: fc, input-norm, k/v proj, k-norm, rope, cache append) ----
+            let (w_fc, w_input_ln, w_k_proj, w_v_proj, w_k_norm) = {
+                let mtp_weights = self.engine.mtp_weights.as_ref().unwrap();
+                let lw = &mtp_weights.layers[0];
+                (
+                    &mtp_weights.fc as *const Buffer,
+                    &lw.input_layernorm as *const Buffer,
+                    &lw.k_proj as *const Buffer,
+                    &lw.v_proj as *const Buffer,
+                    &lw.k_norm as *const Buffer,
+                )
+            };
+            let (buf_fused, buf_hidden, buf_residual, buf_k, buf_v) = {
+                let a = &self.session.mtp.as_ref().unwrap().activations;
+                (
+                    &a.fused as *const Buffer,
+                    &a.hidden as *const Buffer,
+                    &a.residual as *const Buffer,
+                    &a.k as *const Buffer,
+                    &a.v as *const Buffer,
+                )
+            };
+            let (buf_k_cache, buf_v_cache, mtp_seq_len) = {
+                let c = &self.session.mtp.as_ref().unwrap().cache;
+                (
+                    &c.k_buf as *const Buffer,
+                    &c.v_buf as *const Buffer,
+                    c.seq_len,
+                )
+            };
+
+            let cmd = self.engine.queue.new_command_buffer();
+            let enc = cmd.new_compute_command_encoder();
+            unsafe {
+                self.dispatch_matmul_half(
+                    enc,
+                    &*buf_fused,
+                    &*w_fc,
+                    &*buf_hidden,
+                    1,
+                    hidden as u32,
+                    (2 * hidden) as u32,
+                );
+                self.dispatch_copy_and_rms_norm(
+                    enc,
+                    &*buf_hidden,
+                    &*buf_residual,
+                    &*w_input_ln,
+                    hidden as u32,
+                    cfg.rms_norm_eps,
+                );
+                self.dispatch_matmul_half(
+                    enc,
+                    &*buf_hidden,
+                    &*w_k_proj,
+                    &*buf_k,
+                    1,
+                    kv_dim as u32,
+                    hidden as u32,
+                );
+                self.dispatch_matmul_half(
+                    enc,
+                    &*buf_hidden,
+                    &*w_v_proj,
+                    &*buf_v,
+                    1,
+                    kv_dim as u32,
+                    hidden as u32,
+                );
+                self.dispatch_per_head_rms_norm(
+                    enc,
+                    &*buf_k,
+                    &*w_k_norm,
+                    num_kv_heads as u32,
+                    head_dim,
+                    cfg.rms_norm_eps,
+                );
+                self.dispatch_partial_rope(
+                    enc,
+                    &*buf_k,
+                    num_kv_heads as u32,
+                    head_dim,
+                    half_rope_dim,
+                    position as u32,
+                    None,
+                );
+                let kv_cache_off = (mtp_seq_len * kv_dim) as u32;
+                self.dispatch_copy_offset(enc, &*buf_k, &*buf_k_cache, kv_dim as u32, kv_cache_off);
+                self.dispatch_copy_offset(enc, &*buf_v, &*buf_v_cache, kv_dim as u32, kv_cache_off);
+            }
+            enc.end_encoding();
+            cmd.commit();
+            cmd.wait_until_completed();
+
+            if let Some(ref mut mtp) = self.session.mtp {
+                mtp.cache.seq_len += 1;
+            }
+        }
+
         /// Internal single-token forward step.
         ///
         /// When `capture_hidden` is true (or when `self.session.mtp` is loaded), copies the
@@ -6535,6 +6770,10 @@ mod inner {
         }
 
         fn forward_prefill_impl(&mut self, token_ids: &[u32], all_positions: bool) -> Vec<f32> {
+            // Start of a fresh prompt pass: drop any hidden states captured by a
+            // previous prefill so `mtp_prefill` never pairs this prompt's tokens
+            // with a stale prior prompt's hidden states (#1340).
+            self.session.mtp_prefill_hidden.clear();
             let n = token_ids.len();
             let vocab = self.engine.config.vocab_size;
             // Validate all ids once at the entry point (O(seq_len)) before any GPU work.
@@ -7175,6 +7414,42 @@ mod inner {
                     full_idx += 1;
                 }
             }
+
+            // MTP prefill capture (#1340): `activations.hidden` currently holds the
+            // raw, pre-final-RMSNorm target hidden state for every one of this
+            // chunk's `n` positions. The tail below overwrites row `n-1` (default)
+            // or every row (`all_positions`) with its post-RMSNorm value in place,
+            // so this read must land before that dispatch runs — hence ending and
+            // committing the layer-loop's command buffer here instead of after the
+            // tail. `mtp_prefill` (called from `generate()`) drains the accumulated
+            // rows to rebuild the MTP draft head's KV cache from the prompt. Gated
+            // on `mtp.is_some()` so a session without an MTP head pays nothing extra
+            // — the pre-existing single-command-buffer path below is untouched.
+            let (cmd, enc) = if self.session.mtp.is_some() {
+                enc.end_encoding();
+                cmd.commit();
+                cmd.wait_until_completed();
+                // SAFETY: the command buffer just completed; `hidden` (the
+                // activations buffer, not the local `hidden: usize` row-length) is
+                // StorageModeShared and the layer loop above wrote exactly `n`
+                // valid rows into it.
+                let raw_hidden =
+                    unsafe { read_buffer(&self.session.activations.hidden, n * hidden) };
+                self.session
+                    .mtp_prefill_hidden
+                    .extend_from_slice(&raw_hidden);
+
+                if !emit_logits {
+                    self.session.set_position(start_pos + n);
+                    return vec![];
+                }
+
+                let cmd = self.engine.queue.new_command_buffer();
+                let enc = cmd.new_compute_command_encoder();
+                (cmd, enc)
+            } else {
+                (cmd, enc)
+            };
 
             if !emit_logits {
                 // Intermediate chunk of a chunked, `!all_positions` prefill: the caller
@@ -8376,6 +8651,10 @@ mod inner {
                     self.session.compact_topk = 0;
                     self.session.compact_route = GpuTopkRoute::CpuFallback;
                 }
+                // #1340: rebuild the MTP draft head's KV cache from the prompt
+                // before the first draft round, so it attends to the prompt prefix
+                // instead of the single row `reset_state` left it with.
+                self.mtp_prefill(&prompt_ids);
                 return Ok(self.generate_greedy_mtp(
                     &prefill_logits,
                     prompt_len,
@@ -9376,6 +9655,7 @@ mod inner {
             if let Some(ref mut mtp) = self.session.mtp {
                 mtp.cache.reset();
             }
+            self.session.mtp_prefill_hidden.clear();
             if let Some(ref mut pool) = self.session.gdn_checkpoints {
                 pool.active_base_seq_len = None;
             }
@@ -11870,6 +12150,7 @@ mod inner {
                     mtp: mtp_session,
                     gdn_checkpoints,
                     last_pre_final_hidden: vec![0.0f32; hidden],
+                    mtp_prefill_hidden: Vec::new(),
                     capture_final_hidden: false,
                     final_hidden_captured: std::sync::atomic::AtomicBool::new(false),
                     position: 0,
@@ -16700,6 +16981,58 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                  `mtp_forward_one` wrote this round; got {mtp_seq_len}, which means the \
                  next `mtp_forward_one` call will skip a slot and the attention window \
                  will read a never-written row"
+            );
+        }
+
+        // #1340: without `mtp_prefill`, `reset_state` zeroes the MTP cache and the
+        // only prefill on the Metal path fills the *target* model's cache, so the
+        // first `mtp_forward_one` call of a generation dispatches attention with
+        // `cache_len = 1` -- the draft attends to exactly the row it just wrote,
+        // independent of the prompt. This asserts the observable attention-set size
+        // (`cache.seq_len`, and the `cache_len` the first live dispatch sees), not
+        // generated text -- a target-verified MTP draft can never change output, so
+        // an output-only test cannot see this defect either way.
+        #[test]
+        fn mtp_prefill_builds_kv_cache_from_prompt_prefix() {
+            let _gpu_guard = gpu_test_lock();
+            let Some(_) = Device::system_default() else {
+                return;
+            };
+
+            let (mut cfg, weights) = tiny_metal_qwen35_fixture();
+            cfg.mtp_num_hidden_layers = 1;
+            let mut state = metal_state_with_synthetic_mtp_for_test(&weights, &cfg, None);
+            assert!(
+                state.session.mtp.is_some(),
+                "synthetic MTP fixture must populate session.mtp"
+            );
+
+            let prompt_ids: Vec<u32> = vec![3, 7, 11, 19];
+            let prompt_len = prompt_ids.len();
+
+            let _ = state.forward_prefill(&prompt_ids);
+            state.mtp_prefill(&prompt_ids);
+
+            // One cache entry per prompt position beyond the first (position 0 has
+            // no predecessor hidden state to pair with), so the cache scales
+            // directly with the prompt instead of staying at 0.
+            assert_eq!(
+                state.session.mtp.as_ref().unwrap().cache.seq_len,
+                prompt_len - 1,
+                "mtp cache seq_len after prefill must reflect the prompt, not stay at 0"
+            );
+
+            // The first live draft call (mirroring `generate_greedy_mtp`'s first
+            // round) appends one more entry for the just-sampled token, so its
+            // attention dispatch sees cache_len == prompt_len, not 1.
+            let before = state.session.mtp.as_ref().unwrap().cache.seq_len;
+            let pending_token = 5u32;
+            let _ = state.mtp_forward_one(pending_token, prompt_len);
+            let after = state.session.mtp.as_ref().unwrap().cache.seq_len;
+            assert_eq!(after, before + 1);
+            assert_eq!(
+                after, prompt_len,
+                "the first draft's attention dispatch must see cache_len == prompt_len, not 1"
             );
         }
 


### PR DESCRIPTION
Fixes #1340.

On the MTP greedy route, the first draft token was produced from an MTP layer whose KV cache held
nothing for the prompt. `forward_prefill` populates the main model's cache for the whole prompt, but
the MTP layer has its own cache and no corresponding prefill step existed, so the first draft
attended over an empty history and every subsequent draft inherited the resulting state. The
speculative path still produced valid output because the verifier rejects bad drafts, but it was
rejecting drafts that were wrong for a structural reason rather than a modelling one.

This adds `mtp_prefill`, called from `generate()` immediately after `forward_prefill` on that route.
It drains the per-token hidden states captured during prefill and replays them through
`mtp_prefill_append`, pairing each prompt token with the hidden state of its predecessor. A prompt of
length L therefore yields L-1 prefilled entries: the final token has no successor to pair with and is
the one the first live draft consumes.

## Known gap

`mtp_prefill` no-ops when the LoRA-active prefill path is taken, because that path does not populate
the captured-hidden-state buffer. The MTP cache is then empty exactly as before this change. That is
a narrower version of the same defect rather than a new one, and it is called out here rather than
silently narrowed: this change fixes the default path and leaves the LoRA path for a follow-up.

## Interaction with #1360

#1360 changed the MTP cursor advance on the accept path, and both changes write the same cache. The
rebase onto it conflicted, which is the useful signal: the two edits touch the same region, so a
clean auto-merge would have been the thing to distrust rather than to trust.

The resolution was built by extracting each side verbatim from its own ref and splicing, then
asserting byte-identity of each extracted region against its source and asserting no duplicate
function definitions in the result. Post-rebase the diff is still exactly +333/-0 against the new
base, which is the check that nothing from #1360 was dropped while resolving.

## bench-compare disposition

Measured, on a dedicated quiet machine. No structural waiver is available: `mtp_decode` is a declared
bench target that drives `generate()` on both the plain-greedy and MTP-enabled routes, and the changed
call sits on the second one. Execution is positively confirmed rather than assumed — the MTP layer
weight-load line appears in every arm of the run.

| group | time | change |
|---|---|---|
| `mtp_decode/greedy/mtp` (MTP enabled) | 714.90 ms | `[+0.9881% +1.0999% +1.2119%]` (p = 0.08) |
| `mtp_decode/greedy/baseline` (MTP gate off) | 284.29 ms | `[+0.0045% +0.5893% +1.1760%]` (p = 0.13) |

Run conditions: idle 96.32% before the base arm, 97.21% between arms, 97.30% after the head arm.
Base `554224d2ca`, head `7054547b35`, which is this branch's head unchanged since the run.

Main has advanced past that base since the run, so the base is stated rather than assumed still
current. What moved is `crates/inference/src/grammar/pda.rs` and one test file. The `mtp_decode`
bench contains no grammar reference at all and constrains nothing, so neither reaches the measured
path and the comparison stands. That is a reachability claim about the bench, checked the same way
the disposition rule asks for it, not an assertion that a base move is harmless in general.

Read the second row as a negative control, not as a second result. `bench_baseline` constructs the
session with `enable_mtp: Some(false)`, and the new call sits inside the `if use_mtp` branch in
`generate()`, so the changed code provably cannot execute in that group. It moved +0.59% anyway, with
an interval reaching +1.18%.

That bounds what the first row can be claimed to show. The MTP group's interval `[+0.99%, +1.21%]`
overlaps the control's `[+0.00%, +1.18%]` almost entirely, so the honest reading is that any cost on
the MTP path is at most about 1% and is not cleanly separable from this run's own drift floor. It is
specifically not separable enough to attribute the whole +1.10% to the change. Criterion labels both
rows "No change in performance detected"; that label answers a p-threshold question and is not the
measurement, which is why the intervals are quoted and the control is quoted beside them.

Any residual cost is prefill-side work — the replay is O(prompt length) and runs once per generation,
not per decoded token — traded for the first draft attending over real context instead of an empty
cache.

## Test

`mtp_prefill_builds_kv_cache_from_prompt_prefix` builds a synthetic MTP fixture, prefills a
four-token prompt, and asserts the MTP cache holds the prompt-prefix entries afterwards. It asserts
on cache state rather than on generated text deliberately: a target-verified draft can never change
the output, so an output-only test cannot see this defect in either direction.

Mutation arm, run rather than asserted. With `mtp_prefill` reduced to an early return and nothing
else changed, the test fails; restored, it passes. Both arms ran exactly one test, which is worth
stating because the first attempt at this ran zero: the test lives under a `metal-gpu`-gated inner
module, and without the feature flags the filter matched nothing and both arms reported a green
`0 passed`. The numbers above are from the run that executed it.

On the merged base, `speculative` (79 tests) and the `self_spec` group (30 tests) both pass, which is
the runtime side of the interaction check described above.
