### PR TITLE
refactor(lora): extract shared adapter descriptor and blend validation into lattice-fann

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,31 @@ jobs:
           cache-on-failure: true
       - name: tune — safetensors + inference-hook + serde (compile tests)
         run: cargo test -p lattice-tune --features safetensors,inference-hook,serde --no-run
+      # `LoraConfig::validate` (the check `LoraAdapter::new` runs on every
+      # construction path) deliberately does not enforce a known-module-name
+      # allowlist — the adapter representation is model-neutral. The only
+      # remaining enforcement of unknown/wrong-architecture target-module
+      # names is `LoraAdapter::validate_against`/`validate_against_bert`,
+      # gated behind `inference-hook` like the rest of this step's compile
+      # target above, so the `--no-run` step only ever type-checks them.
+      # Build AND run this specific surface, same as the `mixture` and
+      # `simulated-teacher` steps below, so the fail-closed rejection tests
+      # cannot rot silently.
+      - name: tune — LoRA validate_against rejection tests (build + run)
+        run: |
+          log="${RUNNER_TEMP:-/tmp}/lora-validate-against-tests.log"
+          if cargo test -p lattice-tune --lib --features inference-hook \
+            validate_against >"$log" 2>&1
+          then
+            cat "$log"
+          else
+            status=$?
+            cat "$log"
+            exit "$status"
+          fi
+          grep -q 'test lora::tests::validate_against_tests::test_validate_against_unknown_module_errors ... ok' "$log"
+          grep -q 'test lora::tests::validate_against_bert_tests::test_validate_against_bert_unknown_module_rejected ... ok' "$log"
+          grep -Eq '^test result: ok\. [1-9][0-9]* passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' "$log"
       - name: tune — train-backward (compile tests)
         run: cargo test -p lattice-tune --features train-backward --no-run
       # The `mixture` feature gates the experimental online router-refit module

--- a/crates/fann/src/lib.rs
+++ b/crates/fann/src/lib.rs
@@ -14,6 +14,7 @@
 mod activation;
 mod error;
 mod layer;
+pub mod lora;
 mod network;
 pub mod training;
 
@@ -23,6 +24,7 @@ pub mod gpu;
 pub use activation::Activation;
 pub use error::{FannError, FannResult};
 pub use layer::Layer;
+pub use lora::LoraDescriptor;
 pub use network::{Network, NetworkBuilder};
 pub use training::{
     BackpropTrainer, GradientGuardStrategy, Trainer, TrainingConfig, TrainingResult,

--- a/crates/fann/src/lora.rs
+++ b/crates/fann/src/lora.rs
@@ -54,6 +54,58 @@ impl LoraDescriptor {
     }
 }
 
+/// Recognized LoRA target-module names across every architecture this
+/// project trains or serves adapters for: full-attention (GQA) `q_proj`,
+/// `k_proj`, `v_proj`, `o_proj`; linear-attention (GDN) `in_proj_qkv`,
+/// `in_proj_z`, `in_proj_b`, `in_proj_a`, `out_proj`; MLP `gate_proj`,
+/// `up_proj`, `down_proj`; BERT `query`, `key`, `value`, `attn_output`,
+/// `ffn_intermediate`, `ffn_output`.
+///
+/// This is a flat name allowlist, not an architecture-aware shape check —
+/// whether a given module is valid for a *specific* layer's type (e.g. a GDN
+/// module on a full-attention layer) is `qwen35_projection_shape`'s job in
+/// `lattice-inference`, which both `lattice-tune` and the Metal load path
+/// already call. This list exists so a descriptor's declared
+/// `target_modules` can be checked for typos or unrecognized names before
+/// any model architecture is known, in the one leaf crate both consumers share.
+pub const KNOWN_LORA_TARGET_MODULES: &[&str] = &[
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "o_proj",
+    "in_proj_qkv",
+    "in_proj_z",
+    "in_proj_b",
+    "in_proj_a",
+    "out_proj",
+    "gate_proj",
+    "up_proj",
+    "down_proj",
+    "query",
+    "key",
+    "value",
+    "attn_output",
+    "ffn_intermediate",
+    "ffn_output",
+];
+
+/// Reject any `target_modules` entry that is not present in `known`.
+pub fn validate_target_modules(target_modules: &[String], known: &[&str]) -> Result<(), String> {
+    let unknown: Vec<&str> = target_modules
+        .iter()
+        .map(String::as_str)
+        .filter(|m| !known.contains(m))
+        .collect();
+    if unknown.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "unknown LoRA target module(s): {}",
+            unknown.join(", ")
+        ))
+    }
+}
+
 /// Compute `alpha / rank`, treating rank `0` and any non-finite result as `0.0`.
 ///
 /// Free function form of [`LoraDescriptor::scale`] for callers that only
