### PR TITLE
refactor(inference): make prepare_generation's capability order contract-expressible

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -12808,44 +12808,36 @@ mod inner {
             F: FnMut(&str, u32) -> bool,
             C: FnMut() -> bool,
         {
-            // Config preflight checks live here, in the public wrapper, and
-            // must return BEFORE the `match` below (PR #787): the
-            // error-recovery arm of that `match` unconditionally
-            // calls `reset_state()` and removes the cache slot on ANY `Err`
-            // from `_inner`, including a not-yet-attempted preflight
-            // rejection. A caller passing an unsupported config (e.g.
-            // `logprobs` or an active `enable_mtp`) never touches cache/session
-            // state in the first place, so routing that rejection through the
-            // destructive recovery path would evict a valid pre-existing
-            // cross-turn entry the call never mutated. Returning here, before
-            // `_inner` is even called, leaves any existing entry untouched.
-            crate::model::qwen35::check_logprobs_not_set(gen_cfg)?;
-            crate::model::qwen35::check_mtp_not_requested(gen_cfg)?;
-
-            // #856/#922/#827: prompt tokenization, the empty-prompt guard, and
-            // the prompt-plus-decode-budget context bound are delegated to the
-            // same `prepare_generation` shared preparation
-            // `generate_streaming_with_cancel` already routes through, closing
-            // the last unmigrated generation entry point (issue #827). This
-            // reuses `GenerationEntryContract::MetalStreaming`: the pieces
-            // `prepare_generation` actually governs here -- tokenize,
-            // `check_prompt_not_empty`, the vocab-admission no-op, the
-            // zero-budget completion shape, and `check_context_budget` --
-            // are byte-for-byte what this entry point ran inline before. The
-            // `logprobs`/`enable_mtp` preflights above are strictly narrower
-            // than `MetalStreaming`'s permissive `validate_capabilities` (which
-            // exists because plain streaming supports both), so they stay as
-            // explicit checks here rather than folding into the contract --
-            // that keeps their current position ahead of tokenization and
-            // their current per-check error text unchanged for callers that
-            // violate more than one guard at once.
+            // #856/#922/#827/#1354: prompt tokenization, the empty-prompt
+            // guard, and the prompt-plus-decode-budget context bound are
+            // delegated to the same `prepare_generation` shared preparation
+            // `generate_streaming_with_cancel` already routes through,
+            // closing the last unmigrated generation entry point (issue
+            // #827). This uses `GenerationEntryContract::MetalPrefixCacheStreaming`
+            // (#1354), not the plain-streaming `MetalStreaming` variant this
+            // call used to reuse: `MetalStreaming`'s permissive
+            // `validate_capabilities` exists because plain streaming
+            // supports both `logprobs` and `enable_mtp`, but this path does
+            // not, so folding those checks into that variant would have
+            // wrongly restricted plain streaming too. `MetalPrefixCacheStreaming`
+            // carries its own `check_logprobs_not_set` /
+            // `check_mtp_not_requested` guards in `validate_before_tokenization`
+            // (run ahead of tokenization inside `prepare_generation`, same
+            // position these two guards ran in as an explicit preflight
+            // here before this change), so the error text and precedence
+            // for a request that violates more than one guard at once are
+            // unchanged: this call must still return here, before any
+            // cache/session state mutation and before `_inner`'s
+            // destructive-on-`Err` recovery arm is reachable, so a rejected
+            // call never evicts a valid pre-existing cross-turn entry it
+            // never touched (PR #787).
             let prompt_prep = crate::model::qwen35::prepare_generation(
                 tokenizer,
                 prompt,
                 gen_cfg,
                 self.engine.config.vocab_size,
                 self.max_context(),
-                crate::model::qwen35::GenerationEntryContract::MetalStreaming,
+                crate::model::qwen35::GenerationEntryContract::MetalPrefixCacheStreaming,
             )?;
             let (prompt_ids, rng_state) = match prompt_prep {
                 crate::model::qwen35::GenerationPreparation::Complete(output) => {
@@ -12869,8 +12861,9 @@ mod inner {
 
             // #835: validate the suffix a reuse plan would select for this
             // slot BEFORE calling `_inner` at all -- same reasoning as the
-            // `check_logprobs_not_set`/`check_mtp_not_requested` preflights
-            // above (PR #787): the `match` below unconditionally calls
+            // `check_logprobs_not_set`/`check_mtp_not_requested` guards
+            // `prepare_generation` already ran above, ahead of tokenization
+            // (PR #787, #1354): the `match` below unconditionally calls
             // `reset_state()` and evicts the cache slot on ANY `Err` from
             // `_inner`, so a suffix-validation-only rejection (out-of-vocab
             // token, empty suffix, or a suffix overflowing `max_cache_len`)
@@ -32252,9 +32245,10 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// entry is created (or consumed) for the rejected call.
         ///
         /// Mutation sensitivity: removing the `check_logprobs_not_set` call
-        /// at the top of `generate_streaming_with_prefix_cache_and_cancel_inner`
-        /// makes this assertion fail (the call returns `Ok` with empty
-        /// `token_logprobs` instead of `Err`).
+        /// from `GenerationEntryContract::MetalPrefixCacheStreaming`'s
+        /// `validate_before_tokenization` (#1354) makes this assertion fail
+        /// (the call returns `Ok` with empty `token_logprobs` instead of
+        /// `Err`).
         #[test]
         fn generate_streaming_with_prefix_cache_rejects_logprobs_request() {
             let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
@@ -32406,8 +32400,9 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// no indication the request was ignored.
         ///
         /// Mutation sensitivity: removing the `check_mtp_not_requested` call
-        /// in `generate_streaming_with_prefix_cache_and_cancel` makes this
-        /// assertion fail (the call returns `Ok` instead of `Err`).
+        /// from `GenerationEntryContract::MetalPrefixCacheStreaming`'s
+        /// `validate_before_tokenization` (#1354) makes this assertion fail
+        /// (the call returns `Ok` instead of `Err`).
         #[test]
         fn generate_streaming_with_prefix_cache_rejects_active_mtp_request() {
             let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
@@ -32453,6 +32448,115 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             );
         }
 
+        /// #1354: a request that violates two guards at once must surface
+        /// the *specific* error the pre-refactor call order produces, not
+        /// merely *an* error -- a single-violation suite cannot distinguish
+        /// "checks order preserved" from "checks order silently changed"
+        /// because every single-violation test still passes either way.
+        /// `logprobs` and `enable_mtp` were both checked before tokenization
+        /// in the public wrapper, `logprobs` first; an empty prompt is only
+        /// discovered afterward, inside `prepare_generation`. A caller that
+        /// sets `logprobs` on an empty-prompt request must therefore still
+        /// see the logprobs error, not "empty prompt" -- and a caller that
+        /// sets both `logprobs` and `enable_mtp` must see the logprobs
+        /// error, not the MTP one, because logprobs is checked first.
+        ///
+        /// Mutation sensitivity: folding either preflight into
+        /// `prepare_generation`'s post-tokenization `validate_capabilities`
+        /// (rather than a pre-tokenization hook) flips the empty-prompt
+        /// cases to `Err(Inference("empty prompt"))`; swapping the
+        /// logprobs/MTP check order flips the combined case to the MTP
+        /// error text.
+        #[test]
+        fn generate_streaming_with_prefix_cache_multi_violation_requests_return_the_earlier_guards_error()
+         {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _guard = gpu_test_lock();
+
+            use crate::error::InferenceError;
+            use crate::model::qwen35_config::GenerateConfig;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (cfg, weights) = tiny_hybrid_fixture();
+            let slot_id = crate::kv_cache::CrossTurnSlotId::DEFAULT;
+
+            // logprobs + enable_mtp both set: logprobs must win (checked first).
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let both_capabilities_cfg = GenerateConfig {
+                enable_mtp: Some(true),
+                logprobs: Some(0),
+                ..cross_turn_test_gen_cfg(1, 2)
+            };
+            let result = state.generate_streaming_with_prefix_cache(
+                slot_id,
+                "a",
+                &tokenizer,
+                &both_capabilities_cfg,
+                |_, _| true,
+            );
+            assert!(
+                matches!(
+                    result,
+                    Err(InferenceError::InvalidInput(ref msg)) if msg.contains("logprobs")
+                ),
+                "logprobs and enable_mtp set together must reject with the \
+                 logprobs error (checked before MTP); got {result:?}"
+            );
+
+            // logprobs set + empty prompt: logprobs must win (checked before
+            // tokenization discovers the prompt is empty).
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let logprobs_and_empty_cfg = GenerateConfig {
+                logprobs: Some(0),
+                ..cross_turn_test_gen_cfg(1, 2)
+            };
+            let result = state.generate_streaming_with_prefix_cache(
+                slot_id,
+                "",
+                &tokenizer,
+                &logprobs_and_empty_cfg,
+                |_, _| true,
+            );
+            assert!(
+                matches!(
+                    result,
+                    Err(InferenceError::InvalidInput(ref msg)) if msg.contains("logprobs")
+                ),
+                "logprobs set on an empty-prompt request must reject with the \
+                 logprobs error, not \"empty prompt\"; got {result:?}"
+            );
+
+            // enable_mtp set + empty prompt: MTP must win (checked before
+            // tokenization discovers the prompt is empty).
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32).expect("tiny hybrid fixture");
+            let mtp_and_empty_cfg = GenerateConfig {
+                enable_mtp: Some(true),
+                ..cross_turn_test_gen_cfg(1, 2)
+            };
+            let result = state.generate_streaming_with_prefix_cache(
+                slot_id,
+                "",
+                &tokenizer,
+                &mtp_and_empty_cfg,
+                |_, _| true,
+            );
+            assert!(
+                matches!(
+                    result,
+                    Err(InferenceError::InvalidInput(ref msg)) if msg.contains("enable_mtp")
+                ),
+                "enable_mtp set on an empty-prompt request must reject with \
+                 the MTP error, not \"empty prompt\"; got {result:?}"
+            );
+        }
+
         /// #827: `generate_streaming_with_prefix_cache_and_cancel_inner` was
         /// the last of the seven Qwen3.5 generation entry points that did not
         /// route through the shared `prepare_generation` preparation --
@@ -32464,14 +32568,14 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// `generate_streaming_with_cancel` sibling and the prefix-cache
         /// entry point with the identical over-budget prompt/config on
         /// identically-configured fixtures, and asserts both reject with
-        /// the exact same `check_context_budget` text -- the arm
-        /// `GenerationEntryContract::MetalStreaming`'s `validate_context`
-        /// owns inside `prepare_generation`. Both entry points now resolve
-        /// that arm through the one shared call site instead of two
-        /// independently maintained copies, so a future change to the
-        /// bound (or to which contract this path is threaded through)
-        /// cannot silently diverge between the two without this test
-        /// catching it.
+        /// the exact same `check_context_budget` text -- the shared
+        /// `Self::MetalDirect | Self::MetalStreaming | Self::MetalPrefixCacheStreaming`
+        /// arm `validate_context` owns inside `prepare_generation` (#1354).
+        /// Both entry points now resolve that arm through the one shared
+        /// call site instead of two independently maintained copies, so a
+        /// future change to the bound (or to which contract either path is
+        /// threaded through) cannot silently diverge between the two
+        /// without this test catching it.
         #[test]
         fn generate_streaming_with_prefix_cache_context_rejection_matches_migrated_sibling() {
             let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
@@ -32528,9 +32632,10 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 streaming_msg, cached_msg,
                 "generate_streaming_with_prefix_cache_and_cancel must reject an \
                  over-budget prompt with the exact same check_context_budget text \
-                 generate_streaming_with_cancel produces (#827): both now route \
-                 through the same prepare_generation(..., \
-                 GenerationEntryContract::MetalStreaming) call"
+                 generate_streaming_with_cancel produces (#827): both route \
+                 through prepare_generation's shared validate_context arm, \
+                 albeit via different contract variants \
+                 (MetalStreaming / MetalPrefixCacheStreaming, #1354)"
             );
         }
 

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -2317,7 +2317,7 @@ pub(crate) fn check_reasoning_budget_not_set(
 /// draft/verify wiring at all -- gated identically to that Metal-only
 /// consumer (same gate as the `DecodePolicy`/`StepOutcome` re-export in
 /// `mod.rs`) so non-metal-gpu builds don't carry an unused function.
-#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+#[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
 pub(crate) fn check_mtp_not_requested(gen_cfg: &GenerateConfig) -> Result<(), InferenceError> {
     let mtp_enabled = gen_cfg
         .enable_mtp

--- a/crates/inference/src/model/qwen35/generation_setup.rs
+++ b/crates/inference/src/model/qwen35/generation_setup.rs
@@ -1,5 +1,7 @@
 #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
 use super::generation::check_context_budget;
+#[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+use super::generation::check_mtp_not_requested;
 use super::generation::{
     check_grammar_not_set, check_logprobs_not_set, check_prompt_ids_in_vocab,
     check_prompt_not_empty, check_reasoning_budget_not_set, check_stop_strings_not_set,
@@ -19,9 +21,40 @@ pub(crate) enum GenerationEntryContract {
     MetalDirect,
     #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
     MetalStreaming,
+    /// Cross-turn prefix-cache streaming (#1354). Unlike every other
+    /// variant, its capability guards (`logprobs`, `enable_mtp`) must run
+    /// *before* tokenization: a request that violates one of these and is
+    /// also empty must still surface the capability error, matching the
+    /// order the public wrapper ran these checks in prior to this contract
+    /// existing. See [`Self::validate_before_tokenization`].
+    #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+    MetalPrefixCacheStreaming,
 }
 
 impl GenerationEntryContract {
+    /// Guards that must be evaluated before the prompt is tokenized, so
+    /// their errors take precedence over `check_prompt_not_empty` and every
+    /// later step for a request that violates more than one guard at once.
+    /// Every variant except [`Self::MetalPrefixCacheStreaming`] has no
+    /// pre-tokenization guards and returns `Ok(())` unconditionally, leaving
+    /// its existing step order (tokenize first, capabilities checked in
+    /// [`Self::validate_capabilities`] afterward) exactly as it was.
+    fn validate_before_tokenization(self, gen_cfg: &GenerateConfig) -> Result<(), InferenceError> {
+        // Only `MetalPrefixCacheStreaming` (test/metal-gpu-gated) reads
+        // `gen_cfg`; every other variant's arm is unconditionally `Ok(())`.
+        let _ = gen_cfg;
+        match self {
+            Self::StandaloneCpu => Ok(()),
+            #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+            Self::MetalDirect | Self::MetalStreaming => Ok(()),
+            #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+            Self::MetalPrefixCacheStreaming => {
+                check_logprobs_not_set(gen_cfg)?;
+                check_mtp_not_requested(gen_cfg)
+            }
+        }
+    }
+
     fn validate_prompt_ids(
         self,
         prompt_ids: &[u32],
@@ -31,6 +64,8 @@ impl GenerationEntryContract {
             Self::StandaloneCpu => check_prompt_ids_in_vocab(prompt_ids, vocab_size),
             #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
             Self::MetalDirect | Self::MetalStreaming => Ok(()),
+            #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+            Self::MetalPrefixCacheStreaming => Ok(()),
         }
     }
 
@@ -49,6 +84,10 @@ impl GenerationEntryContract {
             }
             #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
             Self::MetalStreaming => Ok(()),
+            // Both capability guards this variant carries already ran in
+            // `validate_before_tokenization`, ahead of tokenization.
+            #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
+            Self::MetalPrefixCacheStreaming => Ok(()),
         }
     }
 
@@ -70,7 +109,7 @@ impl GenerationEntryContract {
                 Ok(gen_cfg.max_new_tokens)
             }
             #[cfg(any(test, all(target_os = "macos", feature = "metal-gpu")))]
-            Self::MetalDirect | Self::MetalStreaming => {
+            Self::MetalDirect | Self::MetalStreaming | Self::MetalPrefixCacheStreaming => {
                 check_context_budget(
                     prompt_len,
                     gen_cfg.reasoning_budget,
@@ -106,6 +145,8 @@ pub(crate) fn prepare_generation(
     contract: GenerationEntryContract,
 ) -> Result<GenerationPreparation, InferenceError> {
     let rng_state = normalize_seed(gen_cfg.seed, system_seed);
+
+    contract.validate_before_tokenization(gen_cfg)?;
 
     let input = tokenizer.tokenize(prompt);
     let prompt_ids = input.input_ids[..input.real_length].to_vec();
@@ -432,11 +473,176 @@ mod tests {
         for contract in [
             GenerationEntryContract::MetalDirect,
             GenerationEntryContract::MetalStreaming,
+            GenerationEntryContract::MetalPrefixCacheStreaming,
         ] {
             let result = prepare_with_contract(&tokenizer, "z", &gen_cfg, 2, 2, contract)
                 .expect("Metal preparation must preserve its existing admission ordering");
             assert!(matches!(result, GenerationPreparation::Ready(_)));
         }
+    }
+
+    #[test]
+    fn metal_prefix_cache_streaming_contract_accepts_unset_capabilities() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 1,
+            ..Default::default()
+        };
+        let result = prepare_with_contract(
+            &tokenizer,
+            "a",
+            &gen_cfg,
+            1,
+            2,
+            GenerationEntryContract::MetalPrefixCacheStreaming,
+        )
+        .expect("prefix-cache streaming must accept a request with no capabilities set");
+        assert!(matches!(result, GenerationPreparation::Ready(_)));
+    }
+
+    /// #1354: `logprobs`/`enable_mtp` must be rejected before tokenization
+    /// discovers the prompt is empty, so a request violating both a
+    /// capability guard and the empty-prompt guard still returns the
+    /// capability error -- exactly the order the public wrapper ran these
+    /// checks in before this contract variant existed.
+    ///
+    /// Mutation sensitivity: moving `validate_before_tokenization`'s call
+    /// site in `prepare_generation` to after tokenization (or folding these
+    /// checks into `validate_capabilities` instead) flips both assertions
+    /// below to `Err(Inference("empty prompt"))`.
+    #[test]
+    fn metal_prefix_cache_streaming_contract_rejects_capabilities_before_empty_prompt() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+
+        let logprobs_and_empty = GenerateConfig {
+            max_new_tokens: 1,
+            logprobs: Some(0),
+            ..Default::default()
+        };
+        let err = prepare_with_contract(
+            &tokenizer,
+            "",
+            &logprobs_and_empty,
+            1,
+            2,
+            GenerationEntryContract::MetalPrefixCacheStreaming,
+        )
+        .expect_err("logprobs set on an empty prompt must still reject");
+        assert!(
+            matches!(
+                err,
+                InferenceError::InvalidInput(ref message) if message.contains("logprobs")
+            ),
+            "expected the logprobs error ahead of the empty-prompt error; got {err:?}"
+        );
+
+        let mtp_and_empty = GenerateConfig {
+            max_new_tokens: 1,
+            enable_mtp: Some(true),
+            ..Default::default()
+        };
+        let err = prepare_with_contract(
+            &tokenizer,
+            "",
+            &mtp_and_empty,
+            1,
+            2,
+            GenerationEntryContract::MetalPrefixCacheStreaming,
+        )
+        .expect_err("enable_mtp set on an empty prompt must still reject");
+        assert!(
+            matches!(
+                err,
+                InferenceError::InvalidInput(ref message) if message.contains("enable_mtp")
+            ),
+            "expected the MTP error ahead of the empty-prompt error; got {err:?}"
+        );
+    }
+
+    /// #1354: when both capability guards are violated at once, `logprobs`
+    /// must win because `validate_before_tokenization` checks it first --
+    /// same order the public wrapper's two explicit preflight calls ran in.
+    #[test]
+    fn metal_prefix_cache_streaming_contract_rejects_logprobs_before_mtp() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+        let gen_cfg = GenerateConfig {
+            max_new_tokens: 1,
+            logprobs: Some(0),
+            enable_mtp: Some(true),
+            ..Default::default()
+        };
+        let err = prepare_with_contract(
+            &tokenizer,
+            "a",
+            &gen_cfg,
+            1,
+            2,
+            GenerationEntryContract::MetalPrefixCacheStreaming,
+        )
+        .expect_err("logprobs and enable_mtp set together must still reject");
+        assert!(
+            matches!(
+                err,
+                InferenceError::InvalidInput(ref message) if message.contains("logprobs")
+            ),
+            "expected the logprobs error (checked before MTP); got {err:?}"
+        );
+    }
+
+    /// #1354: `logprobs`/`enable_mtp` must be rejected before the
+    /// zero-budget short-circuit too, not only before the empty-prompt
+    /// guard -- `validate_before_tokenization` runs unconditionally ahead
+    /// of every later step in `prepare_generation`, zero-budget included.
+    /// A `max_new_tokens: 0` request with `logprobs` set must therefore
+    /// still surface the logprobs error, not an early `Complete` with an
+    /// empty output.
+    #[test]
+    fn metal_prefix_cache_streaming_contract_rejects_capabilities_before_zero_budget() {
+        let tokenizer = tokenizer(&[("a", 0)]);
+
+        let logprobs_and_zero_budget = GenerateConfig {
+            max_new_tokens: 0,
+            logprobs: Some(0),
+            ..Default::default()
+        };
+        let err = prepare_with_contract(
+            &tokenizer,
+            "a",
+            &logprobs_and_zero_budget,
+            1,
+            2,
+            GenerationEntryContract::MetalPrefixCacheStreaming,
+        )
+        .expect_err("logprobs set on a zero-budget request must still reject");
+        assert!(
+            matches!(
+                err,
+                InferenceError::InvalidInput(ref message) if message.contains("logprobs")
+            ),
+            "expected the logprobs error ahead of the zero-budget completion; got {err:?}"
+        );
+
+        let mtp_and_zero_budget = GenerateConfig {
+            max_new_tokens: 0,
+            enable_mtp: Some(true),
+            ..Default::default()
+        };
+        let err = prepare_with_contract(
+            &tokenizer,
+            "a",
+            &mtp_and_zero_budget,
+            1,
+            2,
+            GenerationEntryContract::MetalPrefixCacheStreaming,
+        )
+        .expect_err("enable_mtp set on a zero-budget request must still reject");
+        assert!(
+            matches!(
+                err,
+                InferenceError::InvalidInput(ref message) if message.contains("enable_mtp")
+            ),
+            "expected the MTP error ahead of the zero-budget completion; got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/inference/src/model/qwen35/mod.rs
+++ b/crates/inference/src/model/qwen35/mod.rs
@@ -84,11 +84,6 @@ pub(crate) use generation::check_context_budget;
 // uses `DecodePolicy` directly within its own module.
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 pub(crate) use generation::{DecodePolicy, StepOutcome, StopCheckOutcome};
-// Sibling guard for `enable_mtp` on the cross-turn prefix-cache path, which
-// has no MTP draft/verify wiring (PR #787). Only
-// that Metal-only path needs it, same gate as `DecodePolicy`/`StepOutcome`.
-#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
-pub(crate) use generation::check_mtp_not_requested;
 pub(crate) use norm::qwen35_rms_norm;
 pub(crate) use sampling::sample_token;
 pub(crate) use weights::{


### PR DESCRIPTION
Closes #1354.

## What changed

`prepare_generation` now has a second contract hook, `GenerationEntryContract::validate_before_tokenization`, evaluated ahead of tokenization. The existing `validate_capabilities` hook keeps its position after tokenization, and the new hook's default implementation is a no-op, so every pre-existing contract variant keeps its current step order byte-for-byte.

One caller uses it. `generate_streaming_with_prefix_cache_and_cancel` previously ran `check_logprobs_not_set` / `check_mtp_not_requested` as an explicit preflight in the public wrapper, outside the shared preparation seam, because it needed those two guards to run *before* tokenization and `MetalStreaming`'s permissive `validate_capabilities` runs after. That entry point now uses a new `MetalPrefixCacheStreaming` variant which carries the two guards in `validate_before_tokenization`. No capability check remains outside the shared seam.

A new variant rather than a change to `MetalStreaming`: plain streaming genuinely supports both `logprobs` and `enable_mtp`, so folding these guards into that variant would have wrongly restricted a path that is allowed to use them.

The guards keep their position relative to `_inner`, which matters for a reason unrelated to this refactor: the error-recovery arm of the `match` in `generate_streaming_with_prefix_cache_and_cancel` unconditionally calls `reset_state()` and drops the cache slot on any `Err` from `_inner`. A config rejection that reached that arm would evict a valid cross-turn cache entry the call never touched (#787). Returning from `prepare_generation`, before `_inner` is called, preserves that.

## Why the hook shape

The issue calls out the tradeoff between a hook and a fully explicit step list. One of four entry-point families needed the reorder, so an explicit list would have made three variants restate an order they already have, and every future variant restate it again. The hook expresses only the delta.

## Verification

**Ordering tests written against the pre-refactor code first.** A single-violation test cannot see a step-order change: any ordering produces *an* error. The new tests submit configs that violate two guards at once (empty-prompt × logprobs, zero-budget × MTP, logprobs × MTP) and assert on the *specific* error, which is the only thing that distinguishes the orderings. They were written and run against the pre-refactor code to record the real baseline order, then confirmed unchanged after.

`cargo test -p lattice-inference --lib generation_setup`: **16 passed, 0 failed** (4 new). Full lib suite: 2515 passed, 0 failed. Clippy clean under default features and under `f16,metal-gpu`; `cargo fmt --check` clean.

**Mutation arm.** Moving the hook to run after tokenization reddened exactly one ordering test and left the other 14 green, including the unrelated contracts — the blast radius predicted before running. The mutation was restored and the file verified byte-identical.

Targeted `metal-gpu` subsets covering the changed paths: 29 passed, 0 failed. The crate-wide `metal-gpu` suite did not finish inside the time budget; it was serialized behind another process holding the machine-wide GPU test lock, which is the lock working as intended rather than a signal about this change.

## bench-compare disposition

Mandatory for a `crates/inference/src/` diff, and the structural waiver does not apply here: the change adds a real call to a real function on the generation-entry path, so there is a reachable target and reachability, not compilation, is the predicate.

**Population searched: all 24 declared bench targets in `crates/inference/Cargo.toml`**, by `cfg` gate and by `required-features`. Two reach the change:

- `cross_turn_prefix_cache_bench` — directly. This is the entry point whose contract variant changed.
- `mtp_decode` — incidentally, via the now-universal no-op hook.

Neither is among the two targets `bench-compare` runs by default, and both declare `required-features = ["metal-gpu", "f16"]`, so the default A/B would have been a coverage statement rather than a safety one.

A/B on `cross_turn_prefix_cache` was run on a dedicated quiet machine (base `d955e0124706d1cb6ab785515cba5a2385837485`, head `53b6a3ba4acd869e9d0eb66d40793e2548069433`, `--quick`, ABBA arm order, machine idle 95.8-96.8%), paired with a **negative control**: the `rms_norm|gelu` groups of `elementwise_cpu_bench`, which contain zero references to `prepare_generation`, `GenerationEntryContract`, `generate_streaming`, or `GenerateConfig`, so the change provably cannot execute in them.

**Subject** (`cross_turn_prefix_cache`, head relative to base):

| group | CI low | point | CI high | p |
|---|---|---|---|---|
| `full_reprefill/2_prior_turns` | -0.3225% | **+0.0016%** | +0.3274% | 0.88 |
| `cache_aware_incremental/2_prior_turns` | +0.2567% | **+0.3112%** | +0.3657% | 0.10 |
| `full_reprefill/8_prior_turns` | +0.0713% | **+0.1627%** | +0.2541% | 0.12 |
| `cache_aware_incremental/8_prior_turns` | +0.0569% | **+0.4184%** | +0.7805% | 0.15 |

**Negative control** (`elementwise_cpu_bench`, same run, change cannot execute):

| group | CI low | point | CI high | p |
|---|---|---|---|---|
| `rms_norm/896` | -0.2640% | **+0.1353%** | +0.5353% | 0.72 |
| `rms_norm/4096` | -0.1046% | **+0.5329%** | +1.1743% | 0.30 |
| `gelu/896` | +1.3619% | **+1.9661%** | +2.5727% | 0.10 |
| `gelu/4096` | -0.2816% | **+0.4556%** | +1.1963% | 0.54 |
| `add_bias_gelu/896` | +0.3722% | **+1.1235%** | +1.8803% | 0.13 |
| `add_bias_gelu/4096` | +1.0621% | **+1.9235%** | +2.7941% | 0.08 |

**Reading.** The control carries a systematic positive drift of up to **+1.97%**, and three of its six groups have confidence intervals lying entirely above zero — in groups the change cannot reach. That is the run's noise floor, and it is larger than every subject reading. The largest subject reading is **+0.42%**, roughly a quarter of the control's largest, so nothing in the subject table is separable from ambient drift.

Note that two subject groups also have CIs entirely above zero, and Criterion prints "No change in performance detected" for all ten rows. Neither fact is load-bearing: the significance label is not the verdict, and a CI excluding zero means nothing once the control shows the same shape where no effect is possible. Without the control this table would have read as a small consistent regression.

**Disposition: no measurable performance effect.** The change adds one non-virtual call that returns immediately for every contract except one, on the generation-entry path rather than in a decode loop, which is consistent with what was measured.

## Residual risk

The reordering is observable to any caller that submits a request violating more than one guard at once: it now receives the capability error where it previously received the empty-prompt or zero-budget error. That is the behavior the issue asks for, it is covered by the new tests, and it is confined to requests that were going to be rejected either way.
