### PR TITLE
feat(inference): vision weight preload control and skip redundant multimodal head work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,15 +327,24 @@ jobs:
       # gate to examples, benches, and #[cfg(test)] modules — the same surface
       # where a second wave of lint debt (manual_let_else, approx_constant,
       # dead bench fields) had silently accumulated past the lib+bins gate.
+      - name: inference — metal-gpu clippy (macOS only)
+        if: runner.os == 'macOS'
+        run: cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu -- -D warnings
       # `bench-internals` gates the bench binaries under `src/bin/` (e.g.
       # `bench_vision_prefill_ab`) and their `bench_support` module — without
       # it in this feature list, `--all-targets` never compiles that surface,
       # so lint debt there (an "items after a test module" error, #1336
       # round 2) went undetected by this exact command until a manually
-      # widened invocation caught it.
-      - name: inference — metal-gpu clippy (macOS only)
+      # widened invocation caught it. This is a separate --release step
+      # (rather than adding bench-internals to the step above) because
+      # `bench_vision_prefill_ab.rs:95` has a `compile_error!` gated on
+      # `debug_assertions` — "bench_vision_prefill_ab: MUST build --release
+      # (debug Metal timing is meaningless)" — so this surface cannot compile
+      # in a plain debug clippy pass, and forcing --release onto the fast
+      # debug lint above would slow it for everything else it covers.
+      - name: inference — metal-gpu bench clippy, release (macOS only)
         if: runner.os == 'macOS'
-        run: cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu,bench-internals -- -D warnings
+        run: cargo clippy --release -p lattice-inference --all-targets --features f16,metal-gpu,bench-internals -- -D warnings
       # The worker module is macOS/metal-gpu-gated, but this lifecycle test
       # uses only a blocking thread-local destructor and never acquires a
       # Metal device. Run it explicitly so compiling the test is not mistaken

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,9 +327,15 @@ jobs:
       # gate to examples, benches, and #[cfg(test)] modules — the same surface
       # where a second wave of lint debt (manual_let_else, approx_constant,
       # dead bench fields) had silently accumulated past the lib+bins gate.
+      # `bench-internals` gates the bench binaries under `src/bin/` (e.g.
+      # `bench_vision_prefill_ab`) and their `bench_support` module — without
+      # it in this feature list, `--all-targets` never compiles that surface,
+      # so lint debt there (an "items after a test module" error, #1336
+      # round 2) went undetected by this exact command until a manually
+      # widened invocation caught it.
       - name: inference — metal-gpu clippy (macOS only)
         if: runner.os == 'macOS'
-        run: cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu -- -D warnings
+        run: cargo clippy -p lattice-inference --all-targets --features f16,metal-gpu,bench-internals -- -D warnings
       # The worker module is macOS/metal-gpu-gated, but this lifecycle test
       # uses only a blocking thread-local destructor and never acquires a
       # Metal device. Run it explicitly so compiling the test is not mistaken

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -1073,11 +1073,12 @@ jobs:
       # documents. LATTICE_METAL_TEST_ENFORCE=1 makes a missing device or
       # checkpoint a hard failure instead of the default dev-run skip.
       #
-      # The filter also selects two later additions that reuse this same
+      # The filter also selects later additions that reuse this same
       # checkpoint+device: `forward_step_mrope_emit_head_false_skips_terminal_head_dispatch`
       # (mechanism test: `emit_head=false` must skip the terminal RMSNorm +
-      # lm_head dispatch entirely, not merely its readback) and
-      # `generate_multimodal_vision_emit_head_skip_matches_always_emit_reference`
+      # lm_head dispatch entirely, not merely its readback), its MTP-weights
+      # variant `forward_step_mrope_emit_head_false_skips_terminal_head_dispatch_with_mtp_weights_present_but_request_inactive`,
+      # and `generate_multimodal_vision_emit_head_skip_matches_always_emit_reference`
       # (equivalence test: the skip must not change prefill state) via the
       # `emit_head` filter term, plus the checkpoint-free
       # `vision_runtime_preload_is_noop_when_unsupported` and
@@ -1092,7 +1093,7 @@ jobs:
       # (CPU f16 injection oracle), and
       # `shared_server_runner_drops_router_after_injected_shutdown` (serve-shutdown
       # regression matching only incidentally on the `injected` substring), so
-      # the exact-count grep below is 12 (8 `inject`-filter matches + 2
+      # the exact-count grep below is 13 (8 `inject`-filter matches + 3
       # `emit_head`-filter matches + 2 `vision_runtime_preload`-filter
       # matches), not 5 -- update it in the same PR if the matched test
       # surface changes. libtest ORs multiple filter arguments together, so
@@ -1117,7 +1118,7 @@ jobs:
             cat vision-mp2-inject-gate.log
             exit "$status"
           fi
-          grep -Eq '^test result: ok\. 12 passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' vision-mp2-inject-gate.log
+          grep -Eq '^test result: ok\. 13 passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' vision-mp2-inject-gate.log
 
   # Fail-closed control-flow self-test for the Q4 PPL gate script (issue #616).
   # Cheap, deterministic, GPU-free (sandbox tree + stub eval_perplexity), so —

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -1095,17 +1095,21 @@ jobs:
       # the exact-count grep below is 12 (8 `inject`-filter matches + 2
       # `emit_head`-filter matches + 2 `vision_runtime_preload`-filter
       # matches), not 5 -- update it in the same PR if the matched test
-      # surface changes. `cargo test`'s libtest harness ORs multiple filter
-      # arguments together (verified locally with `--list inject emit_head
-      # vision_runtime_preload`), so one step covers all three groups.
+      # surface changes. libtest ORs multiple filter arguments together, so
+      # one step covers all three groups, but the filters MUST be passed to
+      # libtest after `--`: `cargo test` itself accepts a single positional
+      # TESTNAME (`cargo test [OPTIONS] [TESTNAME] [-- [ARGS]...]`) and exits
+      # 1 with `error: unexpected argument` on the second one, before any
+      # test binary is built or run.
       - name: Run MP2 Metal injection gate (fail-closed)
         if: ${{ !cancelled() }}
         env:
           LATTICE_METAL_TEST_ENFORCE: '1'
         run: |
           if cargo test --release -p lattice-inference --features f16,metal-gpu \
-            --lib inject emit_head vision_runtime_preload \
-            -- --nocapture --test-threads=1 > vision-mp2-inject-gate.log 2>&1
+            --lib \
+            -- inject emit_head vision_runtime_preload \
+            --nocapture --test-threads=1 > vision-mp2-inject-gate.log 2>&1
           then
             cat vision-mp2-inject-gate.log
           else

--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -1071,21 +1071,41 @@ jobs:
       # tests touch the Apple7-gated tiled-GEMM path (decode-only GEMV/element-wise
       # dispatch), the same reasoning the f16-KV-cache Metal gate in ci.yml
       # documents. LATTICE_METAL_TEST_ENFORCE=1 makes a missing device or
-      # checkpoint a hard failure instead of the default dev-run skip. The
-      # `--lib inject` filter also matches `inject_quarot_seed_roundtrips_in_config_json`
+      # checkpoint a hard failure instead of the default dev-run skip.
+      #
+      # The filter also selects two later additions that reuse this same
+      # checkpoint+device: `forward_step_mrope_emit_head_false_skips_terminal_head_dispatch`
+      # (mechanism test: `emit_head=false` must skip the terminal RMSNorm +
+      # lm_head dispatch entirely, not merely its readback) and
+      # `generate_multimodal_vision_emit_head_skip_matches_always_emit_reference`
+      # (equivalence test: the skip must not change prefill state) via the
+      # `emit_head` filter term, plus the checkpoint-free
+      # `vision_runtime_preload_is_noop_when_unsupported` and
+      # `vision_runtime_preload_failure_falls_back_to_lazy_pending_state`
+      # (crates/inference/src/serve/metal_worker.rs) via the
+      # `vision_runtime_preload` filter term — none of these five ran in CI
+      # either, for the same reason: no workflow's filter matched their
+      # names.
+      #
+      # `--lib inject` also matches `inject_quarot_seed_roundtrips_in_config_json`
       # (QuaRot seed round trip), `injection_replaces_lookup_and_is_mutation_sensitive`
       # (CPU f16 injection oracle), and
       # `shared_server_runner_drops_router_after_injected_shutdown` (serve-shutdown
       # regression matching only incidentally on the `injected` substring), so
-      # the exact-count grep below is 8, not 5 -- update it in the same PR if the
-      # `inject`-matching test surface changes.
+      # the exact-count grep below is 12 (8 `inject`-filter matches + 2
+      # `emit_head`-filter matches + 2 `vision_runtime_preload`-filter
+      # matches), not 5 -- update it in the same PR if the matched test
+      # surface changes. `cargo test`'s libtest harness ORs multiple filter
+      # arguments together (verified locally with `--list inject emit_head
+      # vision_runtime_preload`), so one step covers all three groups.
       - name: Run MP2 Metal injection gate (fail-closed)
         if: ${{ !cancelled() }}
         env:
           LATTICE_METAL_TEST_ENFORCE: '1'
         run: |
           if cargo test --release -p lattice-inference --features f16,metal-gpu \
-            --lib inject -- --nocapture --test-threads=1 > vision-mp2-inject-gate.log 2>&1
+            --lib inject emit_head vision_runtime_preload \
+            -- --nocapture --test-threads=1 > vision-mp2-inject-gate.log 2>&1
           then
             cat vision-mp2-inject-gate.log
           else
@@ -1093,7 +1113,7 @@ jobs:
             cat vision-mp2-inject-gate.log
             exit "$status"
           fi
-          grep -Eq '^test result: ok\. 8 passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' vision-mp2-inject-gate.log
+          grep -Eq '^test result: ok\. 12 passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' vision-mp2-inject-gate.log
 
   # Fail-closed control-flow self-test for the Q4 PPL gate script (issue #616).
   # Cheap, deterministic, GPU-free (sandbox tree + stub eval_perplexity), so —

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -152,6 +152,11 @@ path = "src/bin/bench_gdn_prefill_ab.rs"
 required-features = ["f16", "metal-gpu", "bench-internals"]
 
 [[bin]]
+name = "bench_vision_prefill_ab"
+path = "src/bin/bench_vision_prefill_ab.rs"
+required-features = ["f16", "metal-gpu", "bench-internals"]
+
+[[bin]]
 name = "bench_lora_mixture"
 path = "src/bin/bench_lora_mixture.rs"
 required-features = ["f16", "metal-gpu"]

--- a/crates/inference/src/bin/bench_vision_prefill_ab.rs
+++ b/crates/inference/src/bin/bench_vision_prefill_ab.rs
@@ -94,6 +94,34 @@ fn main() {
 ))]
 compile_error!("bench_vision_prefill_ab: MUST build --release (debug Metal timing is meaningless)");
 