@@ -210,11 +262,17 @@ pub fn accumulate_planned_elements(
 /// Reject an aggregate element count exceeding [`MAX_BLEND_TOTAL_ELEMENTS`].
 pub fn check_aggregate_elements_cap(planned_elems: usize, ctx: &str) -> Result<(), String> {
     if planned_elems > MAX_BLEND_TOTAL_ELEMENTS {
+        // `MAX_BLEND_TOTAL_ELEMENTS * 4` is a compile-time constant expression:
+        // on a 32-bit `usize` target (e.g. `wasm32-unknown-unknown`) computing
+        // it in `usize` overflows u32::MAX and fails the build outright
+        // (`#[deny(arithmetic_overflow)]`), not just at large runtime inputs.
+        // Widening to `u64` first keeps the display math off the target's
+        // native word size; `fann` is a public leaf crate other targets embed.
+        let gib = (MAX_BLEND_TOTAL_ELEMENTS as u64 * 4) / (1024 * 1024 * 1024);
         Err(format!(
             "{ctx}: aggregate blend size {planned_elems} elements exceeds \
-             MAX_BLEND_TOTAL_ELEMENTS={MAX_BLEND_TOTAL_ELEMENTS} (~{} GiB f32); reduce the \
+             MAX_BLEND_TOTAL_ELEMENTS={MAX_BLEND_TOTAL_ELEMENTS} (~{gib} GiB f32); reduce the \
              number of adapters, their rank, or the number of target projections",
-            (MAX_BLEND_TOTAL_ELEMENTS * 4) / (1024 * 1024 * 1024)
         ))
     } else {
         Ok(())
@@ -279,7 +337,26 @@ mod tests {
     fn check_aggregate_elements_cap_rejects_over_budget() {
         let err = check_aggregate_elements_cap(MAX_BLEND_TOTAL_ELEMENTS + 1, "ctx").unwrap_err();
         assert!(err.contains("exceeds MAX_BLEND_TOTAL_ELEMENTS") || err.contains("aggregate"));
+        assert!(
+            err.contains("4 GiB"),
+            "error must report the 4 GiB budget; got: {err}"
+        );
         assert!(check_aggregate_elements_cap(MAX_BLEND_TOTAL_ELEMENTS, "ctx").is_ok());
+    }
+
+    /// `MAX_BLEND_TOTAL_ELEMENTS * 4` is a compile-time-constant expression:
+    /// on a 32-bit `usize` target (`wasm32-unknown-unknown`), evaluating it
+    /// in `usize` overflows u32::MAX and fails the build under
+    /// `#[deny(arithmetic_overflow)]`, regardless of `planned_elems` at
+    /// runtime — `cargo test` on this (64-bit) host cannot reproduce that,
+    /// so this pins the u64-widened math's result directly as a same-crate
+    /// regression guard; the 32-bit build itself was verified separately
+    /// with `rustc --target wasm32-unknown-unknown`.
+    #[test]
+    fn max_blend_total_elements_times_four_survives_u64_widening() {
+        let widened = (MAX_BLEND_TOTAL_ELEMENTS as u64).checked_mul(4);
+        assert!(widened.is_some(), "widened GiB math must not overflow u64");
+        assert_eq!(widened.unwrap() / (1024 * 1024 * 1024), 4);
     }
 
     #[test]
@@ -304,5 +381,23 @@ mod tests {
     fn accumulate_rank_overflow_errors() {
         let err = accumulate_rank(usize::MAX, 1, "ctx").unwrap_err();
         assert!(err.contains("overflowed usize"));
+    }
+
+    #[test]
+    fn validate_target_modules_accepts_known_names() {
+        let modules = vec!["q_proj".to_string(), "up_proj".to_string()];
+        assert!(validate_target_modules(&modules, KNOWN_LORA_TARGET_MODULES).is_ok());
+    }
+
+    #[test]
+    fn validate_target_modules_rejects_unknown_name() {
+        let modules = vec!["q_proj".to_string(), "not_a_real_module".to_string()];
+        let err = validate_target_modules(&modules, KNOWN_LORA_TARGET_MODULES).unwrap_err();
+        assert!(err.contains("not_a_real_module"));
+    }
+
+    #[test]
+    fn validate_target_modules_empty_is_ok() {
+        assert!(validate_target_modules(&[], KNOWN_LORA_TARGET_MODULES).is_ok());
     }
 }

--- a/crates/fann/src/lora.rs
+++ b/crates/fann/src/lora.rs
@@ -384,6 +384,35 @@ mod tests {
     }
 
     #[test]
+    fn checked_group_elements_rejects_dims_add_overflow() {
+        let err = checked_group_elements("ctx", 0, "q_proj", 1, usize::MAX, 1).unwrap_err();
+        assert!(
+            err.contains("d_in+d_out overflowed"),
+            "expected d_in+d_out overflow message; got: {err}"
+        );
+    }
+
+    #[test]
+    fn checked_group_elements_rejects_rank_dims_mul_overflow() {
+        // dims = d_in + d_out = 2 (no overflow); rank_total * dims = usize::MAX * 2
+        // overflows the multiplication.
+        let err = checked_group_elements("ctx", 0, "q_proj", usize::MAX, 1, 1).unwrap_err();
+        assert!(
+            err.contains("rank_total*(d_in+d_out) overflowed"),
+            "expected rank_total*(d_in+d_out) overflow message; got: {err}"
+        );
+    }
+
+    #[test]
+    fn accumulate_planned_elements_rejects_overflow() {
+        let err = accumulate_planned_elements(usize::MAX, 1, "ctx").unwrap_err();
+        assert!(
+            err.contains("aggregate blend element count overflowed"),
+            "expected aggregate overflow message; got: {err}"
+        );
+    }
+
+    #[test]
     fn validate_target_modules_accepts_known_names() {
         let modules = vec!["q_proj".to_string(), "up_proj".to_string()];
         assert!(validate_target_modules(&modules, KNOWN_LORA_TARGET_MODULES).is_ok());

--- a/crates/fann/src/lora.rs
+++ b/crates/fann/src/lora.rs
@@ -308,6 +308,33 @@ mod tests {
         }
     }
 
+    /// Direct regression for the `rank == 0` short-circuit: without it,
+    /// `alpha / rank as f32` divides by zero and produces `+inf` for a
+    /// positive finite `alpha`, which the very next check (`!scale.is_finite()`)
+    /// would then reject — wrongly failing a legitimate zero-rank adapter
+    /// (an empty factorization contributing nothing) that this branch exists
+    /// to accept.
+    #[test]
+    fn validate_alpha_finite_accepts_zero_rank_with_finite_alpha() {
+        assert!(validate_alpha_finite(0, 1.0).is_ok());
+        assert_eq!(effective_scale(0, 1.0), 0.0);
+    }
+
+    /// Direct regression for the effective-scale finite guard itself
+    /// (distinct from the `rank == 0` branch above): a typical finite
+    /// `(rank, alpha)` pair must validate. Given `alpha` is already checked
+    /// finite and `rank == 0` is short-circuited above this line, `alpha /
+    /// rank as f32` for a nonzero `rank` cannot itself become non-finite —
+    /// so this guard has no reachable "must fail" input today, and this test
+    /// instead pins the guard's "must pass" side: inverting the
+    /// `!scale.is_finite()` condition would make this fail directly, at the
+    /// fann crate level, instead of only through the many downstream
+    /// `lattice-tune` callers that route through it.
+    #[test]
+    fn validate_alpha_finite_accepts_typical_finite_scale() {
+        assert!(validate_alpha_finite(8, 16.0).is_ok());
+    }
+
     #[test]
     fn descriptor_validate_delegates_to_free_function() {
         let d = LoraDescriptor {
@@ -369,6 +396,37 @@ mod tests {
     fn check_buffer_lengths_rejects_short_b() {
         let err = check_buffer_lengths("ctx", 0, 2, 4, 4, 8, 7).unwrap_err();
         assert!(err.contains("B slice length"));
+    }
+
+    /// Direct regression for the `rank.checked_mul(d_in)` overflow guard:
+    /// replacing it with `unwrap_or(0)` would silently treat an overflowing
+    /// `rank*d_in` as `0`, so any `a_len` would then satisfy `a_len ==
+    /// expected_a` only when `a_len == 0` — a real overflow would either
+    /// false-reject a correctly-sized (impossibly large) buffer or, worse,
+    /// false-accept an empty one. Neither `checked_group_elements`'s own
+    /// overflow tests above nor any existing `check_buffer_lengths` test
+    /// drives `rank*d_in` past `usize::MAX`.
+    #[test]
+    fn check_buffer_lengths_rejects_rank_times_d_in_overflow() {
+        let err = check_buffer_lengths("ctx", 0, usize::MAX, 2, 1, 0, 0).unwrap_err();
+        assert!(
+            err.contains("rank*d_in overflowed usize"),
+            "expected rank*d_in overflow message; got: {err}"
+        );
+    }
+
+    /// Mirror of the above for `d_out.checked_mul(rank)`. Both `expected_a`
+    /// and `expected_b` are computed before either length is checked, so
+    /// `rank*d_in` (`2*1=2`) must itself stay within bounds for this to
+    /// reach and isolate the `d_out*rank` guard rather than failing on the
+    /// earlier `rank*d_in` guard instead.
+    #[test]
+    fn check_buffer_lengths_rejects_d_out_times_rank_overflow() {
+        let err = check_buffer_lengths("ctx", 0, 2, 1, usize::MAX, 0, 0).unwrap_err();
+        assert!(
+            err.contains("d_out*rank overflowed usize"),
+            "expected d_out*rank overflow message; got: {err}"
+        );
     }
 
     #[test]

--- a/crates/fann/src/lora.rs
+++ b/crates/fann/src/lora.rs
@@ -1,0 +1,308 @@
+//! Shared LoRA adapter descriptor and blend-validation primitives.
+//!
+//! `lattice-tune` and `lattice-inference` each own an independent LoRA
+//! adapter implementation (`lattice_tune::lora::LoraAdapter` for training and
+//! CPU serving; `lattice_inference::forward::metal_qwen35` for the Metal GPU
+//! decode path), and the crate dependency direction — `tune` may depend on
+//! `inference`, never the reverse — stops either from importing the other's
+//! validation rules directly. This module lives in `lattice-fann` because it
+//! is the only leaf crate both sides already reach: `tune` depends on it
+//! unconditionally, and `inference` depends on it optionally (the `mixture`
+//! and `metal-gpu` features both enable it), so a rule fixed here is fixed
+//! for every caller instead of drifting between two copies.
+//!
+//! Scope is deliberately narrow: adapter identity (rank, alpha, target
+//! modules, dtype) and the pure, allocation-free checks that guard adapter
+//! blending (weight finiteness, rank/element budget caps, buffer-shape
+//! consistency). The actual blend math (concatenating and scaling A/B
+//! buffers) and the forward-pass kernels stay in each crate — they operate
+//! on crate-local types (`LoraLayer` vs `LoraLayerData`) and are not the
+//! source of the drift this module fixes.
+
+/// A LoRA adapter's static identity: rank, scaling factor, target modules,
+/// and the tensor dtype it was trained/saved in.
+///
+/// `dtype` is a free-form label (e.g. `"f32"`, `"f16"`, `"bf16"`) — it is not
+/// validated here, matching the existing manifest convention where real
+/// tensor dtypes are checked independently at load time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoraDescriptor {
+    /// Low-rank dimension. Typical values: 4, 8, 16, 32, 64.
+    pub rank: usize,
+    /// Scaling factor. The effective scale is `alpha / rank`.
+    pub alpha: f32,
+    /// Names of the modules that have LoRA adapters, e.g. `["q_proj", "v_proj"]`.
+    pub target_modules: Vec<String>,
+    /// Tensor dtype label the adapter was trained/saved in.
+    pub dtype: String,
+}
+
+impl LoraDescriptor {
+    /// Compute the LoRA scaling factor: `alpha / rank`.
+    ///
+    /// A zero rank has an effective scale of zero (an empty factorization
+    /// contributes nothing), and a non-finite `alpha` or resulting scale
+    /// also collapses to zero rather than propagating NaN/Inf into the
+    /// forward pass.
+    pub fn scale(&self) -> f32 {
+        effective_scale(self.rank, self.alpha)
+    }
+
+    /// Validate that `alpha` and the effective `alpha / rank` scale are finite.
+    pub fn validate(&self) -> Result<(), String> {
+        validate_alpha_finite(self.rank, self.alpha)
+    }
+}
+
+/// Compute `alpha / rank`, treating rank `0` and any non-finite result as `0.0`.
+///
+/// Free function form of [`LoraDescriptor::scale`] for callers that only
+/// have `(rank, alpha)` on hand and do not want to build a full descriptor.
+pub fn effective_scale(rank: usize, alpha: f32) -> f32 {
+    let scale = if rank == 0 { 0.0 } else { alpha / rank as f32 };
+    if alpha.is_finite() && scale.is_finite() {
+        scale
+    } else {
+        0.0
+    }
+}
+
+/// Validate that `alpha` and the effective `alpha / rank` scale are finite.
+///
+/// Free function form of [`LoraDescriptor::validate`].
+pub fn validate_alpha_finite(rank: usize, alpha: f32) -> Result<(), String> {
+    if !alpha.is_finite() {
+        return Err(format!("LoRA alpha must be finite, got {alpha}"));
+    }
+    let scale = if rank == 0 { 0.0 } else { alpha / rank as f32 };
+    if !scale.is_finite() {
+        return Err(format!("LoRA effective scale must be finite, got {scale}"));
+    }
+    Ok(())
+}
+
+/// Maximum summed rank for one blended projection.
+///
+/// The Metal GEMV kernels assume a modest rank budget (≤ ~64 per adapter in
+/// a typical mixture); this cap bounds allocations and rejects
+/// adversarially large adapter pools before any `Vec::with_capacity`.
+pub const MAX_BLEND_RANK_TOTAL: usize = 4096;
+
+/// Aggregate cap on a blended adapter's total element count, summed across
+/// every `(layer_idx, module)` projection: `Σ rank_total·(d_in + d_out)`.
+/// At f32 this bounds the blended-adapter allocation to ~4 GiB.
+pub const MAX_BLEND_TOTAL_ELEMENTS: usize = 1usize << 30; // 1,073,741,824 elements ≈ 4 GiB f32
+
+/// Reject a non-finite blend mixture weight.
+///
+/// `ctx` is the caller's function name, reproduced verbatim in the error
+/// message so each crate's existing message format is unchanged.
+pub fn check_finite_weight(ctx: &str, idx: usize, weight: f32) -> Result<(), String> {
+    if !weight.is_finite() {
+        Err(format!(
+            "{ctx}: weight at index {idx} is not finite ({weight})"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Checked-accumulate `rank` into `acc`.
+pub fn accumulate_rank(acc: usize, rank: usize, ctx: &str) -> Result<usize, String> {
+    acc.checked_add(rank)
+        .ok_or_else(|| format!("{ctx}: rank_total overflowed usize"))
+}
+
+/// Reject a summed rank exceeding [`MAX_BLEND_RANK_TOTAL`].
+pub fn check_rank_total_cap(rank_total: usize, ctx: &str) -> Result<(), String> {
+    if rank_total > MAX_BLEND_RANK_TOTAL {
+        Err(format!(
+            "{ctx}: summed rank {rank_total} exceeds MAX_BLEND_RANK_TOTAL={MAX_BLEND_RANK_TOTAL}"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Reject mismatched `(d_in, d_out)` between the first entry of a projection
+/// group and a later entry being folded into it.
+#[allow(clippy::too_many_arguments)]
+pub fn check_dims_match(
+    ctx: &str,
+    layer_idx: usize,
+    module: &str,
+    d_in: usize,
+    d_out: usize,
+    idx: usize,
+    entry_d_in: usize,
+    entry_d_out: usize,
+) -> Result<(), String> {
+    if entry_d_in != d_in || entry_d_out != d_out {
+        Err(format!(
+            "{ctx}: layer {layer_idx} module '{module}' has mismatched dimensions \
+             (entry 0: d_in={d_in}, d_out={d_out}; entry {idx}: d_in={entry_d_in}, d_out={entry_d_out})"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Verify an entry's A/B slice lengths match its declared `rank`, `d_in`,
+/// and `d_out` (row-major `A: (rank, d_in)`, `B: (d_out, rank)`).
+pub fn check_buffer_lengths(
+    ctx: &str,
+    idx: usize,
+    rank: usize,
+    d_in: usize,
+    d_out: usize,
+    a_len: usize,
+    b_len: usize,
+) -> Result<(), String> {
+    let expected_a = rank
+        .checked_mul(d_in)
+        .ok_or_else(|| format!("{ctx}: rank*d_in overflowed usize"))?;
+    let expected_b = d_out
+        .checked_mul(rank)
+        .ok_or_else(|| format!("{ctx}: d_out*rank overflowed usize"))?;
+    if a_len != expected_a {
+        return Err(format!(
+            "{ctx}: entry {idx} A slice length {a_len} \
+             does not match rank*d_in={rank}*{d_in}={expected_a}"
+        ));
+    }
+    if b_len != expected_b {
+        return Err(format!(
+            "{ctx}: entry {idx} B slice length {b_len} \
+             does not match d_out*rank={d_out}*{rank}={expected_b}"
+        ));
+    }
+    Ok(())
+}
+
+/// Checked `rank_total * (d_in + d_out)` for one projection group, used to
+/// build the aggregate element budget across every group before allocating.
+pub fn checked_group_elements(
+    ctx: &str,
+    layer_idx: usize,
+    module: &str,
+    rank_total: usize,
+    d_in: usize,
+    d_out: usize,
+) -> Result<usize, String> {
+    let dims = d_in.checked_add(d_out).ok_or_else(|| {
+        format!("{ctx}: layer {layer_idx} module '{module}' d_in+d_out overflowed usize")
+    })?;
+    rank_total
+        .checked_mul(dims)
+        .ok_or_else(|| format!("{ctx}: rank_total*(d_in+d_out) overflowed usize"))
+}
+
+/// Checked-accumulate one group's element count into the running aggregate.
+pub fn accumulate_planned_elements(
+    acc: usize,
+    group_elems: usize,
+    ctx: &str,
+) -> Result<usize, String> {
+    acc.checked_add(group_elems)
+        .ok_or_else(|| format!("{ctx}: aggregate blend element count overflowed usize"))
+}
+
+/// Reject an aggregate element count exceeding [`MAX_BLEND_TOTAL_ELEMENTS`].
+pub fn check_aggregate_elements_cap(planned_elems: usize, ctx: &str) -> Result<(), String> {
+    if planned_elems > MAX_BLEND_TOTAL_ELEMENTS {
+        Err(format!(
+            "{ctx}: aggregate blend size {planned_elems} elements exceeds \
+             MAX_BLEND_TOTAL_ELEMENTS={MAX_BLEND_TOTAL_ELEMENTS} (~{} GiB f32); reduce the \
+             number of adapters, their rank, or the number of target projections",
+            (MAX_BLEND_TOTAL_ELEMENTS * 4) / (1024 * 1024 * 1024)
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effective_scale_zero_rank_is_zero() {
+        assert_eq!(effective_scale(0, 4.0), 0.0);
+    }
+
+    #[test]
+    fn effective_scale_matches_alpha_over_rank() {
+        assert_eq!(effective_scale(2, 4.0), 2.0);
+    }
+
+    #[test]
+    fn effective_scale_non_finite_alpha_collapses_to_zero() {
+        for alpha in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            assert_eq!(effective_scale(8, alpha), 0.0);
+        }
+    }
+
+    #[test]
+    fn validate_alpha_finite_rejects_non_finite() {
+        for alpha in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let err = validate_alpha_finite(8, alpha).unwrap_err();
+            assert!(err.contains("alpha must be finite"));
+        }
+    }
+
+    #[test]
+    fn descriptor_validate_delegates_to_free_function() {
+        let d = LoraDescriptor {
+            rank: 8,
+            alpha: f32::NAN,
+            target_modules: vec![],
+            dtype: "f32".into(),
+        };
+        assert!(d.validate().is_err());
+        assert_eq!(d.scale(), 0.0);
+    }
+
+    #[test]
+    fn check_finite_weight_rejects_nan() {
+        let err = check_finite_weight("ctx", 3, f32::NAN).unwrap_err();
+        assert!(err.contains("weight at index 3 is not finite"));
+    }
+
+    #[test]
+    fn check_rank_total_cap_rejects_over_budget() {
+        let err = check_rank_total_cap(MAX_BLEND_RANK_TOTAL + 1, "ctx").unwrap_err();
+        assert!(err.contains("exceeds MAX_BLEND_RANK_TOTAL"));
+        assert!(check_rank_total_cap(MAX_BLEND_RANK_TOTAL, "ctx").is_ok());
+    }
+
+    #[test]
+    fn check_aggregate_elements_cap_rejects_over_budget() {
+        let err = check_aggregate_elements_cap(MAX_BLEND_TOTAL_ELEMENTS + 1, "ctx").unwrap_err();
+        assert!(err.contains("exceeds MAX_BLEND_TOTAL_ELEMENTS") || err.contains("aggregate"));
+        assert!(check_aggregate_elements_cap(MAX_BLEND_TOTAL_ELEMENTS, "ctx").is_ok());
+    }
+
+    #[test]
+    fn check_buffer_lengths_rejects_short_a() {
+        let err = check_buffer_lengths("ctx", 0, 2, 4, 4, 7, 8).unwrap_err();
+        assert!(err.contains("A slice length"));
+    }
+
+    #[test]
+    fn check_buffer_lengths_rejects_short_b() {
+        let err = check_buffer_lengths("ctx", 0, 2, 4, 4, 8, 7).unwrap_err();
+        assert!(err.contains("B slice length"));
+    }
+
+    #[test]
+    fn check_dims_match_rejects_mismatch() {
+        let err = check_dims_match("ctx", 0, "q_proj", 4, 4, 1, 4, 8).unwrap_err();
+        assert!(err.contains("mismatched dimensions"));
+    }
+
+    #[test]
+    fn accumulate_rank_overflow_errors() {
+        let err = accumulate_rank(usize::MAX, 1, "ctx").unwrap_err();
+        assert!(err.contains("overflowed usize"));
+    }
+}

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -33,7 +33,10 @@ serve = [
 ]
 std = []
 f16 = []
-metal-gpu = ["dep:metal", "dep:objc"]
+# lattice-fann supplies the shared LoRA descriptor/blend-validation module
+# (issue #615) that `blend_lora_layer_data` and `chat_metal` call, so it must
+# be present whenever this feature is — not just under `mixture`.
+metal-gpu = ["dep:metal", "dep:objc", "dep:lattice-fann"]
 wgpu-gpu = ["dep:wgpu", "dep:pollster", "dep:bytemuck"]
 bench-internals = []
 bench-ort = ["dep:ort", "dep:tokenizers", "f16"]
@@ -41,8 +44,10 @@ backfill = ["dep:rusqlite", "f16"]
 download = ["dep:ureq"]
 train-backward = []
 # AdapterRouter gate: enables the lattice-fann backed routing module.
-# blend_lora_layer_data and generate_with_lora_mixture do NOT require this
-# feature — they are always available.
+# generate_with_lora_mixture does NOT require this feature — it is always
+# available under `metal-gpu`. blend_lora_layer_data now depends on
+# lattice-fann too (issue #615), but that dep is already pulled in by
+# `metal-gpu` itself, so this feature only adds the routing module.
 mixture = ["dep:lattice-fann"]
 # GDN state-traffic byte counters (issue #422, measure-first for ADR-058).
 # Opt-in only: the default decode path stays byte-identical when this is off.

--- a/crates/inference/src/bin/chat_metal.rs
+++ b/crates/inference/src/bin/chat_metal.rs
@@ -383,12 +383,15 @@ fn load_lora_safetensors(
     // Sort by layer_idx for deterministic load order.
     layers.sort_by_key(|l| (l.layer_idx, l.module.clone()));
 
-    // Compute scale = alpha / rank.
+    // Compute scale = alpha / rank via the shared lattice-fann helper (issue #615) —
     // Prefer __metadata__.alpha when available; fall back to alpha = rank (scale = 1.0),
     // matching the tune crate's own default for adapters without embedded metadata.
+    // A rank of 0 (malformed metadata) now resolves to scale = 0.0, matching
+    // `lattice_tune::lora::LoraConfig::scale` — this bin previously fell back to
+    // scale = 1.0 for that case, which is a drift this shares away rather than picks.
     let rank = rank_global.unwrap_or(1);
     let alpha = metadata_alpha.unwrap_or(rank as f32);
-    let scale = if rank > 0 { alpha / rank as f32 } else { 1.0 };
+    let scale = lattice_fann::lora::effective_scale(rank, alpha);
 
     eprintln!(
         "[chat_metal] LoRA: {} layer×module pairs, rank={}, alpha={}, scale={:.2}",
@@ -1325,5 +1328,19 @@ mod tests {
         let parsed =
             parse_serve_request_line(r#"{"prompt":"hi","stop":["\n"]}"#, defaults()).unwrap();
         assert_eq!(parsed.prompt, "hi");
+    }
+
+    // Pre-#615, this file's LoRA scale computation was `if rank > 0 { alpha /
+    // rank } else { 1.0 }` — a rank-0 adapter's scale silently resolved to
+    // 1.0 (full-strength passthrough of a degenerate zero-rank delta).
+    // `lattice_tune::lora::LoraConfig::scale` (crates/tune/src/lora/mod.rs)
+    // has always resolved the same input to 0.0 (an empty factorization
+    // contributes nothing). The two copies disagreed on this edge case;
+    // adopting the shared `lattice_fann::lora::effective_scale` here
+    // resolves it to tune's value. This pins that resolution so it cannot
+    // silently drift back to the old fallback.
+    #[test]
+    fn cm_chat_metal_zero_rank_scale_matches_tune_not_the_old_local_fallback() {
+        assert_eq!(lattice_fann::lora::effective_scale(0, 5.0), 0.0);
     }
 }

--- a/crates/inference/src/bin/chat_metal.rs
+++ b/crates/inference/src/bin/chat_metal.rs
@@ -145,13 +145,34 @@ fn is_supported_lora_target(block: &str, module: &str) -> bool {
     }
 }
 
+/// Resolve the `(rank, alpha, scale)` a [`load_lora_safetensors`] call will
+/// use, given the rank inferred from the adapter's tensor shapes and the
+/// alpha parsed from `__metadata__` (if present).
+///
+/// Prefers `__metadata__.alpha` when available; falls back to `alpha = rank`
+/// (scale = 1.0), matching the tune crate's own default for adapters
+/// without embedded metadata. Scale itself is the shared
+/// `lattice-fann` helper (issue #615) — a rank of 0 (malformed metadata)
+/// resolves to scale = 0.0, matching `lattice_tune::lora::LoraConfig::scale`.
+/// This bin previously fell back to scale = 1.0 for that case; adopting the
+/// shared helper here resolves the drift to tune's value.
+fn resolve_lora_rank_alpha_scale(
+    rank_global: Option<usize>,
+    metadata_alpha: Option<f32>,
+) -> (usize, f32, f32) {
+    let rank = rank_global.unwrap_or(1);
+    let alpha = metadata_alpha.unwrap_or(rank as f32);
+    let scale = lattice_fann::lora::effective_scale(rank, alpha);
+    (rank, alpha, scale)
+}
+
 #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 fn load_lora_safetensors(
     path: &std::path::Path,
 ) -> Result<
     (
         Vec<lattice_inference::forward::metal_qwen35::LoraLayerData>,
-        f32,
+        lattice_fann::lora::LoraDescriptor,
     ),
     Box<dyn std::error::Error>,
 > {
@@ -383,15 +404,21 @@ fn load_lora_safetensors(
     // Sort by layer_idx for deterministic load order.
     layers.sort_by_key(|l| (l.layer_idx, l.module.clone()));
 
-    // Compute scale = alpha / rank via the shared lattice-fann helper (issue #615) —
-    // Prefer __metadata__.alpha when available; fall back to alpha = rank (scale = 1.0),
-    // matching the tune crate's own default for adapters without embedded metadata.
-    // A rank of 0 (malformed metadata) now resolves to scale = 0.0, matching
-    // `lattice_tune::lora::LoraConfig::scale` — this bin previously fell back to
-    // scale = 1.0 for that case, which is a drift this shares away rather than picks.
-    let rank = rank_global.unwrap_or(1);
-    let alpha = metadata_alpha.unwrap_or(rank as f32);
-    let scale = lattice_fann::lora::effective_scale(rank, alpha);
+    let (rank, alpha, scale) = resolve_lora_rank_alpha_scale(rank_global, metadata_alpha);
+
+    let mut target_modules: Vec<String> = layers.iter().map(|l| l.module.clone()).collect();
+    target_modules.sort();
+    target_modules.dedup();
+
+    // In-memory representation is always f32 (`get_f32_tensor` above already
+    // converted any F16/BF16 source tensors), matching the `lattice-tune`
+    // safetensors loader's own convention for this field.
+    let descriptor = lattice_fann::lora::LoraDescriptor {
+        rank,
+        alpha,
+        target_modules,
+        dtype: "f32".into(),
+    };
 
     eprintln!(
         "[chat_metal] LoRA: {} layer×module pairs, rank={}, alpha={}, scale={:.2}",
@@ -401,7 +428,7 @@ fn load_lora_safetensors(
         scale
     );
 
-    Ok((layers, scale))
+    Ok((layers, descriptor))
 }
 
 // ─── JSON generation helper (shared by one-shot and serve paths) ────────────
@@ -820,9 +847,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(ref lp) = lora_path {
         eprintln!("[chat_metal] Loading LoRA adapter from {}...", lp.display());
         let t_lora = std::time::Instant::now();
-        let (layers, scale) = load_lora_safetensors(lp)?;
+        let (layers, descriptor) = load_lora_safetensors(lp)?;
         metal
-            .load_lora_adapter(layers, scale, None)
+            .load_lora_adapter_with_descriptor(layers, &descriptor, None)
             .map_err(|e| format!("load_lora_adapter failed: {e}"))?;
         eprintln!(
             "[chat_metal] LoRA loaded in {:.1}s",
@@ -1343,10 +1370,64 @@ mod tests {
     // has always resolved the same input to 0.0 (an empty factorization
     // contributes nothing). The two copies disagreed on this edge case;
     // adopting the shared `lattice_fann::lora::effective_scale` here
-    // resolves it to tune's value. This pins that resolution so it cannot
-    // silently drift back to the old fallback.
+    // resolves it to tune's value.
+    //
+    // This pins that resolution through `load_lora_safetensors` itself — the
+    // production call site — via a fixture with a rank-0 A/B tensor pair
+    // (shape [0, d_in] / [d_out, 0]) and an explicit `__metadata__.alpha`,
+    // not by re-deriving the answer from `effective_scale` directly. A
+    // version calling `effective_scale` in isolation stays green even if the
+    // call site reverts to the old inline fallback; this one does not.
     #[test]
     fn cm_chat_metal_zero_rank_scale_matches_tune_not_the_old_local_fallback() {
-        assert_eq!(lattice_fann::lora::effective_scale(0, 5.0), 0.0);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("zero_rank.safetensors");
+
+        let mut header = serde_json::Map::new();
+        header.insert(
+            "__metadata__".to_string(),
+            serde_json::json!({"alpha": "5.0"}),
+        );
+        header.insert(
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight".to_string(),
+            serde_json::json!({"dtype": "F32", "shape": [0, 4], "data_offsets": [0, 0]}),
+        );
+        header.insert(
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight".to_string(),
+            serde_json::json!({"dtype": "F32", "shape": [4, 0], "data_offsets": [0, 0]}),
+        );
+        let header_bytes = serde_json::to_vec(&header).unwrap();
+        let mut bytes = (header_bytes.len() as u64).to_le_bytes().to_vec();
+        bytes.extend_from_slice(&header_bytes);
+        std::fs::write(&path, bytes).unwrap();
+
+        let (layers, descriptor) =
+            load_lora_safetensors(&path).expect("zero-rank adapter must load");
+        assert_eq!(layers.len(), 1);
+        assert_eq!(layers[0].rank, 0);
+        assert_eq!(
+            descriptor.scale(),
+            0.0,
+            "rank=0 with alpha=5.0 must resolve to scale=0.0 (matches \
+             lattice_tune::lora::LoraConfig::scale), not the old 1.0 fallback"
+        );
+    }
+
+    // `resolve_lora_rank_alpha_scale` is the pure decision extracted from
+    // `load_lora_safetensors`; covering its metadata-present/absent branches
+    // directly complements the fixture-driven test above, which only
+    // exercises the metadata-present path end to end.
+    #[test]
+    fn resolve_lora_rank_alpha_scale_falls_back_to_rank_as_alpha_without_metadata() {
+        let (rank, alpha, scale) = resolve_lora_rank_alpha_scale(Some(4), None);
+        assert_eq!(rank, 4);
+        assert_eq!(alpha, 4.0);
+        assert_eq!(scale, 1.0);
+    }
+
+    #[test]
+    fn resolve_lora_rank_alpha_scale_defaults_rank_to_one_when_absent() {
+        let (rank, _alpha, _scale) = resolve_lora_rank_alpha_scale(None, None);
+        assert_eq!(rank, 1);
     }
 }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -3759,6 +3759,17 @@ mod inner {
         /// (`in_proj_a`, `in_proj_b` not yet supported — consumed inside fused kernels).
         /// MLP modules (both layer types): `gate_proj`, `up_proj`, `down_proj`.
         ///
+        /// This is the deliberate low-level entry point: `scale` is applied
+        /// exactly as given, with no cross-check against any adapter
+        /// identity (no descriptor, no per-layer rank comparison, nothing
+        /// derived from `layers` itself). The caller owns the invariant that
+        /// `scale` is the correct `alpha / rank` for the adapter these
+        /// `layers` actually represent — this function has no way to verify
+        /// that on its own. Prefer [`Self::load_lora_adapter_with_descriptor`]
+        /// when `scale` should instead be derived from, and checked against,
+        /// a [`lattice_fann::lora::LoraDescriptor`]'s declared rank and
+        /// target modules.
+        ///
         /// # Errors
         ///
         /// Returns an error if:

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -1702,17 +1702,13 @@ mod inner {
     /// The Metal GEMV kernels assume a modest rank budget (≤ ~64 per adapter in a
     /// typical mixture).  This cap bounds allocations and rejects adversarially large
     /// adapter pools before `Vec::with_capacity`.
-    pub(crate) const MAX_BLEND_RANK_TOTAL: usize = 4096;
-
-    /// Aggregate cap on a blended adapter's total element count, summed across
-    /// every (layer_idx, module) projection: Σ rank_total·(d_in + d_out). At f32
-    /// this bounds the blended-adapter allocation to ~4 GiB. MAX_BLEND_RANK_TOTAL
-    /// bounds one projection; this bounds the whole blend, so a full-model adapter
-    /// that keeps every projection near the per-group cap cannot drive a multi-GiB
-    /// aggregate allocation. A realistic micro-LoRA mixture is far below this; a
-    /// large-model mixture at modest summed rank stays within budget, while a
-    /// rank-4096-everywhere adapter (tens of GiB) is rejected before any allocation.
-    pub(crate) const MAX_BLEND_TOTAL_ELEMENTS: usize = 1 << 30; // 1,073,741,824 elements ≈ 4 GiB f32
+    ///
+    /// Re-exported from [`lattice_fann::lora::MAX_BLEND_RANK_TOTAL`], the shared
+    /// cap this crate and `lattice-tune`'s CPU LoRA blend both enforce. Only
+    /// referenced by tests below — non-test code calls `lattice_fann::lora::*`
+    /// directly so the cap itself lives in exactly one place.
+    #[cfg(test)]
+    pub(crate) const MAX_BLEND_RANK_TOTAL: usize = lattice_fann::lora::MAX_BLEND_RANK_TOTAL;
 
     /// Blend multiple sets of [`LoraLayerData`] into one rank-Σr set for use with
     /// the single-slot [`MetalQwen35State::load_lora_adapter`] API.
@@ -1754,11 +1750,8 @@ mod inner {
         }
 
         for (idx, (_, w)) in inputs.iter().enumerate() {
-            if !w.is_finite() {
-                return Err(InferenceError::InvalidInput(format!(
-                    "blend_lora_layer_data: weight at index {idx} is not finite ({w})"
-                )));
-            }
+            lattice_fann::lora::check_finite_weight("blend_lora_layer_data", idx, *w)
+                .map_err(InferenceError::InvalidInput)?;
         }
 
         // Group by (layer_idx, module): collect refs to layer data and effective weights.
@@ -1780,38 +1773,33 @@ mod inner {
         let mut planned_elems: usize = 0;
         for ((layer_idx, module), entries) in &grouped {
             let (first, _) = entries[0]; // each key was inserted with >=1 entry
-            let dims = first.d_in.checked_add(first.d_out).ok_or_else(|| {
-                InferenceError::InvalidInput(format!(
-                    "blend_lora_layer_data: layer {layer_idx} module '{module}' d_in+d_out overflowed usize"
-                ))
-            })?;
             let mut group_rank: usize = 0;
             for (entry, _) in entries {
-                group_rank = group_rank.checked_add(entry.rank).ok_or_else(|| {
-                    InferenceError::InvalidInput(
-                        "blend_lora_layer_data: rank_total overflowed usize".into(),
-                    )
-                })?;
+                group_rank = lattice_fann::lora::accumulate_rank(
+                    group_rank,
+                    entry.rank,
+                    "blend_lora_layer_data",
+                )
+                .map_err(InferenceError::InvalidInput)?;
             }
-            let group_elems = group_rank.checked_mul(dims).ok_or_else(|| {
-                InferenceError::InvalidInput(
-                    "blend_lora_layer_data: rank_total*(d_in+d_out) overflowed usize".into(),
-                )
-            })?;
-            planned_elems = planned_elems.checked_add(group_elems).ok_or_else(|| {
-                InferenceError::InvalidInput(
-                    "blend_lora_layer_data: aggregate blend element count overflowed usize".into(),
-                )
-            })?;
+            let group_elems = lattice_fann::lora::checked_group_elements(
+                "blend_lora_layer_data",
+                *layer_idx,
+                module,
+                group_rank,
+                first.d_in,
+                first.d_out,
+            )
+            .map_err(InferenceError::InvalidInput)?;
+            planned_elems = lattice_fann::lora::accumulate_planned_elements(
+                planned_elems,
+                group_elems,
+                "blend_lora_layer_data",
+            )
+            .map_err(InferenceError::InvalidInput)?;
         }
-        if planned_elems > MAX_BLEND_TOTAL_ELEMENTS {
-            return Err(InferenceError::InvalidInput(format!(
-                "blend_lora_layer_data: aggregate blend size {planned_elems} elements exceeds \
-                 MAX_BLEND_TOTAL_ELEMENTS={MAX_BLEND_TOTAL_ELEMENTS} (~{} GiB f32); reduce the \
-                 number of adapters, their rank, or the number of target projections",
-                (MAX_BLEND_TOTAL_ELEMENTS * 4) / (1024 * 1024 * 1024)
-            )));
-        }
+        lattice_fann::lora::check_aggregate_elements_cap(planned_elems, "blend_lora_layer_data")
+            .map_err(InferenceError::InvalidInput)?;
 
         let mut result: Vec<LoraLayerData> = Vec::with_capacity(grouped.len());
         for ((layer_idx, module), entries) in grouped {
@@ -1821,64 +1809,46 @@ mod inner {
 
             // Validate dimension consistency across adapters for this projection.
             for (idx, (entry, _)) in entries.iter().enumerate() {
-                if entry.d_in != d_in || entry.d_out != d_out {
-                    return Err(InferenceError::InvalidInput(format!(
-                        "blend_lora_layer_data: layer {layer_idx} module '{module}' has \
-                         mismatched dimensions (entry 0: d_in={d_in}, d_out={d_out}; \
-                         entry {idx}: d_in={}, d_out={})",
-                        entry.d_in, entry.d_out
-                    )));
-                }
+                lattice_fann::lora::check_dims_match(
+                    "blend_lora_layer_data",
+                    layer_idx,
+                    &module,
+                    d_in,
+                    d_out,
+                    idx,
+                    entry.d_in,
+                    entry.d_out,
+                )
+                .map_err(InferenceError::InvalidInput)?;
             }
 
             // Accumulate rank_total with overflow protection and a hard cap
             // (MAX_BLEND_RANK_TOTAL is defined at module scope above this function).
             let mut rank_total: usize = 0;
             for (layer, _) in &entries {
-                rank_total = rank_total.checked_add(layer.rank).ok_or_else(|| {
-                    InferenceError::InvalidInput(
-                        "blend_lora_layer_data: rank_total overflowed usize".into(),
-                    )
-                })?;
+                rank_total = lattice_fann::lora::accumulate_rank(
+                    rank_total,
+                    layer.rank,
+                    "blend_lora_layer_data",
+                )
+                .map_err(InferenceError::InvalidInput)?;
             }
-            if rank_total > MAX_BLEND_RANK_TOTAL {
-                return Err(InferenceError::InvalidInput(format!(
-                    "blend_lora_layer_data: summed rank {rank_total} exceeds \
-                     MAX_BLEND_RANK_TOTAL={MAX_BLEND_RANK_TOTAL}"
-                )));
-            }
+            lattice_fann::lora::check_rank_total_cap(rank_total, "blend_lora_layer_data")
+                .map_err(InferenceError::InvalidInput)?;
 
             // Validate source slice lengths before any allocation: a malformed adapter
             // whose A or B buffer is the wrong size would cause out-of-bounds copies.
             for (idx, (entry, _)) in entries.iter().enumerate() {
-                let expected_a = entry.rank.checked_mul(d_in).ok_or_else(|| {
-                    InferenceError::InvalidInput(
-                        "blend_lora_layer_data: rank*d_in overflowed usize".into(),
-                    )
-                })?;
-                let expected_b = d_out.checked_mul(entry.rank).ok_or_else(|| {
-                    InferenceError::InvalidInput(
-                        "blend_lora_layer_data: d_out*rank overflowed usize".into(),
-                    )
-                })?;
-                if entry.a.len() != expected_a {
-                    return Err(InferenceError::InvalidInput(format!(
-                        "blend_lora_layer_data: entry {idx} A slice length {} \
-                         does not match rank*d_in={}*{}={expected_a}",
-                        entry.a.len(),
-                        entry.rank,
-                        d_in,
-                    )));
-                }
-                if entry.b.len() != expected_b {
-                    return Err(InferenceError::InvalidInput(format!(
-                        "blend_lora_layer_data: entry {idx} B slice length {} \
-                         does not match d_out*rank={}*{}={expected_b}",
-                        entry.b.len(),
-                        d_out,
-                        entry.rank,
-                    )));
-                }
+                lattice_fann::lora::check_buffer_lengths(
+                    "blend_lora_layer_data",
+                    idx,
+                    entry.rank,
+                    d_in,
+                    d_out,
+                    entry.a.len(),
+                    entry.b.len(),
+                )
+                .map_err(InferenceError::InvalidInput)?;
             }
 
             let a_buf_len = rank_total.checked_mul(d_in).ok_or_else(|| {
@@ -33923,7 +33893,6 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         // -----------------------------------------------------------------
         #[test]
         fn blend_aggregate_budget_exceeded_returns_err() {
-            // MAX_BLEND_TOTAL_ELEMENTS is in scope via `use super::*` above.
             let rank = MAX_BLEND_RANK_TOTAL; // 4096 — exactly at per-group cap
             let d_in = 2048usize;
             let d_out = 2048usize;

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -3959,16 +3959,27 @@ mod inner {
         /// scale and declared target modules, instead of a bare `scale: f32`
         /// the caller must have derived correctly on its own.
         ///
-        /// Validates `descriptor.alpha`/effective scale (finite) and
-        /// `descriptor.target_modules` (recognized names) before delegating
-        /// to [`Self::load_lora_adapter`] with `descriptor.scale()`. Every
+        /// Validates `descriptor.alpha`/effective scale (finite),
+        /// `descriptor.target_modules` (recognized names), that every
+        /// nonempty `layers` entry's rank matches `descriptor.rank`, and that
+        /// the set of modules present in `layers` matches
+        /// `descriptor.target_modules` exactly — before delegating to
+        /// [`Self::load_lora_adapter`] with `descriptor.scale()`. Every
         /// per-layer, per-architecture shape check `load_lora_adapter` already
         /// performs still applies on top of this.
+        ///
+        /// `descriptor.rank` and `descriptor.target_modules` are the inputs
+        /// `descriptor.scale()` is computed from; without this check a caller
+        /// could pass `layers` built at one rank alongside a `descriptor` built
+        /// at another (or covering a different module set) and silently get
+        /// the wrong scale applied to correctly-shaped buffers.
         ///
         /// # Errors
         ///
         /// Returns an error if the descriptor's alpha/scale is not finite, if
-        /// `target_modules` contains an unrecognized name, or for any reason
+        /// `target_modules` contains an unrecognized name, if any layer's
+        /// rank disagrees with `descriptor.rank`, if the loaded module set
+        /// disagrees with `descriptor.target_modules`, or for any reason
         /// [`Self::load_lora_adapter`] itself would reject the call.
         pub fn load_lora_adapter_with_descriptor(
             &mut self,
@@ -3986,6 +3997,33 @@ mod inner {
                 lattice_fann::lora::KNOWN_LORA_TARGET_MODULES,
             )
             .map_err(InferenceError::InvalidInput)?;
+
+            for layer in &layers {
+                if layer.rank != descriptor.rank {
+                    return Err(InferenceError::InvalidInput(format!(
+                        "load_lora_adapter_with_descriptor: layer {} module '{}' has \
+                         rank={} but descriptor declares rank={}",
+                        layer.layer_idx, layer.module, layer.rank, descriptor.rank
+                    )));
+                }
+            }
+
+            let mut layer_modules: Vec<&str> = layers.iter().map(|l| l.module.as_str()).collect();
+            layer_modules.sort_unstable();
+            layer_modules.dedup();
+            let mut declared_modules: Vec<&str> = descriptor
+                .target_modules
+                .iter()
+                .map(String::as_str)
+                .collect();
+            declared_modules.sort_unstable();
+            declared_modules.dedup();
+            if layer_modules != declared_modules {
+                return Err(InferenceError::InvalidInput(format!(
+                    "load_lora_adapter_with_descriptor: loaded layer modules {layer_modules:?} \
+                     do not match descriptor.target_modules {declared_modules:?}"
+                )));
+            }
 
             self.load_lora_adapter(layers, descriptor.scale(), quarot_seed)
         }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -1719,6 +1719,29 @@ mod inner {
     #[cfg(test)]
     pub(crate) const MAX_BLEND_RANK_TOTAL: usize = lattice_fann::lora::MAX_BLEND_RANK_TOTAL;
 
+    /// Reject any element of `inputs` whose inner layer slice is empty.
+    ///
+    /// An empty inner slice passes an outer `inputs.is_empty()` check (the
+    /// outer slice itself is non-empty) but contributes nothing to a
+    /// group-by-`(layer_idx, module)` pass, silently producing an empty
+    /// result instead of an admission error. Split out from
+    /// [`blend_lora_layer_data`] so callers that mutate state before
+    /// blending (e.g. [`MetalQwen35State::generate_with_lora_mixture`], which
+    /// unloads the currently loaded adapter first) can run this check first
+    /// and reject the request before that mutation, not after.
+    fn reject_empty_inner_layers(
+        inputs: &[(&[LoraLayerData], f32)],
+    ) -> Result<(), crate::error::InferenceError> {
+        for (idx, (layers, _)) in inputs.iter().enumerate() {
+            if layers.is_empty() {
+                return Err(crate::error::InferenceError::InvalidInput(format!(
+                    "blend_lora_layer_data: inputs[{idx}] has an empty layer slice"
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Blend multiple sets of [`LoraLayerData`] into one rank-Σr set for use with
     /// the single-slot [`MetalQwen35State::load_lora_adapter`] API.
     ///
@@ -1740,6 +1763,7 @@ mod inner {
     ///
     /// Returns an error if:
     /// - `inputs` is empty
+    /// - Any element of `inputs` has an empty inner layer slice
     /// - Any weight is not finite
     /// - Two adapters have conflicting `d_in` / `d_out` for the same `(layer_idx, module)`
     /// - The summed rank for a single projection exceeds `MAX_BLEND_RANK_TOTAL`
@@ -1757,6 +1781,15 @@ mod inner {
                 "blend_lora_layer_data: inputs must not be empty".into(),
             ));
         }
+
+        // An empty inner layer slice passes the outer `inputs.is_empty()`
+        // guard above (the outer slice itself is non-empty) but contributes
+        // nothing to `grouped` below, silently producing `Ok(Vec::new())`
+        // instead of an admission error. Callers that unload the currently
+        // loaded adapter before blending (e.g. `generate_with_lora_mixture`)
+        // must reject this before that mutation, not after — see
+        // `reject_empty_inner_layers` and its call site there.
+        reject_empty_inner_layers(inputs)?;
 
         for (idx, (_, w)) in inputs.iter().enumerate() {
             lattice_fann::lora::check_finite_weight("blend_lora_layer_data", idx, *w)
@@ -3921,6 +3954,42 @@ mod inner {
             Ok(())
         }
 
+        /// Load a LoRA adapter using the shared cross-crate
+        /// [`lattice_fann::lora::LoraDescriptor`] as the source of the adapter's
+        /// scale and declared target modules, instead of a bare `scale: f32`
+        /// the caller must have derived correctly on its own.
+        ///
+        /// Validates `descriptor.alpha`/effective scale (finite) and
+        /// `descriptor.target_modules` (recognized names) before delegating
+        /// to [`Self::load_lora_adapter`] with `descriptor.scale()`. Every
+        /// per-layer, per-architecture shape check `load_lora_adapter` already
+        /// performs still applies on top of this.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if the descriptor's alpha/scale is not finite, if
+        /// `target_modules` contains an unrecognized name, or for any reason
+        /// [`Self::load_lora_adapter`] itself would reject the call.
+        pub fn load_lora_adapter_with_descriptor(
+            &mut self,
+            layers: Vec<LoraLayerData>,
+            descriptor: &lattice_fann::lora::LoraDescriptor,
+            quarot_seed: Option<u64>,
+        ) -> Result<(), crate::error::InferenceError> {
+            use crate::error::InferenceError;
+
+            descriptor
+                .validate()
+                .map_err(InferenceError::InvalidInput)?;
+            lattice_fann::lora::validate_target_modules(
+                &descriptor.target_modules,
+                lattice_fann::lora::KNOWN_LORA_TARGET_MODULES,
+            )
+            .map_err(InferenceError::InvalidInput)?;
+
+            self.load_lora_adapter(layers, descriptor.scale(), quarot_seed)
+        }
+
         /// Unload the currently loaded LoRA adapter, freeing GPU buffers.
         pub fn unload_lora_adapter(&mut self) {
             self.lora = None;
@@ -3992,6 +4061,13 @@ mod inner {
                 GenerationPreparation::Complete(output) => return Ok(output),
                 GenerationPreparation::Ready(_) => {}
             }
+
+            // Reject an empty inner layer slice here, before the adapter unload
+            // below — `blend_lora_layer_data` also runs this check, but only
+            // after the unload has already destroyed the previously loaded
+            // adapter. Admission errors must be returned before any existing
+            // adapter or prefix cache is changed (see this method's doc comment).
+            reject_empty_inner_layers(adapter_weights)?;
 
             // Unload any previously loaded adapter so the slot is free.
             self.unload_lora_adapter();
@@ -21929,6 +22005,66 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             assert!(result.is_err(), "zero d_in must return Err");
         }
 
+        // -----------------------------------------------------------------
+        // `generate_with_lora_mixture` must reject an empty inner layer
+        // slice before it unloads the currently loaded adapter — otherwise
+        // the request errors out *after* destroying a previously loaded
+        // adapter, contradicting this method's own admission-error promise
+        // ("Admission errors are returned before the existing adapter or
+        // prefix cache is changed"). Loads a real adapter first so the
+        // destructive path (`unload_lora_adapter`) has something to destroy,
+        // then asserts it is untouched after the rejected call.
+        // -----------------------------------------------------------------
+        #[test]
+        fn generate_with_lora_mixture_rejects_empty_inner_slice_without_unloading() {
+            let Some(_dev) = metal::Device::system_default() else {
+                return;
+            };
+            let _gpu_guard = gpu_test_lock();
+            use crate::model::qwen35_config::GenerateConfig;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let (cfg, weights) = tiny_metal_qwen35_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 4).expect("tiny fixture");
+
+            state
+                .load_lora_adapter(vec![make_valid_layer(cfg.hidden_size, 1)], 1.0, None)
+                .expect("valid LoRA adapter loads");
+            assert!(
+                state.has_lora_adapter(),
+                "precondition: an adapter must be loaded before the rejected call"
+            );
+
+            let gen_cfg = GenerateConfig {
+                max_new_tokens: 4,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(42),
+                stop_token_ids: (0..cfg.vocab_size as u32).collect(),
+                enable_thinking: false,
+                enable_mtp: Some(false),
+                grammar: None,
+                stop_strings: vec![],
+                reasoning_budget: None,
+                logprobs: None,
+            };
+
+            let empty: &[LoraLayerData] = &[];
+            let result =
+                state.generate_with_lora_mixture(&[(empty, 1.0)], "a", &tokenizer, &gen_cfg);
+            assert!(
+                result.is_err(),
+                "an empty inner layer slice must be rejected"
+            );
+            assert!(
+                state.has_lora_adapter(),
+                "the previously loaded adapter must survive a rejected request, \
+                 not be destroyed by the unconditional unload before blending"
+            );
+        }
+
         #[test]
         fn load_lora_adapter_rejects_out_of_range_layer_idx() {
             let _gpu_guard = gpu_test_lock();
@@ -34285,6 +34421,21 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             assert!(
                 result.is_err(),
                 "mismatched B slice length must return an error"
+            );
+        }
+
+        // -----------------------------------------------------------------
+        // An empty inner layer slice passes the outer `inputs.is_empty()`
+        // guard (the outer slice has one entry) but must still be rejected,
+        // not silently produce an empty `Ok(Vec::new())` blend.
+        // -----------------------------------------------------------------
+        #[test]
+        fn blend_lora_layer_data_rejects_empty_inner_layer_slice() {
+            let empty: &[LoraLayerData] = &[];
+            let result = blend_lora_layer_data(&[(empty, 1.0)]);
+            assert!(
+                result.is_err(),
+                "an empty inner layer slice must return an error, not Ok(Vec::new())"
             );
         }
 

--- a/crates/inference/tests/metal_measurement_lock_contract.rs
+++ b/crates/inference/tests/metal_measurement_lock_contract.rs
@@ -191,12 +191,12 @@ const CONSTRUCTION_EXEMPTIONS: &[ConstructionExemption] = &[
     },
     ConstructionExemption {
         site: "bin:chat_metal:src/bin/chat_metal.rs=>src/bin/chat_metal.rs::run::MetalQwen35State::from_q4_dir()#1",
-        recorded_position: "src/bin/chat_metal.rs:773:39",
+        recorded_position: "src/bin/chat_metal.rs:800:39",
         reason: "run Q4 initialization belongs to a long-running interactive process outside the bounded measurement-harness contract",
     },
     ConstructionExemption {
         site: "bin:chat_metal:src/bin/chat_metal.rs=>src/bin/chat_metal.rs::run::MetalQwen35State::new()#1",
-        recorded_position: "src/bin/chat_metal.rs:798:39",
+        recorded_position: "src/bin/chat_metal.rs:825:39",
         reason: "run safetensors initialization belongs to a long-running interactive process outside the bounded measurement-harness contract",
     },
     ConstructionExemption {

--- a/crates/inference/tests/metal_measurement_lock_contract.rs
+++ b/crates/inference/tests/metal_measurement_lock_contract.rs
@@ -191,12 +191,12 @@ const CONSTRUCTION_EXEMPTIONS: &[ConstructionExemption] = &[
     },
     ConstructionExemption {
         site: "bin:chat_metal:src/bin/chat_metal.rs=>src/bin/chat_metal.rs::run::MetalQwen35State::from_q4_dir()#1",
-        recorded_position: "src/bin/chat_metal.rs:770:39",
+        recorded_position: "src/bin/chat_metal.rs:773:39",
         reason: "run Q4 initialization belongs to a long-running interactive process outside the bounded measurement-harness contract",
     },
     ConstructionExemption {
         site: "bin:chat_metal:src/bin/chat_metal.rs=>src/bin/chat_metal.rs::run::MetalQwen35State::new()#1",
-        recorded_position: "src/bin/chat_metal.rs:795:39",
+        recorded_position: "src/bin/chat_metal.rs:798:39",
         reason: "run safetensors initialization belongs to a long-running interactive process outside the bounded measurement-harness contract",
     },
     ConstructionExemption {

--- a/crates/tune/CHANGELOG.md
+++ b/crates/tune/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this crate will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- **Breaking (#1366):** `LoraConfig` gained a required public field, `dtype: String`,
+  the tensor dtype label the adapter's in-memory `f32` buffers were converted from
+  (e.g. `"f32"`, `"f16"`, `"bf16"`), matching the shared
+  `lattice_fann::lora::LoraDescriptor::dtype` this crate now round-trips through.
+  Since `lattice-tune` has not published a `0.9.0` release (the latest published
+  version is `0.8.0`), this is a permitted break under `0.x` semver rather than a
+  violation, but any `struct LoraConfig { .. }` literal written against `0.8.0`
+  will not compile against `0.9.0` without adding the new field — there is no
+  `Default` impl and the struct is not `#[non_exhaustive]`. Add
+  `dtype: "f32".into()` (or the actual source dtype label) to each literal to
+  migrate. Code built from a [`lattice_fann::lora::LoraDescriptor`] via
+  `LoraConfig::from_descriptor` is unaffected.

--- a/crates/tune/docs/lora-core.md
+++ b/crates/tune/docs/lora-core.md
@@ -58,6 +58,26 @@ adapted projection's input and output width. This is the point to reject a
 model/adapter shape mismatch before generation, rather than discovering it in
 a projection call.
 
+### Target-module name checking
+
+`LoraAdapter::new` — the chokepoint `from_safetensors`, `blend_lora_adapters`,
+and training all route through — accepts any non-empty target-module name.
+This keeps construction itself model-neutral and preserves loading for an
+externally produced adapter that targets a projection this crate does not yet
+recognize by name; an unrecognized name only becomes a problem once something
+tries to install the adapter against a specific model, and
+`validate_against`/`validate_against_bert` already reject that at the point
+where the architecture is known.
+
+`LoraAdapter::new_with_descriptor` is stricter: it checks every declared
+`target_modules` entry against
+[`lattice_fann::lora::KNOWN_LORA_TARGET_MODULES`], the flat name list
+`lattice-tune` and `lattice-inference` share, before accepting a descriptor —
+the same check the Metal `load_lora_adapter_with_descriptor` loader performs
+at its own entry point. Prefer this constructor over the bare one when a
+typo'd target module name should fail construction rather than surface later
+as a mismatched-projection error.
+
 ## Exact micro-LoRA training
 
 The `train-backward` feature exposes `train_micro_lora`, a compact CPU trainer

--- a/crates/tune/src/lora/blend.rs
+++ b/crates/tune/src/lora/blend.rs
@@ -37,6 +37,20 @@ pub fn blend_lora_adapters(adapters: &[(&LoraAdapter, f32)]) -> Result<LoraAdapt
             .map_err(TuneError::Validation)?;
     }
 
+    // An adapter with no layers passes the outer `adapters.is_empty()` guard
+    // above (the outer slice itself is non-empty) but contributes nothing to
+    // `grouped` below, silently producing an empty-but-`Ok` blended adapter
+    // instead of an admission error — the same failure shape
+    // `blend_lora_layer_data` in `lattice-inference` rejects for its own
+    // empty inner layer slices.
+    for (idx, (adapter, _)) in adapters.iter().enumerate() {
+        if adapter.layers().is_empty() {
+            return Err(TuneError::Validation(format!(
+                "blend_lora_adapters: adapters[{idx}] has no layers"
+            )));
+        }
+    }
+
     // Group the union of projection keys with their folded source scales.
     let mut grouped: HashMap<(usize, String), Vec<(&LoraLayer, f32)>> = HashMap::new();
     for (adapter, weight) in adapters {
@@ -99,6 +113,7 @@ pub fn blend_lora_adapters(adapters: &[(&LoraAdapter, f32)]) -> Result<LoraAdapt
         rank: total_rank,
         alpha: total_rank as f32,
         target_modules,
+        dtype: "f32".into(),
     };
 
     LoraAdapter::new(config, blended_layers)
@@ -217,6 +232,7 @@ mod tests {
                 rank,
                 alpha: rank as f32, // scale = 1.0
                 target_modules: vec!["q_proj".into()],
+                dtype: "f32".into(),
             },
             layers,
         )
@@ -369,6 +385,33 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Edge-case: an adapter with no layers is rejected explicitly, not
+    // silently blended into an empty-but-Ok adapter. Mirrors
+    // `blend_lora_layer_data`'s empty-inner-layer-slice rejection in
+    // `lattice-inference` (the two blends this crate and Metal both apply
+    // the same admission policy to).
+    // -----------------------------------------------------------------------
+    #[test]
+    fn blend_adapter_with_no_layers_returns_error() {
+        let empty_adapter = LoraAdapter::new(
+            LoraConfig {
+                rank: 1,
+                alpha: 1.0,
+                target_modules: vec![],
+                dtype: "f32".into(),
+            },
+            HashMap::new(),
+        )
+        .expect("an adapter with zero layers is itself a valid, if inert, adapter");
+
+        let result = blend_lora_adapters(&[(&empty_adapter, 1.0)]);
+        assert!(
+            result.is_err(),
+            "an adapter with no layers must be rejected, not silently blended into an empty adapter"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Edge-case: non-finite weight returns an error.
     // -----------------------------------------------------------------------
     #[test]
@@ -406,6 +449,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["q_proj".into()],
+                dtype: "f32".into(),
             },
             layers,
         )
@@ -448,6 +492,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["q_proj".into()],
+                dtype: "f32".into(),
             },
             layers,
         };
@@ -487,6 +532,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["q_proj".into()],
+                dtype: "f32".into(),
             },
             layers,
         };
@@ -529,6 +575,7 @@ mod tests {
                 rank,
                 alpha,
                 target_modules: vec!["q_proj".into()],
+                dtype: "f32".into(),
             },
             layers,
         )
@@ -636,6 +683,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["q_proj".into()],
+                dtype: "f32".into(),
             },
             layers,
         };
@@ -717,6 +765,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["q_proj".into()],
+                dtype: "f32".into(),
             },
             layers,
         };

--- a/crates/tune/src/lora/blend.rs
+++ b/crates/tune/src/lora/blend.rs
@@ -8,13 +8,17 @@
 
 use crate::error::{Result, TuneError};
 use crate::lora::{LoraAdapter, LoraConfig, LoraLayer};
+use lattice_fann::lora as shared;
 use std::collections::HashMap;
 
 /// Maximum summed rank for one blended projection.
-pub(crate) const MAX_BLEND_RANK_TOTAL: usize = 4096;
-
-/// Aggregate cap on all blended A and B elements (about 4 GiB of f32 storage).
-pub(crate) const MAX_BLEND_TOTAL_ELEMENTS: usize = 1 << 30; // 1,073,741,824 elements ≈ 4 GiB f32
+///
+/// Re-exported from [`lattice_fann::lora::MAX_BLEND_RANK_TOTAL`], the shared
+/// cap this crate and `lattice-inference`'s Metal LoRA blend both enforce.
+/// Only referenced by tests below — non-test code calls `shared::*` directly
+/// so the cap itself lives in exactly one place.
+#[cfg(test)]
+pub(crate) const MAX_BLEND_RANK_TOTAL: usize = shared::MAX_BLEND_RANK_TOTAL;
 
 /// Blend a set of `(adapter, mixture_weight)` pairs into one rank-Σr adapter.
 ///
@@ -29,11 +33,8 @@ pub fn blend_lora_adapters(adapters: &[(&LoraAdapter, f32)]) -> Result<LoraAdapt
     }
 
     for (idx, (_, w)) in adapters.iter().enumerate() {
-        if !w.is_finite() {
-            return Err(TuneError::Validation(format!(
-                "blend_lora_adapters: weight at index {idx} is not finite ({w})"
-            )));
-        }
+        shared::check_finite_weight("blend_lora_adapters", idx, *w)
+            .map_err(TuneError::Validation)?;
     }
 
     // Group the union of projection keys with their folded source scales.
@@ -53,36 +54,26 @@ pub fn blend_lora_adapters(adapters: &[(&LoraAdapter, f32)]) -> Result<LoraAdapt
     let mut planned_elems: usize = 0;
     for ((layer_idx, module), entries) in &grouped {
         let (first, _) = entries[0]; // each key was inserted with >=1 layer
-        let dims = first.d_in.checked_add(first.d_out).ok_or_else(|| {
-            TuneError::Validation(format!(
-                "blend_lora_adapters: layer {layer_idx} module '{module}' d_in+d_out overflowed usize"
-            ))
-        })?;
         let mut group_rank: usize = 0;
         for (layer, _) in entries {
-            group_rank = group_rank.checked_add(layer.rank).ok_or_else(|| {
-                TuneError::Validation("blend_lora_adapters: rank_total overflowed usize".into())
-            })?;
+            group_rank = shared::accumulate_rank(group_rank, layer.rank, "blend_lora_adapters")
+                .map_err(TuneError::Validation)?;
         }
-        let group_elems = group_rank.checked_mul(dims).ok_or_else(|| {
-            TuneError::Validation(
-                "blend_lora_adapters: rank_total*(d_in+d_out) overflowed usize".into(),
-            )
-        })?;
-        planned_elems = planned_elems.checked_add(group_elems).ok_or_else(|| {
-            TuneError::Validation(
-                "blend_lora_adapters: aggregate blend element count overflowed usize".into(),
-            )
-        })?;
+        let group_elems = shared::checked_group_elements(
+            "blend_lora_adapters",
+            *layer_idx,
+            module,
+            group_rank,
+            first.d_in,
+            first.d_out,
+        )
+        .map_err(TuneError::Validation)?;
+        planned_elems =
+            shared::accumulate_planned_elements(planned_elems, group_elems, "blend_lora_adapters")
+                .map_err(TuneError::Validation)?;
     }
-    if planned_elems > MAX_BLEND_TOTAL_ELEMENTS {
-        return Err(TuneError::Validation(format!(
-            "blend_lora_adapters: aggregate blend size {planned_elems} elements exceeds \
-             MAX_BLEND_TOTAL_ELEMENTS={MAX_BLEND_TOTAL_ELEMENTS} (~{} GiB f32); reduce the \
-             number of adapters, their rank, or the number of target projections",
-            (MAX_BLEND_TOTAL_ELEMENTS * 4) / (1024 * 1024 * 1024)
-        )));
-    }
+    shared::check_aggregate_elements_cap(planned_elems, "blend_lora_adapters")
+        .map_err(TuneError::Validation)?;
 
     // Blend each (layer_idx, module) group independently.
     let mut blended_layers: HashMap<(usize, String), LoraLayer> = HashMap::new();
@@ -126,55 +117,40 @@ fn blend_layer_entries(
 
     // Validate that all entries share the same projection shape.
     for (idx, (layer, _)) in entries.iter().enumerate() {
-        if layer.d_in != d_in || layer.d_out != d_out {
-            return Err(TuneError::Validation(format!(
-                "blend_lora_adapters: layer {} module '{}' has mismatched dimensions \
-                 (entry 0: d_in={d_in}, d_out={d_out}; entry {idx}: d_in={}, d_out={})",
-                key.0, key.1, layer.d_in, layer.d_out
-            )));
-        }
+        shared::check_dims_match(
+            "blend_lora_adapters",
+            *key.0,
+            key.1,
+            d_in,
+            d_out,
+            idx,
+            layer.d_in,
+            layer.d_out,
+        )
+        .map_err(TuneError::Validation)?;
     }
 
     // Accumulate rank_total with overflow protection and a hard cap.
     let mut rank_total: usize = 0;
     for (layer, _) in entries {
-        rank_total = rank_total.checked_add(layer.rank).ok_or_else(|| {
-            TuneError::Validation("blend_layer_entries: rank_total overflowed usize".into())
-        })?;
+        rank_total = shared::accumulate_rank(rank_total, layer.rank, "blend_layer_entries")
+            .map_err(TuneError::Validation)?;
     }
-    if rank_total > MAX_BLEND_RANK_TOTAL {
-        return Err(TuneError::Validation(format!(
-            "blend_layer_entries: summed rank {rank_total} exceeds \
-             MAX_BLEND_RANK_TOTAL={MAX_BLEND_RANK_TOTAL}"
-        )));
-    }
+    shared::check_rank_total_cap(rank_total, "blend_layer_entries")
+        .map_err(TuneError::Validation)?;
 
     // Validate source buffers before copying their declared row-major shapes.
     for (idx, (layer, _)) in entries.iter().enumerate() {
-        let expected_a = layer.rank.checked_mul(d_in).ok_or_else(|| {
-            TuneError::Validation("blend_layer_entries: rank*d_in overflowed usize".into())
-        })?;
-        let expected_b = d_out.checked_mul(layer.rank).ok_or_else(|| {
-            TuneError::Validation("blend_layer_entries: d_out*rank overflowed usize".into())
-        })?;
-        if layer.a.len() != expected_a {
-            return Err(TuneError::Validation(format!(
-                "blend_layer_entries: entry {idx} A slice length {} \
-                 does not match rank*d_in={}*{}={expected_a}",
-                layer.a.len(),
-                layer.rank,
-                d_in,
-            )));
-        }
-        if layer.b.len() != expected_b {
-            return Err(TuneError::Validation(format!(
-                "blend_layer_entries: entry {idx} B slice length {} \
-                 does not match d_out*rank={}*{}={expected_b}",
-                layer.b.len(),
-                d_out,
-                layer.rank,
-            )));
-        }
+        shared::check_buffer_lengths(
+            "blend_layer_entries",
+            idx,
+            layer.rank,
+            d_in,
+            d_out,
+            layer.a.len(),
+            layer.b.len(),
+        )
+        .map_err(TuneError::Validation)?;
     }
 
     let a_buf_len = rank_total.checked_mul(d_in).ok_or_else(|| {
@@ -717,7 +693,6 @@ mod tests {
     // -----------------------------------------------------------------------
     #[test]
     fn blend_aggregate_budget_exceeded_returns_err() {
-        use super::MAX_BLEND_TOTAL_ELEMENTS;
         let rank = MAX_BLEND_RANK_TOTAL; // 4096 — exactly at per-group cap, passes it
         let d_in = 2048usize;
         let d_out = 2048usize;

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -58,17 +58,13 @@ pub struct LoraConfig {
 
 impl LoraConfig {
     /// Compute the LoRA scaling factor: `alpha / rank`.
+    ///
+    /// Delegates to [`lattice_fann::lora::effective_scale`], the single
+    /// source of truth this crate shares with `lattice-inference`'s Metal
+    /// LoRA path so the zero-rank and non-finite fallbacks cannot drift
+    /// between the two.
     pub fn scale(&self) -> f32 {
-        let scale = if self.rank == 0 {
-            0.0
-        } else {
-            self.alpha / self.rank as f32
-        };
-        if self.alpha.is_finite() && scale.is_finite() {
-            scale
-        } else {
-            0.0
-        }
+        lattice_fann::lora::effective_scale(self.rank, self.alpha)
     }
 
     /// Validate that the LoRA alpha and effective scale are finite.
@@ -78,23 +74,8 @@ impl LoraConfig {
     /// Returns [`crate::error::TuneError::Validation`] when `alpha` or the
     /// effective `alpha / rank` scale is not finite.
     pub fn validate(&self) -> crate::error::Result<()> {
-        if !self.alpha.is_finite() {
-            return Err(crate::error::TuneError::Validation(format!(
-                "LoRA alpha must be finite, got {}",
-                self.alpha
-            )));
-        }
-        let scale = if self.rank == 0 {
-            0.0
-        } else {
-            self.alpha / self.rank as f32
-        };
-        if !scale.is_finite() {
-            return Err(crate::error::TuneError::Validation(format!(
-                "LoRA effective scale must be finite, got {scale}"
-            )));
-        }
-        Ok(())
+        lattice_fann::lora::validate_alpha_finite(self.rank, self.alpha)
+            .map_err(crate::error::TuneError::Validation)
     }
 }
 

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -63,12 +63,16 @@ pub struct LoraConfig {
 impl LoraConfig {
     /// Compute the LoRA scaling factor: `alpha / rank`.
     ///
-    /// Delegates to [`lattice_fann::lora::effective_scale`] via
-    /// [`Self::to_descriptor`], the single source of truth this crate shares
-    /// with `lattice-inference`'s Metal LoRA path so the zero-rank and
-    /// non-finite fallbacks cannot drift between the two.
+    /// Delegates directly to [`lattice_fann::lora::effective_scale`], the
+    /// single source of truth this crate shares with `lattice-inference`'s
+    /// Metal LoRA path so the zero-rank and non-finite fallbacks cannot
+    /// drift between the two. Deliberately bypasses [`Self::to_descriptor`]:
+    /// that helper clones `target_modules` and `dtype` to build a full
+    /// descriptor, and `scale()` is called once per matched row by
+    /// [`LoraAdapter::apply`] — an allocation-free hot path that has no use
+    /// for either field.
     pub fn scale(&self) -> f32 {
-        self.to_descriptor().scale()
+        lattice_fann::lora::effective_scale(self.rank, self.alpha)
     }
 
     /// Validate that the LoRA alpha and effective scale are finite, and that

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -54,28 +54,62 @@ pub struct LoraConfig {
     /// Names of the modules that have LoRA adapters.
     /// e.g., `["q_proj", "v_proj", "gate_proj", "up_proj"]`
     pub target_modules: Vec<String>,
+    /// Tensor dtype label the adapter's in-memory `f32` buffers were
+    /// converted from (e.g. `"f32"`, `"f16"`, `"bf16"`), matching
+    /// [`lattice_fann::lora::LoraDescriptor::dtype`].
+    pub dtype: String,
 }
 
 impl LoraConfig {
     /// Compute the LoRA scaling factor: `alpha / rank`.
     ///
-    /// Delegates to [`lattice_fann::lora::effective_scale`], the single
-    /// source of truth this crate shares with `lattice-inference`'s Metal
-    /// LoRA path so the zero-rank and non-finite fallbacks cannot drift
-    /// between the two.
+    /// Delegates to [`lattice_fann::lora::effective_scale`] via
+    /// [`Self::to_descriptor`], the single source of truth this crate shares
+    /// with `lattice-inference`'s Metal LoRA path so the zero-rank and
+    /// non-finite fallbacks cannot drift between the two.
     pub fn scale(&self) -> f32 {
-        lattice_fann::lora::effective_scale(self.rank, self.alpha)
+        self.to_descriptor().scale()
     }
 
-    /// Validate that the LoRA alpha and effective scale are finite.
+    /// Validate that the LoRA alpha and effective scale are finite, and that
+    /// every declared target module is a recognized name.
     ///
     /// # Errors
     ///
     /// Returns [`crate::error::TuneError::Validation`] when `alpha` or the
-    /// effective `alpha / rank` scale is not finite.
+    /// effective `alpha / rank` scale is not finite, or when
+    /// `target_modules` contains a name outside
+    /// [`lattice_fann::lora::KNOWN_LORA_TARGET_MODULES`].
     pub fn validate(&self) -> crate::error::Result<()> {
-        lattice_fann::lora::validate_alpha_finite(self.rank, self.alpha)
-            .map_err(crate::error::TuneError::Validation)
+        self.to_descriptor()
+            .validate()
+            .map_err(crate::error::TuneError::Validation)?;
+        lattice_fann::lora::validate_target_modules(
+            &self.target_modules,
+            lattice_fann::lora::KNOWN_LORA_TARGET_MODULES,
+        )
+        .map_err(crate::error::TuneError::Validation)
+    }
+
+    /// Convert to the shared cross-crate [`lattice_fann::lora::LoraDescriptor`].
+    pub fn to_descriptor(&self) -> lattice_fann::lora::LoraDescriptor {
+        lattice_fann::lora::LoraDescriptor {
+            rank: self.rank,
+            alpha: self.alpha,
+            target_modules: self.target_modules.clone(),
+            dtype: self.dtype.clone(),
+        }
+    }
+
+    /// Build a `LoraConfig` from the shared cross-crate
+    /// [`lattice_fann::lora::LoraDescriptor`].
+    pub fn from_descriptor(descriptor: lattice_fann::lora::LoraDescriptor) -> Self {
+        Self {
+            rank: descriptor.rank,
+            alpha: descriptor.alpha,
+            target_modules: descriptor.target_modules,
+            dtype: descriptor.dtype,
+        }
     }
 }
 
@@ -435,6 +469,7 @@ mod tests {
             rank: 2,
             alpha: 4.0, // scale = 4.0 / 2 = 2.0
             target_modules: vec!["q_proj".into(), "v_proj".into()],
+            dtype: "f32".into(),
         };
 
         let mut layers = HashMap::new();
@@ -469,6 +504,7 @@ mod tests {
             rank: 8,
             alpha: 16.0,
             target_modules: vec![],
+            dtype: "f32".into(),
         };
         assert!((config.scale() - 2.0).abs() < 1e-6);
 
@@ -476,6 +512,7 @@ mod tests {
             rank: 0,
             alpha: 1.0,
             target_modules: vec![],
+            dtype: "f32".into(),
         };
         assert_eq!(config_zero.scale(), 0.0);
     }
@@ -487,6 +524,7 @@ mod tests {
                 rank: 8,
                 alpha,
                 target_modules: vec![],
+                dtype: "f32".into(),
             };
 
             let err = config.validate().unwrap_err();
@@ -503,6 +541,7 @@ mod tests {
                     rank: 8,
                     alpha,
                     target_modules: vec![],
+                    dtype: "f32".into(),
                 },
                 HashMap::new(),
             );
@@ -615,10 +654,16 @@ mod tests {
 
     #[test]
     fn test_validate_modules_typo() {
+        // `config.target_modules` names a real module ("q_proj") so
+        // construction itself passes the shared-descriptor allowlist check;
+        // the typo lives only in the populated *layer* key ("q_porj"), which
+        // is exactly what `validate_modules` (a check over actual layers,
+        // not the declared `target_modules` field) exists to catch.
         let config = LoraConfig {
             rank: 2,
             alpha: 4.0,
-            target_modules: vec!["q_porj".into()],
+            target_modules: vec!["q_proj".into()],
+            dtype: "f32".into(),
         };
         let mut layers = HashMap::new();
         layers.insert(
@@ -643,6 +688,7 @@ mod tests {
             rank: 2,
             alpha: 4.0,
             target_modules: vec![],
+            dtype: "f32".into(),
         };
         let adapter = LoraAdapter::new(config, HashMap::new()).expect("valid adapter config");
         let unknown = adapter.validate_modules(&["q_proj"]);
@@ -659,6 +705,7 @@ mod tests {
             rank: 4,
             alpha: 4.0,
             target_modules: vec!["q_proj".into()],
+            dtype: "f32".into(),
         };
         let mut layers = HashMap::new();
         layers.insert(
@@ -683,6 +730,7 @@ mod tests {
             rank: 4,
             alpha: 4.0,
             target_modules: vec!["q_proj".into()],
+            dtype: "f32".into(),
         };
         let mut layers = HashMap::new();
         layers.insert(
@@ -698,6 +746,48 @@ mod tests {
         let err = LoraAdapter::new(config, layers)
             .expect_err("B buffer longer than d_out*rank must be rejected");
         assert!(err.to_string().contains("B buffer length"));
+    }
+
+    // -------------------------------------------------------------------
+    // Cross-crate contract: `LoraConfig` must actually carry
+    // `lattice_fann::lora::LoraDescriptor`, not just a same-shaped copy of
+    // it. `LoraAdapter::new` (the single construction chokepoint) routes
+    // `config.validate()` through `LoraConfig::to_descriptor()`, so a
+    // descriptor built independently and round-tripped through
+    // `LoraConfig::from_descriptor` / `to_descriptor` must come back
+    // unchanged, AND a target module unknown to the shared allowlist must be
+    // rejected at construction — not just by some unused helper. If a
+    // future change makes `LoraConfig` stop delegating to
+    // `LoraDescriptor` (e.g. reimplementing `scale`/`validate` locally),
+    // this test's round-trip or its unknown-module rejection breaks.
+    // -------------------------------------------------------------------
+    #[test]
+    fn lora_config_round_trips_through_shared_descriptor() {
+        let descriptor = lattice_fann::lora::LoraDescriptor {
+            rank: 8,
+            alpha: 16.0,
+            target_modules: vec!["q_proj".into(), "up_proj".into()],
+            dtype: "bf16".into(),
+        };
+        let config = LoraConfig::from_descriptor(descriptor.clone());
+        assert_eq!(config.to_descriptor(), descriptor);
+        assert_eq!(config.scale(), descriptor.scale());
+    }
+
+    #[test]
+    fn lora_adapter_new_rejects_unknown_target_module_via_shared_descriptor() {
+        let config = LoraConfig {
+            rank: 2,
+            alpha: 2.0,
+            target_modules: vec!["not_a_real_module".into()],
+            dtype: "f32".into(),
+        };
+        let err = LoraAdapter::new(config, HashMap::new())
+            .expect_err("unknown target module must be rejected at construction");
+        assert!(
+            err.to_string().contains("not_a_real_module"),
+            "error must name the unknown module via the shared validator; got: {err}"
+        );
     }
 
     #[cfg(feature = "inference-hook")]
@@ -728,6 +818,7 @@ mod tests {
                     rank,
                     alpha: rank as f32,
                     target_modules: vec![module.to_string()],
+                    dtype: "f32".into(),
                 },
                 layers,
             )
@@ -951,6 +1042,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec![module.to_string()],
+                dtype: "f32".into(),
             };
             let mut layers = HashMap::new();
             layers.insert(
@@ -1005,6 +1097,7 @@ mod tests {
                     rank,
                     alpha: rank as f32,
                     target_modules: vec![module.to_string()],
+                    dtype: "f32".into(),
                 },
                 layers,
             )
@@ -1150,6 +1243,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["query".to_string()],
+                dtype: "f32".into(),
             };
             let err = LoraAdapter::new(config, layers)
                 .expect_err("an empty A factor with a populated B factor must be rejected");
@@ -1175,6 +1269,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["query".to_string()],
+                dtype: "f32".into(),
             };
             let err = LoraAdapter::new(config, layers)
                 .expect_err("an empty B factor with a populated A factor must be rejected");
@@ -1202,6 +1297,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["query".to_string()],
+                dtype: "f32".into(),
             };
             assert!(
                 LoraAdapter::new(config, layers).is_ok(),
@@ -1236,6 +1332,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["query".to_string()],
+                dtype: "f32".into(),
             };
             let adapter =
                 LoraAdapter::new(config, layers).expect("buffers match the declared rank");
@@ -1272,6 +1369,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["query".to_string()],
+                dtype: "f32".into(),
             };
             let err = LoraAdapter::new(config, layers)
                 .expect_err("an A buffer shorter than rank * d_in must be rejected");
@@ -1303,6 +1401,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["query".to_string()],
+                dtype: "f32".into(),
             };
             let adapter =
                 LoraAdapter::new(config, layers).expect("buffers match the declared rank");
@@ -1335,6 +1434,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["query".to_string()],
+                dtype: "f32".into(),
             };
             let adapter = LoraAdapter::new(config, layers).expect("valid adapter config");
             assert!(
@@ -1369,6 +1469,7 @@ mod tests {
                 rank,
                 alpha: rank as f32,
                 target_modules: vec!["query".to_string()],
+                dtype: "f32".into(),
             };
             let adapter =
                 LoraAdapter::new(config, layers).expect("placeholder layer must construct");

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -238,6 +238,82 @@ impl LoraAdapter {
         Ok(Self { config, layers })
     }
 
+    /// Construct an adapter from a shared cross-crate
+    /// [`lattice_fann::lora::LoraDescriptor`] and pre-built layers, enforcing
+    /// that the descriptor's declared identity actually matches the layer
+    /// data — the check [`Self::new`] deliberately does not make.
+    ///
+    /// [`Self::new`] only checks each layer's buffers against that *same*
+    /// layer's own `rank`/`d_in`/`d_out`; it never compares `config.rank`
+    /// (what [`LoraConfig::scale`] and hence [`Self::apply`] actually use)
+    /// against the layers it is handed, and never compares `config.target_modules`
+    /// against the layer keys present. That permissiveness is required by
+    /// [`crate::lora::blend::blend_lora_adapters`], which legitimately builds
+    /// adapters whose per-projection rank varies (the blended rank is the
+    /// *sum* of the source ranks for that projection, which can differ across
+    /// projection groups when the source adapters don't all cover the same
+    /// modules) alongside a single representative `config.rank`. This
+    /// constructor is for the opposite case: a single adapter loaded from a
+    /// descriptor that is supposed to describe every layer uniformly (e.g. an
+    /// external format's parsed identity plus its layers), where a
+    /// disagreement between the two is a bug in the caller, not a legitimate
+    /// blend artifact. It mirrors the identity check `lattice-inference`'s
+    /// Metal `load_lora_adapter_with_descriptor` performs at its own entry
+    /// point, so a descriptor's `rank`/`target_modules` mean the same thing
+    /// on both sides of the tune/Metal boundary.
+    ///
+    /// [`Self::new`] remains the right choice for blend-style construction,
+    /// or any caller that already owns the rank/module invariant itself;
+    /// this constructor is the stricter alternative for callers that want it
+    /// enforced instead of assumed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the descriptor itself is invalid ([`LoraConfig::validate`]),
+    /// if any non-placeholder layer's `rank` disagrees with `descriptor.rank`,
+    /// if the set of modules present in `layers` disagrees with
+    /// `descriptor.target_modules`, or for any reason [`Self::new`] itself
+    /// would reject the call.
+    pub fn new_with_descriptor(
+        descriptor: lattice_fann::lora::LoraDescriptor,
+        layers: HashMap<(usize, String), LoraLayer>,
+    ) -> crate::error::Result<Self> {
+        let config = LoraConfig::from_descriptor(descriptor);
+        config.validate()?;
+
+        for ((layer_idx, module), layer) in &layers {
+            // Mirrors `Self::new`'s own placeholder exemption: an
+            // untrained/not-yet-populated module carries no rank-dependent
+            // data for this check to disagree over.
+            if layer.a.is_empty() && layer.b.is_empty() {
+                continue;
+            }
+            if layer.rank != config.rank {
+                return Err(crate::error::TuneError::Validation(format!(
+                    "LoRA layer {layer_idx} module '{module}': layer rank {} disagrees with \
+                     descriptor rank {}",
+                    layer.rank, config.rank
+                )));
+            }
+        }
+
+        let mut layer_modules: Vec<&str> = layers.keys().map(|(_, m)| m.as_str()).collect();
+        layer_modules.sort_unstable();
+        layer_modules.dedup();
+        let mut declared_modules: Vec<&str> =
+            config.target_modules.iter().map(String::as_str).collect();
+        declared_modules.sort_unstable();
+        declared_modules.dedup();
+        if layer_modules != declared_modules {
+            return Err(crate::error::TuneError::Validation(format!(
+                "LoRA adapter modules {layer_modules:?} disagree with descriptor \
+                 target_modules {declared_modules:?}"
+            )));
+        }
+
+        Self::new(config, layers)
+    }
+
     /// Return the validated adapter configuration.
     pub fn config(&self) -> &LoraConfig {
         &self.config
@@ -792,6 +868,161 @@ mod tests {
             err.to_string().contains("not_a_real_module"),
             "error must name the unknown module via the shared validator; got: {err}"
         );
+    }
+
+    // -------------------------------------------------------------------
+    // Public-boundary tests for the descriptor/layer identity `Self::new`
+    // does not check: a descriptor declares `rank` and `target_modules`,
+    // but nothing before this constructor compared either against the
+    // layers actually supplied. The only in-tree caller that builds both a
+    // descriptor and its layers (`chat_metal`'s Metal-only LoRA loader)
+    // derives both from the same parsed tensors, so it can never produce a
+    // disagreement — these tests construct one directly.
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn new_bare_constructor_permits_rank_disagreement_as_documented_escape_hatch() {
+        // The exact shape from the round's failing input: a config
+        // declaring rank=8 alongside a populated layer whose own rank is 4.
+        // `LoraAdapter::new` only checks the layer's buffers against its
+        // *own* declared rank/d_in/d_out, never against `config.rank`, so
+        // this constructs successfully — the documented, caller-owned
+        // bypass `new_with_descriptor` (below) closes for descriptor-backed
+        // construction.
+        let config = LoraConfig {
+            rank: 8,
+            alpha: 8.0,
+            target_modules: vec!["q_proj".into()],
+            dtype: "f32".into(),
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![1.0; 4],
+                b: vec![1.0; 4],
+                d_in: 1,
+                d_out: 1,
+                rank: 4,
+            },
+        );
+        let adapter =
+            LoraAdapter::new(config, layers).expect("bare constructor does not cross-check rank");
+        assert_eq!(adapter.config().rank, 8);
+        assert_eq!(
+            adapter
+                .layers()
+                .get(&(0, "q_proj".to_string()))
+                .unwrap()
+                .rank,
+            4
+        );
+    }
+
+    #[test]
+    fn new_with_descriptor_rejects_rank_disagreement() {
+        let descriptor = lattice_fann::lora::LoraDescriptor {
+            rank: 8,
+            alpha: 8.0,
+            target_modules: vec!["q_proj".into()],
+            dtype: "f32".into(),
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![1.0; 4],
+                b: vec![1.0; 4],
+                d_in: 1,
+                d_out: 1,
+                rank: 4,
+            },
+        );
+        let err = LoraAdapter::new_with_descriptor(descriptor, layers)
+            .expect_err("layer rank disagreeing with descriptor rank must be rejected");
+        assert!(
+            err.to_string()
+                .contains("layer rank 4 disagrees with descriptor rank 8"),
+            "error must name both ranks; got: {err}"
+        );
+    }
+
+    #[test]
+    fn new_with_descriptor_accepts_matching_rank() {
+        let descriptor = lattice_fann::lora::LoraDescriptor {
+            rank: 4,
+            alpha: 4.0,
+            target_modules: vec!["q_proj".into()],
+            dtype: "f32".into(),
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![1.0; 4],
+                b: vec![1.0; 4],
+                d_in: 1,
+                d_out: 1,
+                rank: 4,
+            },
+        );
+        assert!(LoraAdapter::new_with_descriptor(descriptor, layers).is_ok());
+    }
+
+    #[test]
+    fn new_with_descriptor_rejects_module_set_disagreement() {
+        // Descriptor declares only "q_proj", but the layers cover "v_proj"
+        // instead — the exact-module-set check `load_lora_adapter_with_descriptor`
+        // performs on the Metal side, mirrored here for the tune side.
+        let descriptor = lattice_fann::lora::LoraDescriptor {
+            rank: 4,
+            alpha: 4.0,
+            target_modules: vec!["q_proj".into()],
+            dtype: "f32".into(),
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "v_proj".into()),
+            LoraLayer {
+                a: vec![1.0; 4],
+                b: vec![1.0; 4],
+                d_in: 1,
+                d_out: 1,
+                rank: 4,
+            },
+        );
+        let err = LoraAdapter::new_with_descriptor(descriptor, layers)
+            .expect_err("module set disagreeing with descriptor target_modules must be rejected");
+        assert!(
+            err.to_string().contains("disagree with descriptor"),
+            "error must report the module-set disagreement; got: {err}"
+        );
+    }
+
+    #[test]
+    fn new_with_descriptor_placeholder_layer_exempt_from_rank_check() {
+        // An untrained placeholder (both `a` and `b` empty) still declares
+        // its module in the map key, so it must count toward the module-set
+        // match, but its `rank` field is not meaningful data to compare
+        // against the descriptor.
+        let descriptor = lattice_fann::lora::LoraDescriptor {
+            rank: 4,
+            alpha: 4.0,
+            target_modules: vec!["q_proj".into()],
+            dtype: "f32".into(),
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![],
+                b: vec![],
+                d_in: 1,
+                d_out: 1,
+                rank: 999, // deliberately disagreeing, but exempt: no data
+            },
+        );
+        assert!(LoraAdapter::new_with_descriptor(descriptor, layers).is_ok());
     }
 
     #[cfg(feature = "inference-hook")]

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -75,24 +75,28 @@ impl LoraConfig {
         lattice_fann::lora::effective_scale(self.rank, self.alpha)
     }
 
-    /// Validate that the LoRA alpha and effective scale are finite, and that
-    /// every declared target module is a recognized name.
+    /// Validate that the LoRA alpha and effective scale are finite.
+    ///
+    /// Deliberately does not check `target_modules` against any known-name
+    /// list: this is the identity check [`LoraAdapter::new`] runs on every
+    /// construction path (safetensors loading, blending, training), and the
+    /// adapter representation is model-neutral (see the module docs) — a
+    /// target module this crate does not yet recognize by name is not
+    /// necessarily invalid, only unusable until something that knows the
+    /// target architecture is asked to install it.
+    /// [`LoraAdapter::new_with_descriptor`] and
+    /// [`LoraAdapter::validate_against`]/[`LoraAdapter::validate_against_bert`]
+    /// enforce a known-name check where the architecture is actually known;
+    /// see `docs/lora-core.md#adapter-validation`.
     ///
     /// # Errors
     ///
     /// Returns [`crate::error::TuneError::Validation`] when `alpha` or the
-    /// effective `alpha / rank` scale is not finite, or when
-    /// `target_modules` contains a name outside
-    /// [`lattice_fann::lora::KNOWN_LORA_TARGET_MODULES`].
+    /// effective `alpha / rank` scale is not finite.
     pub fn validate(&self) -> crate::error::Result<()> {
         self.to_descriptor()
             .validate()
-            .map_err(crate::error::TuneError::Validation)?;
-        lattice_fann::lora::validate_target_modules(
-            &self.target_modules,
-            lattice_fann::lora::KNOWN_LORA_TARGET_MODULES,
-        )
-        .map_err(crate::error::TuneError::Validation)
+            .map_err(crate::error::TuneError::Validation)
     }
 
     /// Convert to the shared cross-crate [`lattice_fann::lora::LoraDescriptor`].
@@ -269,17 +273,31 @@ impl LoraAdapter {
     ///
     /// # Errors
     ///
-    /// Returns an error if the descriptor itself is invalid ([`LoraConfig::validate`]),
-    /// if any non-placeholder layer's `rank` disagrees with `descriptor.rank`,
+    /// Returns an error if the descriptor's alpha/effective scale is not
+    /// finite ([`LoraConfig::validate`]), if `target_modules` contains a
+    /// name outside [`lattice_fann::lora::KNOWN_LORA_TARGET_MODULES`], if
+    /// any non-placeholder layer's `rank` disagrees with `descriptor.rank`,
     /// if the set of modules present in `layers` disagrees with
     /// `descriptor.target_modules`, or for any reason [`Self::new`] itself
     /// would reject the call.
+    ///
+    /// The known-name check lives here rather than in [`LoraConfig::validate`]
+    /// (which [`Self::new`] also calls) so that the permissive bare
+    /// constructor stays permissive; this mirrors
+    /// `MetalQwen35State::load_lora_adapter_with_descriptor`, which performs
+    /// the identical two-step (`validate` then `validate_target_modules`) at
+    /// its own entry point.
     pub fn new_with_descriptor(
         descriptor: lattice_fann::lora::LoraDescriptor,
         layers: HashMap<(usize, String), LoraLayer>,
     ) -> crate::error::Result<Self> {
         let config = LoraConfig::from_descriptor(descriptor);
         config.validate()?;
+        lattice_fann::lora::validate_target_modules(
+            &config.target_modules,
+            lattice_fann::lora::KNOWN_LORA_TARGET_MODULES,
+        )
+        .map_err(crate::error::TuneError::Validation)?;
 
         for ((layer_idx, module), layer) in &layers {
             // Mirrors `Self::new`'s own placeholder exemption: an
@@ -835,11 +853,9 @@ mod tests {
     // `config.validate()` through `LoraConfig::to_descriptor()`, so a
     // descriptor built independently and round-tripped through
     // `LoraConfig::from_descriptor` / `to_descriptor` must come back
-    // unchanged, AND a target module unknown to the shared allowlist must be
-    // rejected at construction — not just by some unused helper. If a
-    // future change makes `LoraConfig` stop delegating to
+    // unchanged. If a future change makes `LoraConfig` stop delegating to
     // `LoraDescriptor` (e.g. reimplementing `scale`/`validate` locally),
-    // this test's round-trip or its unknown-module rejection breaks.
+    // this test's round-trip breaks.
     // -------------------------------------------------------------------
     #[test]
     fn lora_config_round_trips_through_shared_descriptor() {
@@ -854,20 +870,87 @@ mod tests {
         assert_eq!(config.scale(), descriptor.scale());
     }
 
+    // -------------------------------------------------------------------
+    // `LoraAdapter::new` is the generic construction chokepoint
+    // (safetensors loading, blending, training all route through it) and is
+    // deliberately permissive of unrecognized target-module names: the
+    // adapter representation is model-neutral (see the module docs), and an
+    // externally produced adapter naming a projection this crate does not
+    // yet know by name must still load. Name recognition is enforced only
+    // where the target architecture is actually known:
+    // `new_with_descriptor` (below) and `validate_against`/
+    // `validate_against_bert` (see `validate_against_tests` and the BERT
+    // test module).
+    // -------------------------------------------------------------------
     #[test]
-    fn lora_adapter_new_rejects_unknown_target_module_via_shared_descriptor() {
+    fn lora_adapter_new_accepts_unrecognized_target_module() {
         let config = LoraConfig {
             rank: 2,
             alpha: 2.0,
             target_modules: vec!["not_a_real_module".into()],
             dtype: "f32".into(),
         };
-        let err = LoraAdapter::new(config, HashMap::new())
-            .expect_err("unknown target module must be rejected at construction");
+        let adapter = LoraAdapter::new(config, HashMap::new())
+            .expect("LoraAdapter::new must not reject an unrecognized target module name");
+        assert_eq!(adapter.config().target_modules, ["not_a_real_module"]);
+    }
+
+    #[test]
+    fn new_with_descriptor_rejects_unrecognized_target_module() {
+        // The layer set below matches `target_modules` exactly (same key,
+        // same rank), so the pre-existing module-set-agreement check below
+        // this one in the function cannot be what rejects the call — only
+        // the allowlist check can. Without a matching layer this test would
+        // pass for the wrong reason (empty `layers` vs. non-empty
+        // `target_modules` already disagrees on its own).
+        let descriptor = lattice_fann::lora::LoraDescriptor {
+            rank: 2,
+            alpha: 2.0,
+            target_modules: vec!["not_a_real_module".into()],
+            dtype: "f32".into(),
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "not_a_real_module".into()),
+            LoraLayer {
+                a: vec![1.0; 2],
+                b: vec![1.0; 2],
+                d_in: 1,
+                d_out: 1,
+                rank: 2,
+            },
+        );
+        let err = LoraAdapter::new_with_descriptor(descriptor, layers)
+            .expect_err("new_with_descriptor must reject an unrecognized target module name");
         assert!(
             err.to_string().contains("not_a_real_module"),
             "error must name the unknown module via the shared validator; got: {err}"
         );
+    }
+
+    #[test]
+    fn new_with_descriptor_accepts_recognized_target_module() {
+        // Run alongside the rejection test above so a validator that
+        // rejects everything (rather than actually checking names) cannot
+        // pass by accident.
+        let descriptor = lattice_fann::lora::LoraDescriptor {
+            rank: 2,
+            alpha: 2.0,
+            target_modules: vec!["q_proj".into()],
+            dtype: "f32".into(),
+        };
+        let mut layers = HashMap::new();
+        layers.insert(
+            (0, "q_proj".into()),
+            LoraLayer {
+                a: vec![1.0; 2],
+                b: vec![1.0; 2],
+                d_in: 1,
+                d_out: 1,
+                rank: 2,
+            },
+        );
+        assert!(LoraAdapter::new_with_descriptor(descriptor, layers).is_ok());
     }
 
     // -------------------------------------------------------------------
@@ -1126,14 +1209,15 @@ mod tests {
         #[test]
         fn test_validate_against_unknown_module_errors() {
             let cfg = Qwen35Config::qwen35_0_8b();
-            // "query" is in `KNOWN_LORA_TARGET_MODULES` (it's a BERT
-            // projection name), so construction passes the allowlist check
-            // in `LoraConfig::validate` and this test actually reaches
-            // `validate_against`'s own module-recognition rejection instead
-            // of failing at `make_adapter_for_layer`'s `.expect(..)`. A
-            // typo'd name like "xq_proj_typo" is rejected earlier, at
-            // construction, and is covered by
-            // `lora_adapter_new_rejects_unknown_target_module_via_shared_descriptor`.
+            // `make_adapter_for_layer` builds through `LoraAdapter::new`,
+            // which accepts any target-module name (see
+            // `lora_adapter_new_accepts_unrecognized_target_module`), so
+            // both a name unknown to `KNOWN_LORA_TARGET_MODULES` and a name
+            // like "query" that is known but wrong for Qwen3.5 reach this
+            // point unchanged. "query" is used here (a real BERT projection
+            // name) specifically to prove `validate_against` rejects it on
+            // architecture grounds, not merely because the name is
+            // unrecognized anywhere.
             let adapter = make_adapter_for_layer(3, "query", 1024, 4096);
             let err = adapter.validate_against(&cfg).unwrap_err();
             assert!(err.to_string().contains("not a recognised"));
@@ -1381,15 +1465,12 @@ mod tests {
 
         #[test]
         fn test_validate_against_bert_unknown_module_rejected() {
-            // "q_proj" is in `KNOWN_LORA_TARGET_MODULES` (it's a Qwen3.5
-            // full-attention projection name), so construction passes the
-            // allowlist check in `LoraConfig::validate` and this test
-            // actually reaches `validate_against_bert`'s own
-            // module-recognition rejection instead of failing at
-            // `make_bert_adapter`'s `.expect(..)`. A typo'd name like
-            // "xquery_typo" is rejected earlier, at construction, and is
-            // covered by
-            // `lora_adapter_new_rejects_unknown_target_module_via_shared_descriptor`.
+            // `make_bert_adapter` builds through `LoraAdapter::new`, which
+            // accepts any target-module name (see
+            // `lora_adapter_new_accepts_unrecognized_target_module`). "q_proj"
+            // is used here (a real Qwen3.5 projection name, so it is not
+            // merely unrecognized anywhere) specifically to prove
+            // `validate_against_bert` rejects it on architecture grounds.
             let adapter = make_bert_adapter("q_proj", HIDDEN_SIZE, HIDDEN_SIZE);
             let err = adapter
                 .validate_against_bert(NUM_HIDDEN_LAYERS, HIDDEN_SIZE, INTERMEDIATE_SIZE)

--- a/crates/tune/src/lora/mod.rs
+++ b/crates/tune/src/lora/mod.rs
@@ -1126,7 +1126,15 @@ mod tests {
         #[test]
         fn test_validate_against_unknown_module_errors() {
             let cfg = Qwen35Config::qwen35_0_8b();
-            let adapter = make_adapter_for_layer(3, "xq_proj_typo", 1024, 4096);
+            // "query" is in `KNOWN_LORA_TARGET_MODULES` (it's a BERT
+            // projection name), so construction passes the allowlist check
+            // in `LoraConfig::validate` and this test actually reaches
+            // `validate_against`'s own module-recognition rejection instead
+            // of failing at `make_adapter_for_layer`'s `.expect(..)`. A
+            // typo'd name like "xq_proj_typo" is rejected earlier, at
+            // construction, and is covered by
+            // `lora_adapter_new_rejects_unknown_target_module_via_shared_descriptor`.
+            let adapter = make_adapter_for_layer(3, "query", 1024, 4096);
             let err = adapter.validate_against(&cfg).unwrap_err();
             assert!(err.to_string().contains("not a recognised"));
         }
@@ -1373,7 +1381,16 @@ mod tests {
 
         #[test]
         fn test_validate_against_bert_unknown_module_rejected() {
-            let adapter = make_bert_adapter("xquery_typo", HIDDEN_SIZE, HIDDEN_SIZE);
+            // "q_proj" is in `KNOWN_LORA_TARGET_MODULES` (it's a Qwen3.5
+            // full-attention projection name), so construction passes the
+            // allowlist check in `LoraConfig::validate` and this test
+            // actually reaches `validate_against_bert`'s own
+            // module-recognition rejection instead of failing at
+            // `make_bert_adapter`'s `.expect(..)`. A typo'd name like
+            // "xquery_typo" is rejected earlier, at construction, and is
+            // covered by
+            // `lora_adapter_new_rejects_unknown_target_module_via_shared_descriptor`.
+            let adapter = make_bert_adapter("q_proj", HIDDEN_SIZE, HIDDEN_SIZE);
             let err = adapter
                 .validate_against_bert(NUM_HIDDEN_LAYERS, HIDDEN_SIZE, INTERMEDIATE_SIZE)
                 .expect_err("unrecognised BERT module must be rejected");

--- a/crates/tune/src/lora/online.rs
+++ b/crates/tune/src/lora/online.rs
@@ -149,6 +149,7 @@ mod tests {
             rank: 2,
             alpha: 2.0,
             target_modules: vec!["q_proj".into()],
+            dtype: "f32".into(),
         };
         let mut layers = HashMap::new();
         layers.insert(

--- a/crates/tune/src/lora/optimizer.rs
+++ b/crates/tune/src/lora/optimizer.rs
@@ -227,6 +227,7 @@ mod tests {
             rank: 2,
             alpha: 2.0,
             target_modules: vec!["q_proj".into()],
+            dtype: "f32".into(),
         };
         let mut layers = HashMap::new();
         layers.insert(

--- a/crates/tune/src/lora/safetensors.rs
+++ b/crates/tune/src/lora/safetensors.rs
@@ -372,6 +372,7 @@ pub(crate) fn load_peft_safetensors_bytes(bytes: &[u8]) -> Result<LoraAdapter, T
         rank,
         alpha,
         target_modules: target_modules.into_iter().collect(),
+        dtype: "f32".into(),
     };
     LoraAdapter::new(config, layers)
 }
@@ -1057,6 +1058,7 @@ mod tests {
             rank,
             alpha: rank as f32,
             target_modules: vec!["q_proj".to_string(), "gate_proj".to_string()],
+            dtype: "f32".into(),
         };
 
         let a_data: Vec<f32> = (0..rank * d_in).map(|i| i as f32 * 0.01).collect();
@@ -1131,6 +1133,7 @@ mod tests {
             rank,
             alpha: rank as f32,
             target_modules: vec!["q_proj".to_string()],
+            dtype: "f32".into(),
         };
         let mut layers = HashMap::new();
         layers.insert(
@@ -1178,6 +1181,7 @@ mod tests {
             rank,
             alpha: rank as f32,
             target_modules: vec!["q_proj".to_string()],
+            dtype: "f32".into(),
         };
         let mut layers = HashMap::new();
         layers.insert(
@@ -1244,6 +1248,7 @@ mod tests {
             rank,
             alpha: 16.0,
             target_modules: vec!["q_proj".to_string()],
+            dtype: "f32".into(),
         };
 
         let mut layers = HashMap::new();
@@ -1379,6 +1384,7 @@ mod tests {
             rank,
             alpha: rank as f32,
             target_modules: vec!["q_proj".to_string(), "v_proj".to_string()],
+            dtype: "f32".into(),
         };
 
         let mut layers = HashMap::new();

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -582,6 +582,7 @@ fn train_micro_lora_impl(
         rank,
         alpha,
         target_modules,
+        dtype: "f32".into(),
     };
     LoraAdapter::new(lora_config, adapter_layers)
 }

--- a/crates/tune/src/train_support/full_driver.rs
+++ b/crates/tune/src/train_support/full_driver.rs
@@ -1152,6 +1152,7 @@ pub fn run(config: FullDriverConfig) -> Result<FullDriverOutcome, Box<dyn std::e
                 rank,
                 alpha,
                 target_modules,
+                dtype: "f32".into(),
             };
             let adapter = LoraAdapter::new(config, adapter_layers)
                 .map_err(|e| format!("construct adapter: {e}"))?;

--- a/crates/tune/tests/bert_cross_encoder_over_complete_lora.rs
+++ b/crates/tune/tests/bert_cross_encoder_over_complete_lora.rs
@@ -239,6 +239,7 @@ fn over_complete_query_adapter() -> LoraAdapter {
             rank,
             alpha: rank as f32,
             target_modules: vec!["query".to_string()],
+            dtype: "f32".into(),
         },
         layers,
     )
@@ -455,6 +456,7 @@ fn cross_encoder_applies_an_attention_only_adapter() {
             rank,
             alpha: rank as f32,
             target_modules: vec!["value".to_string()],
+            dtype: "f32".into(),
         },
         layers,
     )

--- a/crates/tune/tests/lora_apply_no_alloc.rs
+++ b/crates/tune/tests/lora_apply_no_alloc.rs
@@ -75,6 +75,7 @@ fn make_adapter() -> LoraAdapter {
         rank: 8,
         alpha: 16.0,
         target_modules: vec!["query".into(), "value".into()],
+        dtype: "f32".into(),
     };
 
     let mut layers = HashMap::new();

--- a/crates/tune/tests/lora_apply_no_alloc.rs
+++ b/crates/tune/tests/lora_apply_no_alloc.rs
@@ -1,12 +1,20 @@
 //! Structural regression: `LoraAdapter::apply` must not heap-allocate on the
 //! per-token-row hot path (`lattice_inference::lora_hook::apply_lora_rows`
 //! calls it once per row — 6 x layers x tokens times for a BERT forward
-//! pass), whether or not the layer/module has an adapter.
+//! pass), whether or not the layer/module has an adapter — for ranks within
+//! `apply::STACK_RANK_CAPACITY` (128), the only case this claim covers.
+//! `apply_lora`'s own doc comment states the contract as rank-conditional:
+//! above that cap it falls back to a heap `Vec` for the `A @ x` intermediate
+//! and stays correct, just not allocation-free. `LoraAdapter::validate_against_bert`
+//! deliberately permits `rank > min(d_in, d_out)` (redundant but valid; see
+//! `blend_lora_adapters`, which produces exactly this shape), so a rank above
+//! 128 is reachable through the public API, not just a hypothetical.
 //!
 //! Installs a counting global allocator for this test binary only (isolated
 //! from other integration tests, which run as separate processes) and
 //! asserts zero allocation-call deltas across both the missing-adapter fast
-//! path and the matched, rank-driven path.
+//! path and the matched, rank-driven path — plus a companion test below that
+//! records the heap branch honestly instead of leaving it unmeasured.
 //!
 //! Counters are thread-local (#1272): the test body runs on a harness-spawned
 //! thread while other harness threads (result reporting, output capture,
@@ -143,5 +151,53 @@ fn apply_matched_and_missing_hot_path_allocates_nothing() {
         "LoraAdapter::apply performed {} heap deallocations across 512 * 12 * 4 \
          hooked rows; the per-row hot path must be allocation-free",
         dealloc_after - dealloc_before
+    );
+}
+
+/// Companion to the test above: a rank above the stack-scratch cap (128, per
+/// `apply::STACK_RANK_CAPACITY`) takes the documented heap-fallback branch.
+/// This records that honestly (asserting the allocation actually happens)
+/// rather than silently leaving it unmeasured — a renamed or generalized
+/// "allocation-free" claim without this would still prove nothing about the
+/// over-cap path. `rank = 200` matches the value `apply.rs`'s own internal
+/// unit test uses for the same fallback.
+#[test]
+fn apply_rank_above_stack_capacity_falls_back_to_heap_allocation() {
+    let rank = 200;
+    let config = LoraConfig {
+        rank,
+        alpha: rank as f32,
+        target_modules: vec!["query".into()],
+        dtype: "f32".into(),
+    };
+    let mut layers = HashMap::new();
+    layers.insert(
+        (0, "query".to_string()),
+        LoraLayer {
+            a: vec![0.01; rank * 16],
+            b: vec![0.02; 16 * rank],
+            d_in: 16,
+            d_out: 16,
+            rank,
+        },
+    );
+    let adapter = LoraAdapter::new(config, layers).expect("valid adapter config");
+    let x = vec![0.1f32; 16];
+    let mut output = vec![0.0f32; 16];
+
+    // Warm up once, matching the pattern above, so only the measured calls
+    // below are attributed.
+    adapter.apply(0, "query", &x, &mut output);
+
+    let alloc_before = alloc_calls();
+    adapter.apply(0, "query", &x, &mut output);
+    let alloc_after = alloc_calls();
+
+    assert!(
+        alloc_after > alloc_before,
+        "rank {rank} (above STACK_RANK_CAPACITY=128) is documented to take the \
+         heap-fallback branch for its A @ x scratch buffer, but no allocation \
+         was observed — either the fallback stopped firing or this test no \
+         longer exercises it"
     );
 }


### PR DESCRIPTION
Closes #615.

## What changed

`lattice-fann` gains a `lora` module holding the LoRA adapter descriptor and the blend-validation logic that `lattice-tune` and the Metal inference path had each been carrying their own copy of. Both now call the shared module.

`lattice-fann` is the right home rather than `lattice-inference`: it is the only leaf crate `lattice-tune` depends on unconditionally, whereas the `tune -> inference` edge is behind the `inference-hook` / `train-backward` features and is off in a default build. A module owned by `inference` would have been unreachable from tune's default build, so the dependency direction picks the location here.

## The duplication that existed, and the one disagreement

The caps were genuinely duplicated but did not disagree: `MAX_BLEND_RANK_TOTAL = 4096` and `MAX_BLEND_TOTAL_ELEMENTS = 1 << 30` were identical in `tune`'s `blend_lora_adapters` / `blend_layer_entries` and in inference's Metal-gated `blend_lora_layer_data`. Every existing error message is preserved byte-for-byte.

One thing did disagree, and it is a behavior change worth reading closely. `chat_metal.rs` computed the scale locally as:

```rust
let scale = if rank > 0 { alpha / rank as f32 } else { 1.0 };
```

so a zero rank produced a scale of `1.0`. `tune`'s documented and tested `LoraConfig::scale()` produces `0.0` for the same input. The shared helper adopts tune's value:

```rust
pub fn effective_scale(rank: usize, alpha: f32) -> f32 {
    let scale = if rank == 0 { 0.0 } else { alpha / rank as f32 };
    ...
}
```

Zero rank means an empty factorization, which contributes nothing, so `0.0` is the defensible value and `1.0` was the outlier. The helper also collapses a non-finite `alpha` or a non-finite resulting scale to `0.0` rather than letting NaN or Inf propagate into the forward pass. This is called out rather than folded in silently because it is a real change to what `chat_metal` computes on that input, not a pure refactor.

## Verification

Mutation arm: weakening the rank cap in the shared module reddens exactly the predicted tests in `tune` and in the shared module, and leaves the neighbouring assertions green — including `blend_aggregate_budget_exceeded_returns_err`, which stays passing while `blend_rank_exceeds_cap_returns_error` fails. The mutation was restored and the tree verified clean afterwards.

The inference-side Metal-gated tests call the identical mutated function but were **not executed** this round: the machine-wide GPU test lock was held by another job for the duration. That is a gap in the evidence, not a claim that those tests pass. The shared function they call is the one the mutation arm did cover.

Workspace builds clean on default features; `cargo fmt` and clippy clean.

## bench-compare disposition

Structural waiver, no A/B table, and the population is stated because the two targets `bench-compare` runs by default are not the population.

**Corrected.** An earlier revision of this section searched all 24 declared `[[bench]]` targets in `crates/inference/Cargo.toml` plus the 1 in `crates/fann`, found no reference to `blend_lora`, `effective_scale`, `LoraDescriptor`, or `lora_mixture`, and concluded no measurement of the changed path exists. That search was run with a positive control and did reach every file it enumerated — but it enumerated the wrong population.

`crates/inference/Cargo.toml:159` declares a `[[bin]]`, not a `[[bench]]`:

```toml
[[bin]]
name = "bench_lora_mixture"
path = "src/bin/bench_lora_mixture.rs"
required-features = ["f16", "metal-gpu", "bench-internals"]
```

It calls `blend_lora_layer_data(&refs)` at `src/bin/bench_lora_mixture.rs:141` and `:148` — the function this PR changes. It is a bin rather than a bench because it needs a real Metal device and a model directory, which a Criterion harness cannot supply. So a measurement of the changed path does exist, and enumerating by declaration kind stepped past it.

The manifest change gets its own paragraph, because a build-input change is exactly the case where a structural waiver normally does not apply. `metal-gpu` now carries `dep:lattice-fann`, since `blend_lora_layer_data` and `chat_metal` call the shared module whenever that feature is on rather than only under `mixture`. `metal-gpu` is not a default feature (`default = ["std", "download", "serve"]`), so this adds no dependency to the default bench build and cannot change what those binaries compile. Under a `metal-gpu` bench build it does add a dependency, and no declared bench target reaches the changed code there either.

Residual risk, restated correctly: the LoRA blend path is **not measured by this round**, which is a different and weaker claim than the earlier "no target in the repository can notice". `bench_lora_mixture` reaches the changed function and has not been run against this branch, so the performance of the blend path is unknown here rather than unmeasurable. Treat that as an owed measurement, not as an absence of one.

## Why a test file is in this diff

`metal_measurement_lock_contract.rs` records a `recorded_position` for each construction exemption, and the shared-helper change adds three lines above the two `MetalQwen35State` construction sites in `chat_metal.rs::run`. CI failed with the guard's own wording: *"recorded a position that no longer matches (not a locking violation)"*, `770:39 -> 773:39` and `795:39 -> 798:39`.

Both call sites are byte-identical to their previous form (compared against `origin/main` before touching the numbers, because "move the numbers until it goes green" is exactly how a real violation would hide here). Only the recorded positions move. Locally: `cargo test -p lattice-inference --test metal_measurement_lock_contract` → **53 passed, 0 failed**; the pre-fix state failing in CI is the paired negative arm.