+/// Rejects `repeats == 0` up front. Left unchecked, it leaves both timing
+/// vectors empty and [`median`]'s `v[v.len() / 2]` indexing panics deep
+/// inside the measurement loop — after the (slow) model load has already
+/// paid its cost. Fail with an operator-facing message before that point
+/// instead.
+fn validate_repeats(repeats: usize) -> Result<(), String> {
+    if repeats == 0 {
+        return Err(
+            "BENCH_REPEATS=0 would leave both timing vectors empty; set BENCH_REPEATS to a \
+             positive integer (default 5)"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// Sorts `values` in place and returns the median. Returns `Err` instead of
+/// panicking on an empty slice — [`validate_repeats`] is what keeps `run()`
+/// from ever reaching this on an empty vector, but the helper does not rely
+/// on that caller discipline to stay panic-free.
+fn median(values: &mut [f64]) -> Result<f64, String> {
+    if values.is_empty() {
+        return Err("median: cannot compute a median of an empty timing vector".to_string());
+    }
+    values.sort_by(|a, b| a.partial_cmp(b).expect("no NaN in timing data"));
+    Ok(values[values.len() / 2])
+}
+
 #[cfg(all(
     target_os = "macos",
     feature = "metal-gpu",
@@ -124,6 +152,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(5);
+    validate_repeats(repeats)?;
 
     eprintln!("[bench] loading {model_dir_str} (safetensors)");
     let model = Qwen35Model::from_safetensors(dir).map_err(|e| format!("load model: {e}"))?;
@@ -180,12 +209,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         optimized_ms.push(o);
     }
 
-    let median = |v: &mut Vec<f64>| -> f64 {
-        v.sort_by(|a, b| a.partial_cmp(b).expect("no NaN in timing data"));
-        v[v.len() / 2]
-    };
-    let baseline_median = median(&mut baseline_ms);
-    let optimized_median = median(&mut optimized_ms);
+    let baseline_median = median(&mut baseline_ms)?;
+    let optimized_median = median(&mut optimized_ms)?;
     let delta_median_ms = baseline_median - optimized_median;
     let delta_median_pct = if baseline_median > 0.0 {
         100.0 * delta_median_ms / baseline_median
@@ -200,4 +225,42 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{median, validate_repeats};
+
+    #[test]
+    fn validate_repeats_rejects_zero() {
+        let err = validate_repeats(0).expect_err("BENCH_REPEATS=0 must be rejected");
+        assert!(
+            err.contains("BENCH_REPEATS=0"),
+            "error message must name the offending env var; got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_repeats_accepts_positive_values() {
+        assert!(validate_repeats(1).is_ok());
+        assert!(validate_repeats(5).is_ok());
+    }
+
+    #[test]
+    fn median_rejects_empty_slice_instead_of_panicking() {
+        let mut empty: Vec<f64> = Vec::new();
+        assert!(median(&mut empty).is_err());
+    }
+
+    #[test]
+    fn median_of_single_repeat_is_that_repeat() {
+        let mut v = vec![42.0];
+        assert_eq!(median(&mut v).unwrap(), 42.0);
+    }
+
+    #[test]
+    fn median_sorts_before_indexing() {
+        let mut v = vec![3.0, 1.0, 2.0];
+        assert_eq!(median(&mut v).unwrap(), 2.0);
+    }
 }

--- a/crates/inference/src/bin/bench_vision_prefill_ab.rs
+++ b/crates/inference/src/bin/bench_vision_prefill_ab.rs
@@ -1,0 +1,203 @@
+//! Issue #1336 multimodal-prefill A/B measurement harness.
+//!
+//! Measures Metal M-RoPE multimodal prefill wall time on a real checkpoint
+//! with two arms that differ ONLY in one runtime flag, never in source or
+//! binary:
+//!   - baseline (`always_emit_head=true`): terminal RMSNorm + lm_head
+//!     dispatched at every prefill position — the pre-#1336 shape.
+//!   - optimized (`always_emit_head=false`): terminal head dispatched only
+//!     at the final prefill position — the shipped
+//!     `generate_multimodal_vision_impl` behavior (`emit_head = pos ==
+//!     last_prefill_pos`).
+//!
+//! Both arms call `bench_support::run_multimodal_prefill`
+//! (`forward/metal_qwen35.rs`), which drives the exact same
+//! `forward_step_mrope`/`forward_step_injected_mrope` functions the
+//! production path calls. There is no recompile between arms: one process,
+//! one binary, the flag is a function argument selected per repeat.
+//!
+//! What this harness does NOT measure: ViT/merger (vision-encoder) cost.
+//! `post_merger_rows` are synthetic, checkpoint-shape-correct values, not a
+//! real decoded image — the emit_head optimization is entirely inside the
+//! decoder's per-position forward step, downstream of and insensitive to
+//! merger output content, only to its shape (hidden_size, row count). A
+//! number from this harness is "decoder multimodal-prefill time", not
+//! "end-to-end multimodal request latency"; do not quote it as the latter.
+//!
+//! Declared confounds this harness does NOT control for:
+//!   - Shared-machine contention: other processes competing for the GPU,
+//!     CPU, or memory bandwidth bias wall-clock time in either direction.
+//!     Run under the fleet's exclusive heavy-lane + GPU lock discipline.
+//!   - Thermal state: sustained runs on a laptop/mini can throttle Metal
+//!     clocks mid-run; the first repeat after a cold start and the last
+//!     repeat of a long run are not directly comparable.
+//!   - Command-buffer / driver warm-up: the single untimed warmup repeat
+//!     below reduces but does not eliminate first-dispatch overhead
+//!     (pipeline-state compilation, allocator warm-up).
+//!   - OS scheduler noise on the CPU side of each `wait_until_completed`.
+//!   - This is single-request prefill only — no batching, no concurrent
+//!     requests, no KV-cache reuse across requests.
+//!
+//! Env:
+//!   LATTICE_MODEL_DIR    model dir (default ~/.lattice/models/qwen3.5-0.8b),
+//!                        must be a real vision-capable checkpoint
+//!                        (safetensors format; Q4 vision loading is out of
+//!                        scope for this harness)
+//!   BENCH_VISUAL_ROWS    target post-merger visual row count (default 1024;
+//!                        actual count is rounded up to the next square grid
+//!                        and printed)
+//!   BENCH_WARMUP         untimed warmup repeats per arm (default 1)
+//!   BENCH_REPEATS        timed repeats per arm (default 5)
+//!
+//! Output: one `RESULT` line per (arm, repeat) to stdout, plus a
+//! `SUMMARY` line with median baseline/optimized/delta, all parseable
+//! without scraping prose.
+//!
+//! Operator command (run elsewhere, on real hardware — this environment is
+//! prohibited from executing it):
+//!   cargo run --release -p lattice-inference --features f16,metal-gpu,bench-internals \
+//!     --bin bench_vision_prefill_ab
+//! with LATTICE_MODEL_DIR pointed at the checkpoint if it is not at the
+//! default path.
+
+#[cfg(not(all(
+    target_os = "macos",
+    feature = "metal-gpu",
+    feature = "bench-internals"
+)))]
+fn main() {
+    eprintln!("Requires macOS + metal-gpu + bench-internals features.");
+    std::process::exit(1);
+}
+
+#[cfg(all(
+    target_os = "macos",
+    feature = "metal-gpu",
+    feature = "bench-internals"
+))]
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("bench_vision_prefill_ab failed: {e}");
+        std::process::exit(1);
+    }
+}
+
+// Debug-build Metal timing is meaningless (unoptimized dispatch encoding,
+// debug assertions on the hot path) — fail to build rather than produce a
+// number nobody should trust. Compile-time check because
+// `debug_assertions` is a compile-time constant.
+#[cfg(all(
+    target_os = "macos",
+    feature = "metal-gpu",
+    feature = "bench-internals",
+    debug_assertions
+))]
+compile_error!("bench_vision_prefill_ab: MUST build --release (debug Metal timing is meaningless)");
+
+#[cfg(all(
+    target_os = "macos",
+    feature = "metal-gpu",
+    feature = "bench-internals"
+))]
+fn run() -> Result<(), Box<dyn std::error::Error>> {
+    use lattice_inference::forward::metal_qwen35::MetalQwen35State;
+    use lattice_inference::forward::metal_qwen35::bench_support;
+    use lattice_inference::model::qwen35::Qwen35Model;
+
+    eprintln!("[bench] acquiring shared Metal GPU lock ...");
+    let _gpu_lock = lattice_inference::measurement::gpu_test_lock();
+
+    let home = std::env::var("HOME")?;
+    let model_dir_str = std::env::var("LATTICE_MODEL_DIR")
+        .unwrap_or_else(|_| format!("{home}/.lattice/models/qwen3.5-0.8b"));
+    let dir = std::path::Path::new(&model_dir_str);
+
+    let visual_rows_target: usize = std::env::var("BENCH_VISUAL_ROWS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1024);
+    let warmup: usize = std::env::var("BENCH_WARMUP")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1);
+    let repeats: usize = std::env::var("BENCH_REPEATS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5);
+
+    eprintln!("[bench] loading {model_dir_str} (safetensors)");
+    let model = Qwen35Model::from_safetensors(dir).map_err(|e| format!("load model: {e}"))?;
+    let cfg = model.config().clone();
+
+    let request = bench_support::vision_prefill_fixture(&cfg, visual_rows_target, 0.02)?;
+    let prompt_len = request.input_ids.len();
+    let visual_rows_actual = request.image_pad_count();
+    // Generous cache headroom above the prefill length; no decode steps run.
+    let cache_len = (prompt_len + 256).max(4096);
+
+    eprintln!(
+        "[bench] visual_rows_target={visual_rows_target} visual_rows_actual={visual_rows_actual} \
+         prompt_tokens={prompt_len} cache_len={cache_len}"
+    );
+
+    let mut state = MetalQwen35State::new(model.weights(), &cfg, cache_len)
+        .map_err(|e| format!("init metal: {e}"))?;
+
+    let run_arm = |state: &mut MetalQwen35State, always_emit_head: bool| -> Result<f64, String> {
+        state.reset_state();
+        let start = std::time::Instant::now();
+        let logits =
+            bench_support::run_multimodal_prefill(state, &request, &cfg, always_emit_head)?;
+        let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
+        if logits.is_empty() {
+            return Err(
+                "final-position prefill must return non-empty logits in both arms \
+                         (final position always has emit_head=true)"
+                    .to_string(),
+            );
+        }
+        Ok(elapsed_ms)
+    };
+
+    for _ in 0..warmup {
+        let _ = run_arm(&mut state, true)?;
+        let _ = run_arm(&mut state, false)?;
+    }
+
+    let mut baseline_ms = Vec::with_capacity(repeats);
+    let mut optimized_ms = Vec::with_capacity(repeats);
+    for i in 0..repeats {
+        let b = run_arm(&mut state, true)?;
+        let o = run_arm(&mut state, false)?;
+        let delta_ms = b - o;
+        let delta_pct = if b > 0.0 { 100.0 * delta_ms / b } else { 0.0 };
+        println!(
+            "RESULT repeat={i} visual_rows={visual_rows_actual} prompt_tokens={prompt_len} \
+             baseline_always_emit_ms={b:.3} optimized_emit_skip_ms={o:.3} delta_ms={delta_ms:.3} \
+             delta_pct={delta_pct:.2}"
+        );
+        baseline_ms.push(b);
+        optimized_ms.push(o);
+    }
+
+    let median = |v: &mut Vec<f64>| -> f64 {
+        v.sort_by(|a, b| a.partial_cmp(b).expect("no NaN in timing data"));
+        v[v.len() / 2]
+    };
+    let baseline_median = median(&mut baseline_ms);
+    let optimized_median = median(&mut optimized_ms);
+    let delta_median_ms = baseline_median - optimized_median;
+    let delta_median_pct = if baseline_median > 0.0 {
+        100.0 * delta_median_ms / baseline_median
+    } else {
+        0.0
+    };
+    println!(
+        "SUMMARY visual_rows={visual_rows_actual} prompt_tokens={prompt_len} repeats={repeats} \
+         baseline_always_emit_median_ms={baseline_median:.3} \
+         optimized_emit_skip_median_ms={optimized_median:.3} delta_median_ms={delta_median_ms:.3} \
+         delta_median_pct={delta_median_pct:.2}"
+    );
+
+    Ok(())
+}

--- a/crates/inference/src/bin/lattice/main.rs
+++ b/crates/inference/src/bin/lattice/main.rs
@@ -86,6 +86,21 @@ enum Command {
                 .range(1..=(tokio::sync::Semaphore::MAX_PERMITS as u64))
         )]
         max_pending: usize,
+        /// Eagerly load vision weights at startup instead of on the first
+        /// image request (issue #1336). Off by default: lazy loading keeps
+        /// text-only startup time and resident memory unchanged from a
+        /// text-only checkpoint, since vision weights are never read at all
+        /// unless an image request arrives. Pass this flag to trade a
+        /// longer, predictable startup (and the vision weights' resident
+        /// memory footprint held from the first request onward instead of
+        /// only after it) for eliminating the first image request's extra
+        /// load latency. Only affects Q4/Metal-backed vision-capable
+        /// checkpoints; text-only and non-Metal backends ignore it. If the
+        /// eager load fails, startup still succeeds: the server warns on
+        /// stderr and falls back to the normal lazy load on the first image
+        /// request, exactly as if this flag had not been passed.
+        #[arg(long)]
+        preload_vision: bool,
     },
     /// Preflight check: memory fit and artifact compatibility, without
     /// loading any model weights (config + tensor index inspection only).
@@ -156,6 +171,7 @@ async fn main() {
             model_id,
             tokenizer_dir,
             max_pending,
+            preload_vision,
         } => {
             use std::path::Path;
             use std::sync::Arc;
@@ -196,6 +212,7 @@ async fn main() {
                             model_path.to_path_buf(),
                             tokenizer_dir_path,
                             max_pending,
+                            preload_vision,
                         ) {
                             Ok((backend, _max_context)) => backend,
                             Err(e) => {
@@ -208,6 +225,7 @@ async fn main() {
                     {
                         let _ = &tokenizer_dir;
                         let _ = max_pending;
+                        let _ = preload_vision;
                         eprintln!("Error: {}", backend::metal_gpu_required_message(model_path));
                         std::process::exit(1);
                     }
@@ -355,5 +373,38 @@ mod max_pending_cli_tests {
             parse_max_pending(&["--max-pending", "8"]).expect("8 is a valid cap"),
             8
         );
+    }
+}
+
+// ─── #1336 CLI boundary tests: `--preload-vision` defaults to lazy ────────
+#[cfg(test)]
+mod preload_vision_cli_tests {
+    use super::*;
+
+    fn parse_preload_vision(args: &[&str]) -> bool {
+        let mut full = vec!["lattice", "serve", "--model", "/tmp/model"];
+        full.extend_from_slice(args);
+        match Cli::try_parse_from(full)
+            .expect("fixed --model arg always parses")
+            .command
+        {
+            Command::Serve { preload_vision, .. } => preload_vision,
+            _ => panic!("expected Command::Serve, got a different Command variant"),
+        }
+    }
+
+    /// Lazy loading is the default: omitting `--preload-vision` must not
+    /// flip it on. This is the CLI-level half of the "lazy stays the
+    /// default" contract the issue asks for -- the startup-behavior half is
+    /// structural (`ModelBackend::spawn_metal` only calls
+    /// `VisionRuntime::preload()` inside `if preload_vision { .. }`).
+    #[test]
+    fn preload_vision_omitted_defaults_to_false() {
+        assert!(!parse_preload_vision(&[]));
+    }
+
+    #[test]
+    fn preload_vision_flag_present_is_true() {
+        assert!(parse_preload_vision(&["--preload-vision"]));
     }
 }

--- a/crates/inference/src/bin/lattice/serve.rs
+++ b/crates/inference/src/bin/lattice/serve.rs
@@ -359,6 +359,7 @@ impl ModelBackend {
         model_dir: std::path::PathBuf,
         tokenizer_dir: Option<std::path::PathBuf>,
         max_pending: usize,
+        preload_vision: bool,
     ) -> Result<(Self, usize), String> {
         use lattice_inference::serve::metal_worker::{
             ContextWindowPolicy, MetalWorker, StartupError, VisionRuntime, WorkerMetadata,
@@ -390,7 +391,20 @@ impl ModelBackend {
         // first in `prepare_chat_request`.
         let max_context = crate::chat::chat_max_cache_len();
         let vision_config = crate::chat::load_q4_config(&model_dir)?;
-        let vision_runtime = VisionRuntime::from_model_config(model_dir.clone(), &vision_config);
+        let mut vision_runtime =
+            VisionRuntime::from_model_config(model_dir.clone(), &vision_config);
+        if preload_vision {
+            // issue #1336: eager-load now, on this startup thread, before the
+            // Metal worker thread spawns. Lazy stays the default (see the
+            // `--preload-vision` help text); a failure here must not abort
+            // startup — warn and fall back to the normal lazy load on the
+            // first image request, exactly as if this flag were absent.
+            if let Err(err) = vision_runtime.preload() {
+                eprintln!(
+                    "Warning: --preload-vision failed, falling back to lazy vision loading: {err}"
+                );
+            }
+        }
         let model_dir_for_loader = model_dir.clone();
         let tokenizer_path_for_loader = tokenizer_path.clone();
         let (owner, client, _meta) = MetalWorker::spawn_with_vision(

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -2675,6 +2675,12 @@ mod imp {
             .cloned()
     }
 
+    /// Presence-only boolean flag (no value): `--preload-vision`, not
+    /// `--preload-vision true`.
+    fn parse_flag(args: &[String], flag: &str) -> bool {
+        args.iter().any(|a| a == flag)
+    }
+
     /// Parses `--max-pending`, rejecting a malformed or negative value
     /// outright instead of silently substituting the default (issue #939):
     /// the prior `.and_then(|s| s.parse().ok()).unwrap_or(DEFAULT)` chain
@@ -2809,6 +2815,13 @@ mod imp {
         // runs one generation at a time.
         let max_pending: usize = parse_max_pending(&args)?;
 
+        // issue #1336: eagerly load vision weights at startup instead of on
+        // the first image request. Off by default -- lazy loading keeps
+        // text-only startup time and resident memory unchanged; see
+        // `lattice/main.rs`'s `--preload-vision` help text for the full
+        // startup-time/memory tradeoff this trades away.
+        let preload_vision = parse_flag(&args, "--preload-vision");
+
         eprintln!(
             "[lattice_serve] loading model from {} ({}) ...",
             model_dir.display(),
@@ -2828,7 +2841,16 @@ mod imp {
         let tokenizer_path_for_vocab = tokenizer_path.clone();
         let vision_config = Qwen35Config::from_model_dir(&model_dir)
             .map_err(|e| format!("config.json load failed: {e}"))?;
-        let vision_runtime = VisionRuntime::from_model_config(model_dir.clone(), &vision_config);
+        let mut vision_runtime =
+            VisionRuntime::from_model_config(model_dir.clone(), &vision_config);
+        if preload_vision {
+            if let Err(err) = vision_runtime.preload() {
+                eprintln!(
+                    "[lattice_serve] WARNING: --preload-vision failed, falling back to lazy \
+                     vision loading: {err}"
+                );
+            }
+        }
         let (
             owner,
             jobs,

--- a/crates/inference/src/bin/lattice_serve.rs
+++ b/crates/inference/src/bin/lattice_serve.rs
@@ -2843,13 +2843,11 @@ mod imp {
             .map_err(|e| format!("config.json load failed: {e}"))?;
         let mut vision_runtime =
             VisionRuntime::from_model_config(model_dir.clone(), &vision_config);
-        if preload_vision {
-            if let Err(err) = vision_runtime.preload() {
-                eprintln!(
-                    "[lattice_serve] WARNING: --preload-vision failed, falling back to lazy \
+        if preload_vision && let Err(err) = vision_runtime.preload() {
+            eprintln!(
+                "[lattice_serve] WARNING: --preload-vision failed, falling back to lazy \
                      vision loading: {err}"
-                );
-            }
+            );
         }
         let (
             owner,

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -5469,6 +5469,7 @@ mod inner {
                 position,
                 capture_hidden,
                 false,
+                true,
                 GdnStateTrafficScope::Decode,
                 None,
                 None,
@@ -5495,6 +5496,7 @@ mod inner {
                 position,
                 capture_hidden,
                 false,
+                true,
                 scope,
                 None,
                 None,
@@ -5527,6 +5529,7 @@ mod inner {
                 position,
                 false,
                 false,
+                true,
                 GdnStateTrafficScope::Decode,
                 Some(embedding),
                 None,
@@ -5541,11 +5544,18 @@ mod inner {
         /// `forward_step_inner_impl`'s `mrope_cos_sin` doc). Used for image-pad
         /// prefill positions, where `injected_embedding` and `mrope_cos_sin` are
         /// both `Some`.
+        ///
+        /// `emit_head` gates the terminal RMSNorm + lm_head dispatch, same
+        /// contract as `forward_step_inner_impl`'s parameter of the same name —
+        /// pass `false` for a multimodal prefill position whose logits will
+        /// never be sampled (KV/GDN state still advances); pass `true` for every
+        /// decode step and for the prompt's final prefill position.
         fn forward_step_injected_mrope(
             &mut self,
             embedding: &[f32],
             position: usize,
             mrope_cos_sin: Option<(&[f32], &[f32])>,
+            emit_head: bool,
             signpost_scope: crate::forward::signpost::Scope,
         ) -> Vec<f32> {
             self.cross_turn_prefix_cache.clear();
@@ -5554,6 +5564,7 @@ mod inner {
                 position,
                 false,
                 false,
+                emit_head,
                 GdnStateTrafficScope::Decode,
                 Some(embedding),
                 mrope_cos_sin,
@@ -5568,11 +5579,14 @@ mod inner {
         /// vision delimiters keep the normal embedding lookup, but still rotate
         /// with the 3-axis table once an image has shifted the position
         /// coordinate) and for every decode step after a multimodal prefill.
+        ///
+        /// `emit_head`: see [`Self::forward_step_injected_mrope`]'s doc.
         fn forward_step_mrope(
             &mut self,
             token_id: u32,
             position: usize,
             mrope_cos_sin: Option<(&[f32], &[f32])>,
+            emit_head: bool,
             signpost_scope: crate::forward::signpost::Scope,
         ) -> Vec<f32> {
             self.cross_turn_prefix_cache.clear();
@@ -5581,6 +5595,7 @@ mod inner {
                 position,
                 false,
                 false,
+                emit_head,
                 GdnStateTrafficScope::Decode,
                 None,
                 mrope_cos_sin,
@@ -5595,6 +5610,15 @@ mod inner {
         /// row for every full-attention layer in this step — mirrors
         /// `cpu_f16::full_attention_step_f16`'s `mrope_cos_sin` parameter. GDN
         /// layers never consume RoPE and are unaffected either way.
+        ///
+        /// `emit_head`, when `false`, skips the terminal RMSNorm + lm_head dispatch
+        /// (`encode_final_head`) and its GPU readback entirely — every layer still
+        /// runs, so the KV cache and GDN recurrent state are fully advanced, but
+        /// `logits` comes back empty (issue #1336: a multimodal prefill position
+        /// whose logits are never sampled has no reason to pay for the vocabulary
+        /// projection). Forced back to `true` whenever `capture_hidden` or an
+        /// active MTP session needs the pre-final hidden state this step, so a
+        /// caller cannot accidentally starve MTP capture by passing `false`.
         #[allow(clippy::too_many_arguments)]
         fn forward_step_inner_impl(
             &mut self,
@@ -5602,6 +5626,7 @@ mod inner {
             position: usize,
             capture_hidden: bool,
             skip_logits_readback: bool,
+            emit_head: bool,
             _traffic_scope: GdnStateTrafficScope,
             injected_embedding: Option<&[f32]>,
             mrope_cos_sin: Option<(&[f32], &[f32])>,
@@ -5613,6 +5638,13 @@ mod inner {
             );
             let cfg = self.engine.config.clone();
             let hidden = cfg.hidden_size;
+
+            // A caller that wants pre-final hidden capture (MTP) still needs the
+            // terminal RMSNorm dispatched even if it passed `emit_head=false`
+            // (only the multimodal prefill loop does today, and never with MTP
+            // active) — this keeps the flag safe by construction rather than by
+            // caller discipline.
+            let run_head = emit_head || capture_hidden || self.session.mtp.is_some();
 
             // Build the single-token M-RoPE cos/sin buffers once for this step (all
             // six GQA layers rotate with the same per-token row); `None` keeps every
@@ -5855,8 +5887,11 @@ mod inner {
                     &*(self.engine.queue.new_command_buffer() as *const metal::CommandBufferRef)
                 };
                 let head_enc = head_cmd.new_compute_command_encoder();
-                let topk_which_inner =
-                    self.encode_final_head(head_enc, &cfg, capture_hidden, &mut prof, profiling);
+                let topk_which_inner = if run_head {
+                    self.encode_final_head(head_enc, &cfg, capture_hidden, &mut prof, profiling)
+                } else {
+                    None
+                };
                 head_enc.end_encoding();
                 let t_gpu = std::time::Instant::now();
                 {
@@ -5957,7 +5992,7 @@ mod inner {
                     Vec::new()
                 };
 
-                let logits = if skip_logits_readback {
+                let logits = if !run_head || skip_logits_readback {
                     vec![]
                 } else if let Some(which) = topk_which_inner {
                     let _signpost_host_read = crate::forward::signpost::interval_in(
@@ -6038,8 +6073,11 @@ mod inner {
                 }
             } // end layer loop
 
-            let topk_which =
-                self.encode_final_head(enc, &cfg, capture_hidden, &mut prof, profiling);
+            let topk_which = if run_head {
+                self.encode_final_head(enc, &cfg, capture_hidden, &mut prof, profiling)
+            } else {
+                None
+            };
 
             // Single submit for entire forward pass + optional top-k.
             enc.end_encoding();
@@ -6124,7 +6162,7 @@ mod inner {
                 Vec::new()
             };
 
-            let logits = if skip_logits_readback {
+            let logits = if !run_head || skip_logits_readback {
                 vec![]
             } else if let Some(which) = topk_which {
                 // Compact path: read k*(f32+u32)=k*8 bytes instead of vocab*4 bytes.
@@ -6356,6 +6394,7 @@ mod inner {
                 token_id,
                 position,
                 false,
+                true,
                 true,
                 GdnStateTrafficScope::Decode,
                 None,
@@ -9177,6 +9216,7 @@ mod inner {
             // identical to the pre-MP3 text-only route.
             let mut visual_row = 0usize;
             let mut last_logits = Vec::new();
+            let last_prefill_pos = prompt_len - 1;
             for (pos, &token_id) in prompt_ids.iter().enumerate() {
                 if Self::multimodal_cancel_requested(&mut should_cancel) {
                     return Ok(Self::cancelled_multimodal_output(prompt_len));
@@ -9186,6 +9226,10 @@ mod inner {
                 } else {
                     None
                 };
+                // issue #1336: only the prompt's final position is ever sampled —
+                // every earlier position still advances KV/GDN state but skips the
+                // terminal RMSNorm/lm_head/vocab readback (`emit_head=false`).
+                let emit_head = pos == last_prefill_pos;
                 if has_image && token_id == request.image_token_id {
                     let start = visual_row * request.decoder_hidden_size;
                     let end = start + request.decoder_hidden_size;
@@ -9203,6 +9247,7 @@ mod inner {
                         row,
                         pos,
                         cos_sin,
+                        emit_head,
                         crate::forward::signpost::Scope::NotDecode,
                     );
                 } else {
@@ -9210,6 +9255,7 @@ mod inner {
                         token_id,
                         pos,
                         cos_sin,
+                        emit_head,
                         crate::forward::signpost::Scope::NotDecode,
                     );
                 }
@@ -9301,6 +9347,7 @@ mod inner {
                     last_token,
                     physical_pos,
                     mrope_cos_sin,
+                    true,
                     crate::forward::signpost::Scope::Decode,
                 );
                 if let Some(probe) = decode_logits_probe.as_deref_mut() {
@@ -23692,6 +23739,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     0,
                     false,
                     false,
+                    true,
                     GdnStateTrafficScope::Decode,
                     Some(&row),
                     None,
@@ -23707,6 +23755,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     0,
                     false,
                     false,
+                    true,
                     GdnStateTrafficScope::Decode,
                     Some(&row),
                     None,
@@ -23823,6 +23872,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 &row,
                 2,
                 Some((&cos_a, &sin_a)),
+                true,
                 crate::forward::signpost::Scope::NotDecode,
             );
             prime(&mut state);
@@ -23830,6 +23880,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 &row,
                 2,
                 Some((&cos_b, &sin_b)),
+                true,
                 crate::forward::signpost::Scope::NotDecode,
             );
 
@@ -23897,6 +23948,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                         row,
                         pos,
                         cos_sin,
+                        true,
                         crate::forward::signpost::Scope::NotDecode,
                     );
                 } else {
@@ -23904,6 +23956,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                         token_id,
                         pos,
                         cos_sin,
+                        true,
                         crate::forward::signpost::Scope::NotDecode,
                     );
                 }
@@ -23940,6 +23993,279 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                  fallback — forcing the 1-D path produced indistinguishable final-prefill \
                  logits (max_abs_diff={max_abs_diff})"
             );
+        }
+
+        /// Issue #1336: mechanism-level proof that `emit_head=false` skips the
+        /// actual terminal RMSNorm + lm_head GPU dispatch, not merely its CPU
+        /// readback. Poisons the shared logits buffer with a sentinel pattern
+        /// before an `emit_head=false` step and asserts it is UNCHANGED
+        /// afterward — the only way the sentinel survives is if
+        /// `encode_final_head` (which writes this buffer) never ran.
+        ///
+        /// This is the must-fail-arm control the equivalence test below
+        /// cannot provide on its own: both of that test's arms pass
+        /// `emit_head=true` at the position they compare, so an
+        /// implementation that ignores the flag and always dispatches the
+        /// head would still pass it trivially. Here, `emit_head=true` is the
+        /// positive control (must overwrite the sentinel) and `emit_head=
+        /// false` is the subject (must not).
+        ///
+        /// Mutation-predicted: reverting `run_head`'s gating of
+        /// `self.encode_final_head(...)` in `forward_step_inner_impl` back to
+        /// an unconditional call reddens the `emit_head=false` assertion
+        /// below (the sentinel gets overwritten by the real lm_head GEMV
+        /// every time, regardless of the flag). Verified in REPORT.md.
+        #[test]
+        fn forward_step_mrope_emit_head_false_skips_terminal_head_dispatch() {
+            let Some(model) = require_metal_and_real_checkpoint_or_skip(
+                "forward_step_mrope_emit_head_false_skips_terminal_head_dispatch",
+            ) else {
+                return;
+            };
+            let _guard = gpu_test_lock();
+
+            let cfg = model.config().clone();
+            let probe_len = cfg.vocab_size.min(64);
+            let sentinel: f32 = -12345.6789;
+            let mut state = MetalQwen35State::new(model.weights(), model.config(), 128)
+                .expect("real-checkpoint state");
+
+            // SAFETY (both closures): `activations.logits` is StorageModeShared;
+            // no GPU work is in flight between test steps (each
+            // `forward_step_mrope` call waits for its own command buffer
+            // before returning), and `probe_len <= vocab_size`.
+            let poison = |state: &MetalQwen35State| unsafe {
+                let ptr = state.session.activations.logits.contents() as *mut f32;
+                for i in 0..probe_len {
+                    *ptr.add(i) = sentinel;
+                }
+            };
+            let read_probe = |state: &MetalQwen35State| -> Vec<f32> {
+                unsafe {
+                    std::slice::from_raw_parts(
+                        state.session.activations.logits.contents() as *const f32,
+                        probe_len,
+                    )
+                    .to_vec()
+                }
+            };
+
+            // Control: emit_head=true must overwrite the poison.
+            state.reset_state();
+            poison(&state);
+            let control_logits = state.forward_step_mrope(
+                7,
+                0,
+                None,
+                true,
+                crate::forward::signpost::Scope::NotDecode,
+            );
+            assert!(
+                !control_logits.is_empty(),
+                "emit_head=true must return full vocab logits"
+            );
+            let after_true = read_probe(&state);
+            assert!(
+                after_true.iter().any(|&v| v != sentinel),
+                "control failed: emit_head=true must overwrite the poisoned logits buffer via \
+                 the real lm_head dispatch — if this fails, the poison/readback mechanism \
+                 itself is broken and the subject assertion below is meaningless"
+            );
+
+            // Subject: emit_head=false must leave the poison untouched.
+            state.reset_state();
+            poison(&state);
+            let subject_logits = state.forward_step_mrope(
+                7,
+                0,
+                None,
+                false,
+                crate::forward::signpost::Scope::NotDecode,
+            );
+            assert!(
+                subject_logits.is_empty(),
+                "emit_head=false must return no logits: nothing was computed this step"
+            );
+            let after_false = read_probe(&state);
+            assert_eq!(
+                after_false,
+                vec![sentinel; probe_len],
+                "emit_head=false must skip the terminal RMSNorm + lm_head dispatch entirely — \
+                 the logits buffer must remain untouched, not merely unread"
+            );
+        }
+
+        /// Issue #1336: `emit_head=false` on a non-final multimodal prefill
+        /// position must not change what that position contributes to the
+        /// residual stream, KV cache, or GDN recurrent state — only the
+        /// terminal RMSNorm/lm_head/vocab readback it skips. Runs the same
+        /// `vision_gate_fixture` prefill twice: once with `emit_head=true` at
+        /// every position (the "always-emitting reference path" the issue
+        /// calls out), once with `emit_head=false` at every position except
+        /// the last (mirrors `generate_multimodal_vision_impl`'s production
+        /// loop). Compares:
+        ///  - final-position logits: bit-identical
+        ///  - GDN recurrent state (every linear layer's conv + S-matrix
+        ///    buffers, via `MtpTargetVerifier::snapshot_gdn_states`):
+        ///    bit-identical
+        ///  - KV cache (every full-attention layer's written prefix):
+        ///    byte-identical
+        ///  - a subsequent decode step off each final state: bit-identical
+        ///    logits — the exact consumer a real state divergence would
+        ///    reach.
+        ///
+        /// This test alone cannot catch an `emit_head` no-op that always
+        /// dispatches the head (both arms compare identically in that case,
+        /// trivially) — that failure mode is covered by
+        /// `forward_step_mrope_emit_head_false_skips_terminal_head_dispatch`
+        /// above. Together they prove both halves the issue asks for: the
+        /// skip is real (mechanism test) and it is safe (this test).
+        #[test]
+        fn generate_multimodal_vision_emit_head_skip_matches_always_emit_reference() {
+            let Some(model) = require_metal_and_real_checkpoint_or_skip(
+                "generate_multimodal_vision_emit_head_skip_matches_always_emit_reference",
+            ) else {
+                return;
+            };
+            let _guard = gpu_test_lock();
+            use crate::speculative::MtpTargetVerifier as _;
+
+            let cfg = model.config().clone();
+            let request = vision_gate_fixture(&cfg, 0.02);
+            let (_positions, tables) = request
+                .build_mrope_tables(&cfg)
+                .expect("fixture request builds M-RoPE tables");
+            let prompt_len = request.input_ids.len();
+
+            let run_prefill = |always_emit: bool| -> (Vec<f32>, MetalQwen35State) {
+                let mut state = MetalQwen35State::new(model.weights(), model.config(), 128)
+                    .expect("real-checkpoint state");
+                state.reset_state();
+                let mut visual_row = 0usize;
+                let mut last_logits = Vec::new();
+                for (pos, &token_id) in request.input_ids.iter().enumerate() {
+                    let cos_sin = Some((tables.cos[pos].as_slice(), tables.sin[pos].as_slice()));
+                    let emit_head = always_emit || pos + 1 == prompt_len;
+                    if token_id == request.image_token_id {
+                        let start = visual_row * request.decoder_hidden_size;
+                        let end = start + request.decoder_hidden_size;
+                        let row = &request.post_merger_rows[start..end];
+                        visual_row += 1;
+                        last_logits = state.forward_step_injected_mrope(
+                            row,
+                            pos,
+                            cos_sin,
+                            emit_head,
+                            crate::forward::signpost::Scope::NotDecode,
+                        );
+                    } else {
+                        last_logits = state.forward_step_mrope(
+                            token_id,
+                            pos,
+                            cos_sin,
+                            emit_head,
+                            crate::forward::signpost::Scope::NotDecode,
+                        );
+                    }
+                }
+                (last_logits, state)
+            };
+
+            let (logits_reference, mut state_reference) = run_prefill(true);
+            let (logits_optimized, mut state_optimized) = run_prefill(false);
+
+            // Final-logit equivalence: bit-identical.
+            assert!(
+                !logits_reference.is_empty(),
+                "fixture's final position must produce real vocab logits"
+            );
+            assert_eq!(logits_reference.len(), logits_optimized.len());
+            for (i, (a, b)) in logits_reference.iter().zip(&logits_optimized).enumerate() {
+                assert_eq!(
+                    a.to_bits(),
+                    b.to_bits(),
+                    "final-position logit {i} diverged between the always-emit reference and \
+                     the emit_head-skip optimization ({a} vs {b})"
+                );
+            }
+
+            // GDN recurrent-state equivalence.
+            let gdn_reference = state_reference.snapshot_gdn_states();
+            let gdn_optimized = state_optimized.snapshot_gdn_states();
+            assert_eq!(
+                gdn_reference, gdn_optimized,
+                "GDN recurrent state (conv + S-matrix buffers) diverged between the \
+                 always-emit reference and the emit_head-skip optimization"
+            );
+
+            // KV-cache equivalence: every full-attention layer's written prefix.
+            let kv_row_bytes = if state_reference.use_kv_f16 {
+                2usize
+            } else {
+                4usize
+            };
+            let used_bytes = prompt_len * cfg.full_kv_dim() * kv_row_bytes;
+            let num_full_layers = state_reference.session.kv_cache.k_bufs.len();
+            for i in 0..num_full_layers {
+                // SAFETY: both buffers are StorageModeShared; every command
+                // buffer in `run_prefill`'s loop above was waited on before
+                // the next step began (see `forward_step_inner_impl`).
+                unsafe {
+                    let k_ref = std::slice::from_raw_parts(
+                        state_reference.session.kv_cache.k_bufs[i].contents() as *const u8,
+                        used_bytes,
+                    );
+                    let k_opt = std::slice::from_raw_parts(
+                        state_optimized.session.kv_cache.k_bufs[i].contents() as *const u8,
+                        used_bytes,
+                    );
+                    assert_eq!(k_ref, k_opt, "K cache layer {i} diverged");
+                    let v_ref = std::slice::from_raw_parts(
+                        state_reference.session.kv_cache.v_bufs[i].contents() as *const u8,
+                        used_bytes,
+                    );
+                    let v_opt = std::slice::from_raw_parts(
+                        state_optimized.session.kv_cache.v_bufs[i].contents() as *const u8,
+                        used_bytes,
+                    );
+                    assert_eq!(v_ref, v_opt, "V cache layer {i} diverged");
+                }
+            }
+
+            // Decode continuation: the exact consumer "state equivalence"
+            // exists for — a subsequent decode step must sample identically
+            // off either state.
+            let physical_pos_ref = state_reference.session.kv_cache.seq_len;
+            let physical_pos_opt = state_optimized.session.kv_cache.seq_len;
+            assert_eq!(
+                physical_pos_ref, physical_pos_opt,
+                "KV cursor position diverged between the two prefill arms"
+            );
+            let decode_token = 5u32;
+            let decode_logits_ref = state_reference.forward_step_mrope(
+                decode_token,
+                physical_pos_ref,
+                None,
+                true,
+                crate::forward::signpost::Scope::Decode,
+            );
+            let decode_logits_opt = state_optimized.forward_step_mrope(
+                decode_token,
+                physical_pos_opt,
+                None,
+                true,
+                crate::forward::signpost::Scope::Decode,
+            );
+            assert_eq!(decode_logits_ref.len(), decode_logits_opt.len());
+            for (i, (a, b)) in decode_logits_ref.iter().zip(&decode_logits_opt).enumerate() {
+                assert_eq!(
+                    a.to_bits(),
+                    b.to_bits(),
+                    "post-prefill decode-step logit {i} diverged — KV/GDN state after the \
+                     emit_head-skip optimization is not equivalent to the always-emit \
+                     reference ({a} vs {b})"
+                );
+            }
         }
 
         /// Qwen3.5 vision (ADR-069 Metal MP3 gate, test 3/4 — text-only
@@ -24054,6 +24380,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     token_id,
                     pos,
                     None,
+                    true,
                     crate::forward::signpost::Scope::NotDecode,
                 );
                 let b = state_plain_bits.forward_step(token_id, pos);
@@ -24074,6 +24401,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     next_id,
                     physical_pos,
                     None,
+                    true,
                     crate::forward::signpost::Scope::NotDecode,
                 );
                 let b = state_plain_bits.forward_step(next_id, physical_pos);
@@ -24230,6 +24558,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                             row,
                             pos,
                             cos_sin,
+                            true,
                             crate::forward::signpost::Scope::NotDecode,
                         );
                     } else {
@@ -24237,6 +24566,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                             token_id,
                             pos,
                             cos_sin,
+                            true,
                             crate::forward::signpost::Scope::NotDecode,
                         );
                     }
@@ -24268,6 +24598,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                     first_id,
                     physical_pos,
                     cos_sin,
+                    true,
                     crate::forward::signpost::Scope::NotDecode,
                 )
             };

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -24026,7 +24026,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
 
             let cfg = model.config().clone();
             let probe_len = cfg.vocab_size.min(64);
-            let sentinel: f32 = -12345.6789;
+            let sentinel: f32 = -12_345.679;
             let mut state = MetalQwen35State::new(model.weights(), model.config(), 128)
                 .expect("real-checkpoint state");
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -36978,6 +36978,129 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             Ok(())
         }
 
+        /// Issue #1336 harness support (`bin/bench_vision_prefill_ab.rs`): a
+        /// checkpoint-shaped multimodal-prefill fixture sized to a
+        /// caller-chosen visual-row count, generalizing the
+        /// `#[cfg(test)]`-only `vision_gate_fixture` (fixed at 4 rows,
+        /// adequate for a correctness gate but too short for the
+        /// terminal-head-skip saving to be a measurable fraction of total
+        /// prefill time). `t=1`, a square merged grid with
+        /// `side_merged = ceil(sqrt(num_visual_rows_target))`, so the actual
+        /// row count returned may exceed the target slightly (rounded up to
+        /// the next square); the harness reports the actual count.
+        ///
+        /// Per-lane-varying (not per-row-constant) synthetic content, same
+        /// reasoning as `vision_gate_fixture`: a constant vector is
+        /// invariant under Qwen3.5's RMSNorm one layer in. Real pixel
+        /// content is not required here — the emit_head optimization gates
+        /// the decoder's terminal RMSNorm + lm_head dispatch only, which is
+        /// insensitive to what values the injected embedding carries, only
+        /// to its shape (see this bin's module doc for the corollary: this
+        /// harness does not include ViT/merger cost).
+        pub fn vision_prefill_fixture(
+            cfg: &Qwen35Config,
+            num_visual_rows_target: usize,
+            seed: f32,
+        ) -> Result<crate::vision::multimodal::Qwen35VisionRequest, String> {
+            let vision_cfg = cfg
+                .vision_config
+                .as_ref()
+                .ok_or_else(|| "checkpoint carries no vision_config".to_string())?;
+            let image_token_id = cfg
+                .image_token_id
+                .ok_or_else(|| "checkpoint carries no image_token_id".to_string())?;
+            let merge = vision_cfg.spatial_merge_size;
+            if merge == 0 {
+                return Err("checkpoint vision_config.spatial_merge_size is 0".to_string());
+            }
+            let rows_target = num_visual_rows_target.max(1);
+            let side_merged = (rows_target as f64).sqrt().ceil() as usize;
+            let side_merged = side_merged.max(1);
+            let grid = crate::vision::qwen35_vit::GridThw {
+                t: 1,
+                h: side_merged * merge,
+                w: side_merged * merge,
+            };
+            let num_rows = (grid.t * grid.h * grid.w) / (merge * merge);
+
+            let mut input_ids = vec![10u32, 11];
+            input_ids.extend(std::iter::repeat_n(image_token_id, num_rows));
+            input_ids.push(12);
+
+            let mut post_merger_rows = vec![0.0f32; num_rows * cfg.hidden_size];
+            for (i, v) in post_merger_rows.iter_mut().enumerate() {
+                *v = seed + 0.01 * ((i % 97) as f32 - 48.0);
+            }
+
+            Ok(crate::vision::multimodal::Qwen35VisionRequest {
+                input_ids,
+                image_grids: vec![grid],
+                post_merger_rows,
+                image_token_id,
+                spatial_merge_size: merge,
+                decoder_hidden_size: cfg.hidden_size,
+            })
+        }
+
+        /// Issue #1336 harness support: runs one multimodal prefill over
+        /// `request`, selecting `emit_head` per position exactly the way
+        /// `generate_multimodal_vision_impl` does in production
+        /// (`pos == last_prefill_pos`) when `always_emit_head=false`, or
+        /// forcing it `true` at every position (the pre-#1336 baseline
+        /// shape) when `always_emit_head=true`. Both arms call the same
+        /// `forward_step_mrope`/`forward_step_injected_mrope` functions the
+        /// production path calls — same code, same binary, differing only
+        /// in this flag — mirroring
+        /// `generate_multimodal_vision_emit_head_skip_matches_always_emit_reference`'s
+        /// `run_prefill` closure.
+        ///
+        /// Returns nothing: like [`forward_prefill_production_chunk`], every
+        /// `forward_step_mrope`/`forward_step_injected_mrope` call already
+        /// waits for its own command buffer before returning, so the caller
+        /// times the call from outside with a plain CPU `Instant` — no
+        /// internal instrumentation is needed or added. `state` must already
+        /// be freshly reset (`state.reset_state()`) by the caller.
+        pub fn run_multimodal_prefill(
+            state: &mut MetalQwen35State,
+            request: &crate::vision::multimodal::Qwen35VisionRequest,
+            cfg: &Qwen35Config,
+            always_emit_head: bool,
+        ) -> Result<Vec<f32>, String> {
+            let (_positions, tables) = request
+                .build_mrope_tables(cfg)
+                .map_err(|e| format!("build_mrope_tables: {e}"))?;
+            let prompt_len = request.input_ids.len();
+
+            let mut visual_row = 0usize;
+            let mut last_logits = Vec::new();
+            for (pos, &token_id) in request.input_ids.iter().enumerate() {
+                let cos_sin = Some((tables.cos[pos].as_slice(), tables.sin[pos].as_slice()));
+                let emit_head = always_emit_head || pos + 1 == prompt_len;
+                if token_id == request.image_token_id {
+                    let row_start = visual_row * request.decoder_hidden_size;
+                    let row_end = row_start + request.decoder_hidden_size;
+                    let row = &request.post_merger_rows[row_start..row_end];
+                    visual_row += 1;
+                    last_logits = state.forward_step_injected_mrope(
+                        row,
+                        pos,
+                        cos_sin,
+                        emit_head,
+                        crate::forward::signpost::Scope::NotDecode,
+                    );
+                } else {
+                    last_logits = state.forward_step_mrope(
+                        token_id,
+                        pos,
+                        cos_sin,
+                        emit_head,
+                        crate::forward::signpost::Scope::NotDecode,
+                    );
+                }
+            }
+            Ok(last_logits)
+        }
+
         #[cfg(test)]
         mod tests {
             use super::first_out_of_vocab;
@@ -37137,152 +37260,6 @@ mod public_scheduling_entry_point_tests {
                 item(real, declaration).contains(preflight),
                 "{declaration} must route through {preflight}"
             );
-        }
-
-        /// Issue #1336 harness support (`bin/bench_vision_prefill_ab.rs`): a
-        /// checkpoint-shaped multimodal-prefill fixture sized to a
-        /// caller-chosen visual-row count, generalizing the
-        /// `#[cfg(test)]`-only `vision_gate_fixture` (fixed at 4 rows,
-        /// adequate for a correctness gate but too short for the
-        /// terminal-head-skip saving to be a measurable fraction of total
-        /// prefill time). `t=1`, a square merged grid with
-        /// `side_merged = ceil(sqrt(num_visual_rows_target))`, so the actual
-        /// row count returned may exceed the target slightly (rounded up to
-        /// the next square); the harness reports the actual count.
-        ///
-        /// Per-lane-varying (not per-row-constant) synthetic content, same
-        /// reasoning as `vision_gate_fixture`: a constant vector is
-        /// invariant under Qwen3.5's RMSNorm one layer in. Real pixel
-        /// content is not required here — the emit_head optimization gates
-        /// the decoder's terminal RMSNorm + lm_head dispatch only, which is
-        /// insensitive to what values the injected embedding carries, only
-        /// to its shape (see this bin's module doc for the corollary: this
-        /// harness does not include ViT/merger cost).
-        pub fn vision_prefill_fixture(
-            cfg: &Qwen35Config,
-            num_visual_rows_target: usize,
-            seed: f32,
-        ) -> Result<crate::vision::multimodal::Qwen35VisionRequest, String> {
-            let vision_cfg = cfg
-                .vision_config
-                .as_ref()
-                .ok_or_else(|| "checkpoint carries no vision_config".to_string())?;
-            let image_token_id = cfg
-                .image_token_id
-                .ok_or_else(|| "checkpoint carries no image_token_id".to_string())?;
-            let merge = vision_cfg.spatial_merge_size;
-            if merge == 0 {
-                return Err("checkpoint vision_config.spatial_merge_size is 0".to_string());
-            }
-            let rows_target = num_visual_rows_target.max(1);
-            let side_merged = (rows_target as f64).sqrt().ceil() as usize;
-            let side_merged = side_merged.max(1);
-            let grid = crate::vision::qwen35_vit::GridThw {
-                t: 1,
-                h: side_merged * merge,
-                w: side_merged * merge,
-            };
-            let num_rows = (grid.t * grid.h * grid.w) / (merge * merge);
-
-            let mut input_ids = vec![10u32, 11];
-            input_ids.extend(std::iter::repeat_n(image_token_id, num_rows));
-            input_ids.push(12);
-
-            let mut post_merger_rows = vec![0.0f32; num_rows * cfg.hidden_size];
-            for (i, v) in post_merger_rows.iter_mut().enumerate() {
-                *v = seed + 0.01 * ((i % 97) as f32 - 48.0);
-            }
-
-            Ok(crate::vision::multimodal::Qwen35VisionRequest {
-                input_ids,
-                image_grids: vec![grid],
-                post_merger_rows,
-                image_token_id,
-                spatial_merge_size: merge,
-                decoder_hidden_size: cfg.hidden_size,
-            })
-        }
-
-        /// Issue #1336 harness support: runs one multimodal prefill over
-        /// `request`, selecting `emit_head` per position exactly the way
-        /// `generate_multimodal_vision_impl` does in production
-        /// (`pos == last_prefill_pos`) when `always_emit_head=false`, or
-        /// forcing it `true` at every position (the pre-#1336 baseline
-        /// shape) when `always_emit_head=true`. Both arms call the same
-        /// `forward_step_mrope`/`forward_step_injected_mrope` functions the
-        /// production path calls — same code, same binary, differing only
-        /// in this flag — mirroring
-        /// `generate_multimodal_vision_emit_head_skip_matches_always_emit_reference`'s
-        /// `run_prefill` closure.
-        ///
-        /// Returns nothing: like [`forward_prefill_production_chunk`], every
-        /// `forward_step_mrope`/`forward_step_injected_mrope` call already
-        /// waits for its own command buffer before returning, so the caller
-        /// times the call from outside with a plain CPU `Instant` — no
-        /// internal instrumentation is needed or added. `state` must already
-        /// be freshly reset (`state.reset_state()`) by the caller.
-        pub fn run_multimodal_prefill(
-            state: &mut MetalQwen35State,
-            request: &crate::vision::multimodal::Qwen35VisionRequest,
-            cfg: &Qwen35Config,
-            always_emit_head: bool,
-        ) -> Result<Vec<f32>, String> {
-            let (_positions, tables) = request
-                .build_mrope_tables(cfg)
-                .map_err(|e| format!("build_mrope_tables: {e}"))?;
-            let prompt_len = request.input_ids.len();
-
-            let mut visual_row = 0usize;
-            let mut last_logits = Vec::new();
-            for (pos, &token_id) in request.input_ids.iter().enumerate() {
-                let cos_sin = Some((tables.cos[pos].as_slice(), tables.sin[pos].as_slice()));
-                let emit_head = always_emit_head || pos + 1 == prompt_len;
-                if token_id == request.image_token_id {
-                    let row_start = visual_row * request.decoder_hidden_size;
-                    let row_end = row_start + request.decoder_hidden_size;
-                    let row = &request.post_merger_rows[row_start..row_end];
-                    visual_row += 1;
-                    last_logits = state.forward_step_injected_mrope(
-                        row,
-                        pos,
-                        cos_sin,
-                        emit_head,
-                        crate::forward::signpost::Scope::NotDecode,
-                    );
-                } else {
-                    last_logits = state.forward_step_mrope(
-                        token_id,
-                        pos,
-                        cos_sin,
-                        emit_head,
-                        crate::forward::signpost::Scope::NotDecode,
-                    );
-                }
-            }
-            Ok(last_logits)
-        }
-
-        #[cfg(test)]
-        mod tests {
-            use super::first_out_of_vocab;
-
-            #[test]
-            fn first_out_of_vocab_accepts_in_range() {
-                assert_eq!(first_out_of_vocab(&[0, 1, 99], 100), None);
-                assert_eq!(first_out_of_vocab(&[], 100), None);
-            }
-
-            #[test]
-            fn first_out_of_vocab_finds_first_offender() {
-                // Two offenders; the FIRST (index 1) must be reported.
-                assert_eq!(first_out_of_vocab(&[5, 200, 300], 100), Some((1, 200)));
-            }
-
-            #[test]
-            fn first_out_of_vocab_rejects_id_equal_to_vocab() {
-                // vocab_size itself is out of range (valid ids are 0..vocab_size).
-                assert_eq!(first_out_of_vocab(&[100], 100), Some((0, 100)));
-            }
         }
     }
 }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -35025,6 +35025,129 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             assert_token_ids_in_vocab(state, token_ids);
             let _ = state.forward_prefill_batched_chunk(token_ids, start_pos, true, false);
         }
+
+        /// Issue #1336 harness support (`bin/bench_vision_prefill_ab.rs`): a
+        /// checkpoint-shaped multimodal-prefill fixture sized to a
+        /// caller-chosen visual-row count, generalizing the
+        /// `#[cfg(test)]`-only `vision_gate_fixture` (fixed at 4 rows,
+        /// adequate for a correctness gate but too short for the
+        /// terminal-head-skip saving to be a measurable fraction of total
+        /// prefill time). `t=1`, a square merged grid with
+        /// `side_merged = ceil(sqrt(num_visual_rows_target))`, so the actual
+        /// row count returned may exceed the target slightly (rounded up to
+        /// the next square); the harness reports the actual count.
+        ///
+        /// Per-lane-varying (not per-row-constant) synthetic content, same
+        /// reasoning as `vision_gate_fixture`: a constant vector is
+        /// invariant under Qwen3.5's RMSNorm one layer in. Real pixel
+        /// content is not required here — the emit_head optimization gates
+        /// the decoder's terminal RMSNorm + lm_head dispatch only, which is
+        /// insensitive to what values the injected embedding carries, only
+        /// to its shape (see this bin's module doc for the corollary: this
+        /// harness does not include ViT/merger cost).
+        pub fn vision_prefill_fixture(
+            cfg: &Qwen35Config,
+            num_visual_rows_target: usize,
+            seed: f32,
+        ) -> Result<crate::vision::multimodal::Qwen35VisionRequest, String> {
+            let vision_cfg = cfg
+                .vision_config
+                .as_ref()
+                .ok_or_else(|| "checkpoint carries no vision_config".to_string())?;
+            let image_token_id = cfg
+                .image_token_id
+                .ok_or_else(|| "checkpoint carries no image_token_id".to_string())?;
+            let merge = vision_cfg.spatial_merge_size;
+            if merge == 0 {
+                return Err("checkpoint vision_config.spatial_merge_size is 0".to_string());
+            }
+            let rows_target = num_visual_rows_target.max(1);
+            let side_merged = (rows_target as f64).sqrt().ceil() as usize;
+            let side_merged = side_merged.max(1);
+            let grid = crate::vision::qwen35_vit::GridThw {
+                t: 1,
+                h: side_merged * merge,
+                w: side_merged * merge,
+            };
+            let num_rows = (grid.t * grid.h * grid.w) / (merge * merge);
+
+            let mut input_ids = vec![10u32, 11];
+            input_ids.extend(std::iter::repeat_n(image_token_id, num_rows));
+            input_ids.push(12);
+
+            let mut post_merger_rows = vec![0.0f32; num_rows * cfg.hidden_size];
+            for (i, v) in post_merger_rows.iter_mut().enumerate() {
+                *v = seed + 0.01 * ((i % 97) as f32 - 48.0);
+            }
+
+            Ok(crate::vision::multimodal::Qwen35VisionRequest {
+                input_ids,
+                image_grids: vec![grid],
+                post_merger_rows,
+                image_token_id,
+                spatial_merge_size: merge,
+                decoder_hidden_size: cfg.hidden_size,
+            })
+        }
+
+        /// Issue #1336 harness support: runs one multimodal prefill over
+        /// `request`, selecting `emit_head` per position exactly the way
+        /// `generate_multimodal_vision_impl` does in production
+        /// (`pos == last_prefill_pos`) when `always_emit_head=false`, or
+        /// forcing it `true` at every position (the pre-#1336 baseline
+        /// shape) when `always_emit_head=true`. Both arms call the same
+        /// `forward_step_mrope`/`forward_step_injected_mrope` functions the
+        /// production path calls — same code, same binary, differing only
+        /// in this flag — mirroring
+        /// `generate_multimodal_vision_emit_head_skip_matches_always_emit_reference`'s
+        /// `run_prefill` closure.
+        ///
+        /// Returns nothing: like [`forward_prefill_production_chunk`], every
+        /// `forward_step_mrope`/`forward_step_injected_mrope` call already
+        /// waits for its own command buffer before returning, so the caller
+        /// times the call from outside with a plain CPU `Instant` — no
+        /// internal instrumentation is needed or added. `state` must already
+        /// be freshly reset (`state.reset_state()`) by the caller.
+        pub fn run_multimodal_prefill(
+            state: &mut MetalQwen35State,
+            request: &crate::vision::multimodal::Qwen35VisionRequest,
+            cfg: &Qwen35Config,
+            always_emit_head: bool,
+        ) -> Result<Vec<f32>, String> {
+            let (_positions, tables) = request
+                .build_mrope_tables(cfg)
+                .map_err(|e| format!("build_mrope_tables: {e}"))?;
+            let prompt_len = request.input_ids.len();
+
+            let mut visual_row = 0usize;
+            let mut last_logits = Vec::new();
+            for (pos, &token_id) in request.input_ids.iter().enumerate() {
+                let cos_sin = Some((tables.cos[pos].as_slice(), tables.sin[pos].as_slice()));
+                let emit_head = always_emit_head || pos + 1 == prompt_len;
+                if token_id == request.image_token_id {
+                    let row_start = visual_row * request.decoder_hidden_size;
+                    let row_end = row_start + request.decoder_hidden_size;
+                    let row = &request.post_merger_rows[row_start..row_end];
+                    visual_row += 1;
+                    last_logits = state.forward_step_injected_mrope(
+                        row,
+                        pos,
+                        cos_sin,
+                        emit_head,
+                        crate::forward::signpost::Scope::NotDecode,
+                    );
+                } else {
+                    last_logits = state.forward_step_mrope(
+                        token_id,
+                        pos,
+                        cos_sin,
+                        emit_head,
+                        crate::forward::signpost::Scope::NotDecode,
+                    );
+                }
+            }
+            Ok(last_logits)
+        }
     }
 }
 

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -1620,6 +1620,17 @@ mod inner {
         pub(crate) compact_result: Vec<crate::sampling::Candidate>,
         // MTP per-session cache and activations (None if model has no MTP).
         pub(crate) mtp: Option<MetalMtpSession>,
+        /// True for the remainder of the current request once `generate()`'s
+        /// `use_mtp` (see [`super::mtp_route_active`]) commits to the MTP
+        /// greedy/verify path. Distinct from `mtp.is_some()`, which only
+        /// reports whether the checkpoint carries MTP weights: a checkpoint
+        /// can ship MTP weights while a specific request runs with MTP
+        /// disabled (`enable_mtp: Some(false)`), and pre-final-hidden-capture
+        /// gates must not treat that request as MTP-active just because the
+        /// weights happen to be resident (#1336 round 2). Reset to `false` by
+        /// `reset_state()`, which every generate entry point calls before
+        /// this flag is next read or set.
+        pub(crate) mtp_active: bool,
         pub(crate) gdn_checkpoints: Option<MetalGdnCheckpointPool>,
         pub(crate) last_pre_final_hidden: Vec<f32>,
         /// Raw (pre-final-RMSNorm) target hidden states captured by
@@ -3416,6 +3427,7 @@ mod inner {
                 compact_route: GpuTopkRoute::CpuFallback,
                 compact_result: Vec::new(),
                 mtp,
+                mtp_active: false,
                 gdn_checkpoints,
                 last_pre_final_hidden: vec![0.0f32; hidden],
                 mtp_prefill_hidden: Vec::new(),
@@ -5879,8 +5891,14 @@ mod inner {
             // terminal RMSNorm dispatched even if it passed `emit_head=false`
             // (only the multimodal prefill loop does today, and never with MTP
             // active) — this keeps the flag safe by construction rather than by
-            // caller discipline.
-            let run_head = emit_head || capture_hidden || self.session.mtp.is_some();
+            // caller discipline. `mtp_active` is this request's own commitment
+            // to the MTP path (set by `generate()`'s `use_mtp`, cleared by
+            // `reset_state()`), not `self.session.mtp.is_some()`: the latter
+            // reports only that the checkpoint carries MTP weights, which stays
+            // true even when this request runs with `enable_mtp: Some(false)`
+            // (#1336 round 2 — that combination must still honor
+            // `emit_head=false` for the multimodal prefill loop).
+            let run_head = emit_head || capture_hidden || self.session.mtp_active;
 
             // Build the single-token M-RoPE cos/sin buffers once for this step (all
             // six GQA layers rotate with the same per-token row); `None` keeps every
@@ -8687,6 +8705,12 @@ mod inner {
                 use_compact,
             );
             if use_mtp {
+                // This request has committed to the MTP path (#1336 round 2) —
+                // downstream pre-final-hidden-capture gates key off this, not
+                // off `self.session.mtp.is_some()` (which only reports whether
+                // the checkpoint carries MTP weights, not whether this request
+                // uses them).
+                self.session.mtp_active = true;
                 if use_compact {
                     self.session.compact_topk = 0;
                     self.session.compact_route = GpuTopkRoute::CpuFallback;
@@ -9703,6 +9727,10 @@ mod inner {
             if let Some(ref mut mtp) = self.session.mtp {
                 mtp.cache.reset();
             }
+            // A fresh request has not yet decided whether it will take the MTP
+            // greedy/verify path (#1336 round 2) — `generate()` sets this back
+            // to `true` itself once `use_mtp` commits.
+            self.session.mtp_active = false;
             self.session.mtp_prefill_hidden.clear();
             if let Some(ref mut pool) = self.session.gdn_checkpoints {
                 pool.active_base_seq_len = None;
@@ -12196,6 +12224,7 @@ mod inner {
                     compact_route: GpuTopkRoute::CpuFallback,
                     compact_result: Vec::new(),
                     mtp: mtp_session,
+                    mtp_active: false,
                     gdn_checkpoints,
                     last_pre_final_hidden: vec![0.0f32; hidden],
                     mtp_prefill_hidden: Vec::new(),
@@ -24422,6 +24451,121 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             );
         }
 
+        /// Issue #1336 round 2 (F1): `run_head` must key off THIS request's
+        /// own MTP activation (`session.mtp_active`), not off whether the
+        /// loaded checkpoint merely carries MTP weights
+        /// (`session.mtp.is_some()`). A checkpoint can ship MTP weights
+        /// while a specific request runs with MTP disabled
+        /// (`enable_mtp: Some(false)`, or simply a caller — like
+        /// `generate_multimodal_vision_impl`'s prefill loop — that never
+        /// takes `generate()`'s `use_mtp` branch at all); that combination
+        /// must still honor `emit_head=false`.
+        ///
+        /// Builds a session with MTP weights resident via the same
+        /// `metal_state_with_constant_zero_draft_mtp_for_test` fixture the
+        /// MTP-rollback tests above use (so `session.mtp.is_some() ==
+        /// true`), but drives `forward_step_mrope` directly — the same call
+        /// `generate_multimodal_vision_impl`'s prefill loop makes — without
+        /// ever calling `generate()`, so `session.mtp_active` stays at its
+        /// post-`reset_state()` default of `false`. This is exactly the
+        /// "MTP weights present, this request never activated MTP" case the
+        /// old `self.session.mtp.is_some()` gate could not distinguish from
+        /// "MTP weights present and this request is using them".
+        ///
+        /// Reuses `forward_step_mrope_emit_head_false_skips_terminal_head_dispatch`'s
+        /// poison/read_probe mechanism above: `emit_head=false` already
+        /// returns empty logits by contract whether or not the head actually
+        /// ran, so the only way to observe a stray dispatch is to poison the
+        /// shared logits buffer first and assert it survives untouched.
+        ///
+        /// Expected-redden check: before this fix, `run_head` computed
+        /// `emit_head || capture_hidden || self.session.mtp.is_some()`.
+        /// Reverting to that expression makes `run_head` evaluate to `true`
+        /// here purely from `session.mtp.is_some() == true` (both `emit_head`
+        /// and `capture_hidden` are `false`), so `encode_final_head` runs and
+        /// overwrites the sentinel — reddening only the final `assert_eq!`
+        /// below (the two `mtp_active` setup assertions above it stay green
+        /// either way, since they inspect the flag directly rather than
+        /// `run_head`'s output).
+        #[test]
+        fn forward_step_mrope_emit_head_false_skips_terminal_head_dispatch_with_mtp_weights_present_but_request_inactive()
+         {
+            let _gpu_guard = gpu_test_lock();
+            let Some(_) = Device::system_default() else {
+                return;
+            };
+
+            let (mut cfg, weights) = tiny_metal_qwen35_fixture();
+            cfg.mtp_num_hidden_layers = 1;
+            let mut state = metal_state_with_constant_zero_draft_mtp_for_test(&weights, &cfg);
+            assert!(
+                state.session.mtp.is_some(),
+                "fixture setup: this test requires MTP weights to be resident — otherwise it \
+                 cannot distinguish the fixed gate from the pre-fix one"
+            );
+            assert!(
+                !state.session.mtp_active,
+                "fixture setup: a freshly-constructed session must not report MTP as active \
+                 for the request merely because the checkpoint carries MTP weights"
+            );
+
+            let probe_len = cfg.vocab_size.min(64);
+            let sentinel: f32 = -12_345.679;
+
+            // SAFETY: same as `forward_step_mrope_emit_head_false_skips_terminal_head_dispatch`
+            // above — `activations.logits` is StorageModeShared, no GPU work is in
+            // flight between test steps, and probe_len <= vocab_size.
+            let poison = |state: &MetalQwen35State| unsafe {
+                let ptr = state.session.activations.logits.contents() as *mut f32;
+                for i in 0..probe_len {
+                    *ptr.add(i) = sentinel;
+                }
+            };
+            let read_probe = |state: &MetalQwen35State| -> Vec<f32> {
+                unsafe {
+                    std::slice::from_raw_parts(
+                        state.session.activations.logits.contents() as *const f32,
+                        probe_len,
+                    )
+                    .to_vec()
+                }
+            };
+
+            state.reset_state();
+            assert!(
+                state.session.mtp.is_some(),
+                "reset_state must not clear MTP weight residency"
+            );
+            assert!(
+                !state.session.mtp_active,
+                "reset_state must clear any stale per-request MTP activation from a prior call"
+            );
+            poison(&state);
+
+            let subject_logits = state.forward_step_mrope(
+                7,
+                0,
+                None,
+                false,
+                crate::forward::signpost::Scope::NotDecode,
+            );
+            assert!(
+                subject_logits.is_empty(),
+                "emit_head=false must return no logits regardless of whether MTP weights are \
+                 resident on the checkpoint"
+            );
+            let after_false = read_probe(&state);
+            assert_eq!(
+                after_false,
+                vec![sentinel; probe_len],
+                "emit_head=false must skip the terminal RMSNorm + lm_head dispatch even when \
+                 the checkpoint carries MTP weights and this request never activated MTP — \
+                 gating on `self.session.mtp.is_some()` instead of the request's own \
+                 `mtp_active` flag would dispatch the head here and overwrite the sentinel, \
+                 which is exactly the #1336-round-2 defeat this test guards against"
+            );
+        }
+
         /// Issue #1336: `emit_head=false` on a non-final multimodal prefill
         /// position must not change what that position contributes to the
         /// residual stream, KV cache, or GDN recurrent state — only the
@@ -34963,29 +35107,6 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             MetalQwen35State::supports_gdn_chunked_prefill(&state.engine.config)
         }
 
-        #[cfg(test)]
-        mod tests {
-            use super::first_out_of_vocab;
-
-            #[test]
-            fn first_out_of_vocab_accepts_in_range() {
-                assert_eq!(first_out_of_vocab(&[0, 1, 99], 100), None);
-                assert_eq!(first_out_of_vocab(&[], 100), None);
-            }
-
-            #[test]
-            fn first_out_of_vocab_finds_first_offender() {
-                // Two offenders; the FIRST (index 1) must be reported.
-                assert_eq!(first_out_of_vocab(&[5, 200, 300], 100), Some((1, 200)));
-            }
-
-            #[test]
-            fn first_out_of_vocab_rejects_id_equal_to_vocab() {
-                // vocab_size itself is out of range (valid ids are 0..vocab_size).
-                assert_eq!(first_out_of_vocab(&[100], 100), Some((0, 100)));
-            }
-        }
-
         /// The session's `max_prefill` (single-command-buffer chunk cap; 512 for all
         /// current configs, `max_cache_len.min(512)`) — the caller-side chunking loop
         /// for [`forward_prefill_gdn_isolated_chunk`] must split prompts on this
@@ -35147,6 +35268,29 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
                 }
             }
             Ok(last_logits)
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use super::first_out_of_vocab;
+
+            #[test]
+            fn first_out_of_vocab_accepts_in_range() {
+                assert_eq!(first_out_of_vocab(&[0, 1, 99], 100), None);
+                assert_eq!(first_out_of_vocab(&[], 100), None);
+            }
+
+            #[test]
+            fn first_out_of_vocab_finds_first_offender() {
+                // Two offenders; the FIRST (index 1) must be reported.
+                assert_eq!(first_out_of_vocab(&[5, 200, 300], 100), Some((1, 200)));
+            }
+
+            #[test]
+            fn first_out_of_vocab_rejects_id_equal_to_vocab() {
+                // vocab_size itself is out of range (valid ids are 0..vocab_size).
+                assert_eq!(first_out_of_vocab(&[100], 100), Some((0, 100)));
+            }
         }
     }
 }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -24341,7 +24341,7 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// `self.encode_final_head(...)` in `forward_step_inner_impl` back to
         /// an unconditional call reddens the `emit_head=false` assertion
         /// below (the sentinel gets overwritten by the real lm_head GEMV
-        /// every time, regardless of the flag). Verified in REPORT.md.
+        /// every time, regardless of the flag).
         #[test]
         fn forward_step_mrope_emit_head_false_skips_terminal_head_dispatch() {
             let Some(model) = require_metal_and_real_checkpoint_or_skip(

--- a/crates/inference/src/serve/metal_worker.rs
+++ b/crates/inference/src/serve/metal_worker.rs
@@ -716,6 +716,38 @@ impl VisionRuntime {
         self.vision_supported.clone()
     }
 
+    /// Eagerly load vision weights now, ahead of the first image request
+    /// (`--preload-vision`). A no-op when there is nothing pending (already
+    /// loaded, or the checkpoint never advertised vision capability).
+    ///
+    /// On failure, deliberately leaves `state` at `Pending` rather than
+    /// `Failed` — unlike [`Self::get_or_load`]'s terminal-failure contract,
+    /// a startup preload attempt is a best-effort optimization: the caller
+    /// is expected to warn and continue, and the FIRST image request still
+    /// gets its own (possibly successful) lazy-load attempt via
+    /// `get_or_load`, exactly as if `--preload-vision` had never been
+    /// passed. This is what "falls back to lazy loading" means for this
+    /// flag: preload failing must never disable vision for the session.
+    pub fn preload(&mut self) -> Result<(), String> {
+        let (model_dir, config) = match &self.state {
+            VisionState::Pending { model_dir, config } => (model_dir.clone(), config.clone()),
+            VisionState::Unsupported | VisionState::Loaded(_) | VisionState::Failed(_) => {
+                return Ok(());
+            }
+        };
+        let mut never_cancel = || false;
+        match load_qwen35_vision_weights_with_cancel(&model_dir, &config, &mut never_cancel) {
+            Ok(Some(weights)) => {
+                self.state = VisionState::Loaded(weights);
+                Ok(())
+            }
+            // `never_cancel` always returns `false`, so `should_cancel` can never
+            // observe a cancellation request; `None` is unreachable in practice.
+            Ok(None) => Ok(()),
+            Err(err) => Err(format!("vision preload failed: {err}")),
+        }
+    }
+
     fn get_or_load(
         &mut self,
         should_cancel: &mut dyn FnMut() -> bool,
@@ -1797,6 +1829,124 @@ mod tests {
         config.vision_end_token_id = None;
         assert!(
             !VisionRuntime::from_model_config(temp.path().to_path_buf(), &config).is_supported()
+        );
+    }
+
+    /// A `Pending` runtime whose weight-source manifest passes the inventory
+    /// preflight (every expected tensor name is present) but whose backing
+    /// file is not real tensor data, so any actual load attempt fails —
+    /// mirrors the junk-payload fixture in
+    /// `vision_runtime_capability_requires_config_token_metadata_and_weight_source`.
+    /// Reused by the `--preload-vision` tests below, which care about the
+    /// *failure* path, not a successful load (a real checkpoint is needed
+    /// for that and is already covered by the `metal_qwen35` gate tests).
+    fn pending_vision_runtime_with_unloadable_weights() -> (tempfile::TempDir, VisionRuntime) {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let mut config = Qwen35Config::qwen35_0_8b();
+        config.vision_config = Some(tiny_vision_config(config.hidden_size));
+        config.image_token_id = Some(10);
+        config.vision_start_token_id = Some(11);
+        config.vision_end_token_id = Some(12);
+
+        let mut names = vec![
+            "model.visual.patch_embed.proj.weight".to_string(),
+            "model.visual.patch_embed.proj.bias".to_string(),
+            "model.visual.pos_embed.weight".to_string(),
+            "model.visual.merger.linear_fc1.weight".to_string(),
+            "model.visual.merger.linear_fc1.bias".to_string(),
+            "model.visual.merger.linear_fc2.weight".to_string(),
+            "model.visual.merger.linear_fc2.bias".to_string(),
+            "model.visual.merger.norm.weight".to_string(),
+            "model.visual.merger.norm.bias".to_string(),
+        ];
+        for suffix in [
+            "attn.qkv.weight",
+            "attn.qkv.bias",
+            "attn.proj.weight",
+            "attn.proj.bias",
+            "mlp.linear_fc1.weight",
+            "mlp.linear_fc1.bias",
+            "mlp.linear_fc2.weight",
+            "mlp.linear_fc2.bias",
+            "norm1.weight",
+            "norm1.bias",
+            "norm2.weight",
+            "norm2.bias",
+        ] {
+            names.push(format!("model.visual.blocks.0.{suffix}"));
+        }
+        std::fs::write(temp.path().join("visual.bin"), b"not real tensor data")
+            .expect("visual tensor marker");
+        let entries: Vec<_> = names
+            .iter()
+            .map(|name| serde_json::json!({"name": name, "file": "visual.bin"}))
+            .collect();
+        std::fs::write(
+            temp.path().join("quantize_index.json"),
+            serde_json::to_vec(&entries).expect("manifest fixture"),
+        )
+        .expect("complete vision manifest");
+
+        let runtime = VisionRuntime::from_model_config(temp.path().to_path_buf(), &config);
+        assert!(
+            runtime.is_supported(),
+            "fixture must advertise capability so preload has a Pending state to act on"
+        );
+        (temp, runtime)
+    }
+
+    /// `--preload-vision` on a checkpoint with no vision capability (or an
+    /// already-resolved runtime) must not error and must not change
+    /// capability — there is nothing pending to load.
+    #[test]
+    fn vision_runtime_preload_is_noop_when_unsupported() {
+        let mut runtime = VisionRuntime::unsupported();
+        runtime
+            .preload()
+            .expect("preloading an unsupported runtime is a no-op, not an error");
+        assert!(!runtime.is_supported());
+    }
+
+    /// The failure-fallback contract `--preload-vision` depends on: a failed
+    /// eager load at startup must warn (the CLI layer's job) and leave the
+    /// runtime exactly as if `--preload-vision` had never been passed — still
+    /// `Pending`, still advertising capability, so the first real image
+    /// request gets its own normal lazy-load attempt rather than an
+    /// immediately-terminal one.
+    ///
+    /// Mutation-sensitivity: this is the test that reddens if `preload()` is
+    /// wired to `get_or_load()` directly (or otherwise poisons state to
+    /// `Failed` on error) instead of leaving `Pending` on failure — the
+    /// terminal-failure contract is correct for `get_or_load` (proven by
+    /// `vision_runtime_capability_requires_config_token_metadata_and_weight_source`
+    /// above) but wrong for `preload`, whose whole point is that failing must
+    /// not be terminal.
+    #[test]
+    fn vision_runtime_preload_failure_falls_back_to_lazy_pending_state() {
+        let (_temp, mut runtime) = pending_vision_runtime_with_unloadable_weights();
+
+        let preload_err = runtime
+            .preload()
+            .expect_err("junk tensor payload must fail preload");
+        assert!(preload_err.contains("vision preload failed"));
+        assert!(
+            runtime.is_supported(),
+            "a failed preload must not revoke vision capability — the CLI falls back to lazy \
+             loading, it does not disable vision for the session"
+        );
+
+        // The first real image request's lazy load must still be attempted
+        // fresh (not short-circuited by a stale `Failed` state left behind
+        // by preload) — same junk payload, so it fails too, but critically
+        // via `get_or_load`'s own (terminal) contract, not preload's.
+        let mut never_cancel = || false;
+        let lazy_err = runtime
+            .get_or_load(&mut never_cancel)
+            .expect_err("lazy load retries the same unloadable fixture and fails the same way");
+        assert!(lazy_err.contains("vision weights failed to load"));
+        assert!(
+            !runtime.is_supported(),
+            "get_or_load's own terminal-failure contract still applies once it actually runs"
         );
     }
 

--- a/crates/inference/tests/metal_measurement_lock_contract.rs
+++ b/crates/inference/tests/metal_measurement_lock_contract.rs
@@ -93,6 +93,7 @@ const TARGETS_WITH_RECOGNIZED_METAL_MARKERS: &[&str] = &[
     "src/bin/bench_gdn_prefill_ab.rs",
     "src/bin/bench_logit_dump.rs",
     "src/bin/bench_lora_mixture.rs",
+    "src/bin/bench_vision_prefill_ab.rs",
     "src/bin/chat_metal.rs",
     "src/bin/dump_quarot_q4_golden.rs",
     "src/bin/eval_perplexity.rs",

--- a/scripts/bench-measurements.toml
+++ b/scripts/bench-measurements.toml
@@ -106,6 +106,7 @@ paths = [
     "crates/inference/src/bin/bench_gdn_prefill_ab.rs",
     "crates/inference/src/bin/bench_logit_dump.rs",
     "crates/inference/src/bin/bench_lora_mixture.rs",
+    "crates/inference/src/bin/bench_vision_prefill_ab.rs",
     "crates/inference/src/bin/eval_perplexity.rs",
     "crates/inference/src/bin/gramperf_profile.rs",
     "crates/inference/src/bin/gramtime_profile.rs",

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -2254,11 +2254,19 @@ class E2eRunnerSpecializationWorkflowTests(unittest.TestCase):
         self.assertIn("-xf quarot-q4.tar", q4_metal_code)
         self.assertIn("LATTICE_QUAROT_ARTIFACT_CONSUMED", q4_metal_code)
         self.assertNotIn("--bin quantize_quarot", q4_metal_code)
+        # The injection gate's filter list is pinned in full, and after the
+        # `--` separator. `cargo test` accepts one positional TESTNAME, so a
+        # multi-term filter written as `--lib a b c` exits 1 at argument
+        # parsing before any test binary is built; only libtest, on the far
+        # side of `--`, ORs multiple filters. Pinning the separator and every
+        # term is what distinguishes the working invocation from that
+        # look-alike, and it makes a change to the selected surface land in
+        # the same commit as the exact-count grep the gate asserts.
         for metal_gate_anchor in (
             "--test quarot_q4_composed_golden",
             '--features "f16,metal-gpu"',
             "LATTICE_METAL_TEST_ENFORCE: '1'",
-            "--lib inject",
+            "-- inject emit_head vision_runtime_preload",
             "--test vision_s5b_e2e_gate_test",
             "LATTICE_VISION_S5B_GREEDY_TOKENS",
             "--bin eval_perplexity --bin quantize_q4",

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -2258,7 +2258,7 @@ class E2eRunnerSpecializationWorkflowTests(unittest.TestCase):
             "--test quarot_q4_composed_golden",
             '--features "f16,metal-gpu"',
             "LATTICE_METAL_TEST_ENFORCE: '1'",
-            "--lib inject -- --nocapture --test-threads=1",
+            "--lib inject",
             "--test vision_s5b_e2e_gate_test",
             "LATTICE_VISION_S5B_GREEDY_TOKENS",
             "--bin eval_perplexity --bin quantize_q4",


### PR DESCRIPTION
Vision prefill runs many positions before the first token is emitted, and only the last of them needs the terminal RMSNorm and `lm_head` dispatch. This lets the earlier positions skip that work.

## What changed

`forward_step_mrope` and `forward_step_injected_mrope` take an `emit_head` flag; the vision prefill loop passes `false` for every position except the last. When `emit_head` is false the terminal head is not encoded at all, rather than encoded and discarded.

## The guard that decides whether the head runs

The head runs when the caller asks for it, when hidden capture is requested, or when this request has activated MTP:

```rust
let run_head = emit_head || capture_hidden || self.session.mtp_active;
```

The third operand is a per-request flag, not a property of the checkpoint. That distinction is the substance of this change. `session.mtp` reports whether MTP weights are resident, and weights load whenever `mtp_num_hidden_layers != 0`, independently of whether a request enables MTP. Keying the guard on residency meant that any vision request against an MTP-capable checkpoint ran the terminal head at every prefill position, which is exactly the work this change exists to skip.

`mtp_active` defaults to false, is set true only in the branch that commits to MTP for a request (immediately before `mtp_prefill`, the sole production call site), and is cleared by `reset_state()`. Every generate entry point calls `reset_state()` at its top, so no request inherits activation from a prior call on the same session — `generate_multimodal_vision_impl` clears it at :9491, ahead of the prefill loop's `forward_step_mrope` calls at :9550 and :9558. The protection the original operand provided is preserved: while MTP is genuinely active, the head still runs for any caller of the mrope entry points.

## Also in this change

- The bench binary's `BENCH_REPEATS` rejects `0` before model initialization instead of panicking on an out-of-bounds median index after the slow model load. The median helper returns a `Result` on empty input rather than indexing.
- The `#[cfg(test)] mod tests` block inside `bench_support` moved below the helper functions it precedes, so the file has no items after a test module.

## CI coverage for the bench surface

`--all-targets` does not reach the bench binaries under `src/bin/` unless `bench-internals` is in the feature list, so that surface was going unlinted. It is now linted by its own macOS-only step that passes `--release`, rather than by adding the feature to the existing debug lint. The reason is specific: `bench_vision_prefill_ab.rs` carries a `compile_error!` gated on `debug_assertions`, so that surface cannot compile in a debug clippy pass at all, and forcing `--release` onto the existing step would slow it for everything else it covers. The existing metal-gpu clippy step is unchanged.

The MP2 Metal injection gate asserts an exact test count, and this change adds tests that its filter selects, so the expected count moves from 12 to 13. The count in the committed workflow was measured by running the gate's own command, not computed; a stale explanatory comment beside it, which undercounted the `emit_head` matches, was corrected at the same time.

## Verification

The regression fixture builds a session with MTP weights resident and `mtp_active` false, calls `forward_step_mrope` directly with `emit_head=false` — the same call the vision prefill loop makes — and asserts no logits are returned and a sentinel written into the shared logits buffer survives untouched. Poisoning the buffer is necessary because `emit_head=false` returns empty logits by contract either way, so the return value alone cannot distinguish "skipped" from "ran and was discarded".

Executed on an Apple M2 Max, green. Reverting the guard's third operand to the residency check reddens it (exit 101) at the `must return no logits` assertion, because the mutated guard dispatches the terminal head; restoring the operand returns it to green. Three runs, green then red then green.

Both assertions were then shown to be load-bearing individually, which the run above does not establish on its own: the first assertion aborts the test before the sentinel comparison executes, so that comparison passing proves nothing about whether it can detect anything. A second mutation disabled the first assertion in this one test so control could reach the second, and reverted the guard as before. The test then failed at the sentinel `assert_eq!` with its own message, the observed buffer holding zeros where the sentinel had been written. The sentinel was overwritten, so the terminal head demonstrably dispatched, and the sentinel comparison is what caught it. Both edits were reverted and the test returns to green.

Clippy is clean under `f16,metal-gpu,bench-internals` and under `f16,metal-gpu,serve`; five unit tests cover the repeats validation and the median helper.

## Semver gate disclosure

The `semver-checks` job on this PR is green and that green is not coverage. The job's own annotation:

> **SEMVER: 0 checks executed** (0.8.0 -> 0.9.0; a 0.x minor bump reads as an assumed-major change, so cargo-semver-checks skipped all 254 checks). A green result here is NOT coverage. It becomes coverage again once the bumped version is published and becomes the crates.io baseline. Observed `lattice-transport` directly; the other workspace crates are inferred to be in the same state because they share one `[workspace.package] version`.

The workspace sits at an unpublished 0.9.0 against a published 0.8.0, so under 0.x rules the bump already declares breaking-allowed and the comparison is moot rather than merely unmeasured. Tracked in #1378. No semver claim of any sign is being made about this change.

## bench-compare disposition

A reachable target now exists and the measurement is unrun. This section replaces an earlier
structural waiver that is no longer accurate at this head.

### Measurement (issue #1336's acceptance criterion)

#1336 requires a before/after multimodal-prefill measurement and states there is no performance
claim without it. That criterion is **not discharged by this PR**, and this section replaces an
earlier structural waiver that is no longer accurate: at this head the branch itself adds the
missing bench target, so "no declared bench target reaches this path" is false.

What now exists: `crates/inference/src/bin/bench_vision_prefill_ab.rs`, an A/B harness whose two
arms are the same per-position forward-step calls differing only in a runtime `emit_head` flag,
so the two arms are one binary rather than two builds. It is registered with
`required-features = ["f16", "metal-gpu", "bench-internals"]`, matching the existing
`bench_decode_ab` and `bench_gdn_prefill_ab` targets.

Operator command:

```
LATTICE_MODEL_DIR=<checkpoint dir> \
BENCH_VISUAL_ROWS=1024 BENCH_WARMUP=1 BENCH_REPEATS=5 \
cargo run --release -p lattice-inference --features f16,metal-gpu,bench-internals \
  --bin bench_vision_prefill_ab
```

What the harness does not control for, stated by the harness's own module doc: it excludes
ViT/merger cost (synthetic checkpoint-shaped `post_merger_rows`, so the number is decoder
multimodal-prefill time and not full request latency), it is sensitive to machine contention and
thermal state, one untimed warmup per arm reduces but does not remove first-dispatch overhead,
and it models a single request with no batching or KV reuse.

**No number is claimed anywhere in this PR.** The harness compiles under
`--features f16,metal-gpu,bench-internals` and its debug-build guard was confirmed live, but it
has not been executed: timed runs happen on the dedicated bench machine under an exclusive lock,
not here. #1336 stays open until that run produces the before/after figures.
