### PR TITLE
fix(inference): route all checkpoint mmap sites through the trust boundary

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -776,16 +776,17 @@ mod inner {
 
         validate_q3_mlp_role(tensor_name).map_err(|e| e.to_string())?;
 
-        let (mut file, metadata) = crate::weights::mmap_trust::open_trusted_mmap_file(path)?;
-        let header = crate::weights::q3_weights::read_q3_header(&mut file)
+        let mut handle = crate::weights::mmap_trust::open_trusted_mmap_file(path)?;
+        let header = crate::weights::q3_weights::read_q3_header(handle.file_mut())
             .map_err(|e| format!("failed to parse Q3 header {}: {e}", path.display()))?;
-        let file_len = file
+        let file_len = handle
+            .file_mut()
             .metadata()
             .map_err(|e| format!("failed to stat {}: {e}", path.display()))?
             .len();
         crate::weights::q3_weights::validate_q3_header_payload_bounds(&header, file_len, path)
             .map_err(|e| format!("failed to validate Q3 payload {}: {e}", path.display()))?;
-        let mmap = crate::weights::mmap_trust::map_and_verify_trusted(&file, &metadata, path)?;
+        let mmap = crate::weights::mmap_trust::map_and_verify_trusted(&handle)?;
 
         let buf = device.new_buffer_with_bytes_no_copy(
             mmap.as_ptr().cast(),

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -755,7 +755,12 @@ mod inner {
     ///
     /// # Safety invariant
     /// The mmap is read-only (`MAP_PRIVATE`) and the model files must not be
-    /// modified while the process is running.
+    /// modified while the process is running. [`crate::weights::mmap_trust::open_trusted_mmap_file`]
+    /// enforces the write-boundary half of that invariant (group/other-writable,
+    /// foreign ownership, a writable ancestor directory, or a permission-granting
+    /// extended ACL) the same way [`mmap_q4_weight`] does; same-uid mutation
+    /// through a second fd remains the documented residual, as for every mmap
+    /// site in this crate.
     ///
     /// Not yet called from live checkpoint loading (proven end-to-end by this
     /// module's `mmap_q3_weight_*` tests instead).
@@ -771,8 +776,7 @@ mod inner {
 
         validate_q3_mlp_role(tensor_name).map_err(|e| e.to_string())?;
 
-        let mut file = std::fs::File::open(path)
-            .map_err(|e| format!("failed to open {}: {e}", path.display()))?;
+        let (mut file, _metadata) = crate::weights::mmap_trust::open_trusted_mmap_file(path)?;
         let header = crate::weights::q3_weights::read_q3_header(&mut file)
             .map_err(|e| format!("failed to parse Q3 header {}: {e}", path.display()))?;
         let file_len = file
@@ -17674,6 +17678,66 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             assert!(
                 result.is_ok(),
                 "mmap_q3_weight must accept a well-formed MLP-role payload: {:?}",
+                result.err()
+            );
+        }
+
+        // #1368: `mmap_q3_weight` must route through the same mmap trust
+        // boundary `mmap_q4_weight` already does -- proves the wiring, not
+        // just the underlying `open_trusted_mmap_file` predicate (already
+        // covered directly in `mmap_trust`'s own tests).
+        #[cfg(unix)]
+        #[test]
+        fn mmap_q3_weight_rejects_a_group_or_other_writable_file() {
+            use std::os::unix::fs::PermissionsExt;
+
+            let Some(device) = Device::system_default() else {
+                return;
+            };
+            let tmp = tempfile::tempdir().expect("tempdir create");
+            let path = tmp.path().join("writable.q3");
+            let tensor = crate::weights::q3_weights::Q3Tensor {
+                blocks: vec![
+                    crate::weights::q3_weights::Q3Block {
+                        scale: 0,
+                        bias: 0,
+                        packed: [0u8; 12]
+                    };
+                    2
+                ],
+                shape: vec![64],
+                original_len: 64,
+            };
+            crate::weights::q3_weights::save_q3_file(&path, &tensor)
+                .expect("save well-formed q3 file");
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666))
+                .expect("chmod 0o666");
+
+            let result = mmap_q3_weight(
+                &device,
+                &path,
+                "model.layers.0.mlp.down_proj.weight",
+                "writable-file-rejected",
+            );
+            let Err(err) = result else {
+                panic!("a group/other-writable Q3 file must be refused")
+            };
+            assert!(
+                err.contains("refusing to load"),
+                "expected a trust-boundary refusal, got: {err}"
+            );
+
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                .expect("chmod 0o600");
+            let result = mmap_q3_weight(
+                &device,
+                &path,
+                "model.layers.0.mlp.down_proj.weight",
+                "owner-only-accepted",
+            );
+            assert!(
+                result.is_ok(),
+                "an owner-only Q3 file must still be accepted: {:?}",
                 result.err()
             );
         }

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -777,13 +777,11 @@ mod inner {
         validate_q3_mlp_role(tensor_name).map_err(|e| e.to_string())?;
 
         let mut handle = crate::weights::mmap_trust::open_trusted_mmap_file(path)?;
-        let header = crate::weights::q3_weights::read_q3_header(handle.file_mut())
+        let header = crate::weights::q3_weights::read_q3_header(&mut handle)
             .map_err(|e| format!("failed to parse Q3 header {}: {e}", path.display()))?;
         let file_len = handle
-            .file_mut()
-            .metadata()
-            .map_err(|e| format!("failed to stat {}: {e}", path.display()))?
-            .len();
+            .len()
+            .map_err(|e| format!("failed to stat {}: {e}", path.display()))?;
         crate::weights::q3_weights::validate_q3_header_payload_bounds(&header, file_len, path)
             .map_err(|e| format!("failed to validate Q3 payload {}: {e}", path.display()))?;
         let mmap = crate::weights::mmap_trust::map_and_verify_trusted(&handle)?;

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -776,7 +776,7 @@ mod inner {
 
         validate_q3_mlp_role(tensor_name).map_err(|e| e.to_string())?;
 
-        let (mut file, _metadata) = crate::weights::mmap_trust::open_trusted_mmap_file(path)?;
+        let (mut file, metadata) = crate::weights::mmap_trust::open_trusted_mmap_file(path)?;
         let header = crate::weights::q3_weights::read_q3_header(&mut file)
             .map_err(|e| format!("failed to parse Q3 header {}: {e}", path.display()))?;
         let file_len = file
@@ -785,13 +785,7 @@ mod inner {
             .len();
         crate::weights::q3_weights::validate_q3_header_payload_bounds(&header, file_len, path)
             .map_err(|e| format!("failed to validate Q3 payload {}: {e}", path.display()))?;
-        // SAFETY: `mmap`'s read-only-mmap invariant is documented above
-        // (`# Safety invariant`): the file is opened read-only and mapped
-        // `MAP_PRIVATE`, and the caller must not mutate the on-disk file
-        // while this process runs — the same invariant `mmap_q4_weight`
-        // relies on for its no-copy Metal buffer.
-        let mmap = unsafe { memmap2::MmapOptions::new().map(&file) }
-            .map_err(|e| format!("failed to mmap {}: {e}", path.display()))?;
+        let mmap = crate::weights::mmap_trust::map_and_verify_trusted(&file, &metadata, path)?;
 
         let buf = device.new_buffer_with_bytes_no_copy(
             mmap.as_ptr().cast(),

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -138,16 +138,10 @@ impl Shard {
         // runtime baseline forward pass does (see `QuarotTensorReader::open`'s
         // doc comment), so `path` may resolve through a final-component
         // symlink -- `open_trusted_mmap_file`'s `O_NOFOLLOW` would reject
-        // that. `reject_if_open_mmap_file_untrusted` applies the same
-        // mode/uid/ACL/parent-directory checks without it.
-        crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted(&file, path)
+        // that. `map_after_untrusted_open` applies the same
+        // mode/uid/ACL/parent-directory checks without it, then maps.
+        let mmap = crate::weights::mmap_trust::map_after_untrusted_open(&file, path)
             .map_err(InferenceError::InvalidSafetensors)?;
-        // SAFETY: the file is opened read-only; the returned Mmap owns the
-        // mapping. The File handle can be dropped immediately after — the OS
-        // keeps the fd alive through the map. Standard memmap2 usage.
-        let mmap = unsafe { Mmap::map(&file) }.map_err(|e| {
-            InferenceError::InvalidSafetensors(format!("failed to mmap {}: {e}", path.display()))
-        })?;
 
         if mmap.len() < 8 {
             return Err(InferenceError::InvalidSafetensors(format!(

--- a/crates/inference/src/quant/quarot/io.rs
+++ b/crates/inference/src/quant/quarot/io.rs
@@ -134,6 +134,14 @@ impl Shard {
         let file = File::open(path).map_err(|e| {
             InferenceError::InvalidSafetensors(format!("failed to open {}: {e}", path.display()))
         })?;
+        // This reader loads the same HuggingFace hub-cache checkpoints the
+        // runtime baseline forward pass does (see `QuarotTensorReader::open`'s
+        // doc comment), so `path` may resolve through a final-component
+        // symlink -- `open_trusted_mmap_file`'s `O_NOFOLLOW` would reject
+        // that. `reject_if_open_mmap_file_untrusted` applies the same
+        // mode/uid/ACL/parent-directory checks without it.
+        crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted(&file, path)
+            .map_err(InferenceError::InvalidSafetensors)?;
         // SAFETY: the file is opened read-only; the returned Mmap owns the
         // mapping. The File handle can be dropped immediately after — the OS
         // keeps the fd alive through the map. Standard memmap2 usage.
@@ -1209,6 +1217,36 @@ mod tests {
         for (g, &v) in got.iter().zip(values.iter()) {
             assert_eq!(*g, v as f64);
         }
+    }
+
+    // #1368: `Shard::open` (reached via `QuarotTensorReader::open`) is a
+    // raw-open mmap site that must route through the mmap trust boundary the
+    // same as every other checkpoint mmap site in this crate. This proves
+    // the wiring at the public entry point, not just the underlying
+    // `reject_if_open_mmap_file_untrusted` predicate (already covered
+    // directly in `mmap_trust`'s own tests).
+    #[cfg(unix)]
+    #[test]
+    fn open_rejects_a_group_or_other_writable_checkpoint_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("model.safetensors");
+        write_safetensors(&path, &[("w", FixtureDType::F32, vec![1], &[1.0])]);
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666))
+            .expect("chmod 0o666");
+
+        let err = QuarotTensorReader::open(dir.path())
+            .expect_err("a group/other-writable checkpoint file must be refused");
+        assert!(
+            matches!(&err, InferenceError::InvalidSafetensors(msg) if msg.contains("refusing to load")),
+            "expected a trust-boundary refusal, got: {err:?}"
+        );
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .expect("chmod 0o600");
+        QuarotTensorReader::open(dir.path())
+            .expect("an owner-only checkpoint file must still be accepted");
     }
 
     #[test]

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -167,9 +167,9 @@ impl CrossEncoderWeights {
 ///
 /// The owned variant exists for targets without real file-descriptor/mmap
 /// support (`wasm32-unknown-unknown`: `memmap2`'s wasm fallback compiles but
-/// every `Mmap::map` call returns `io::ErrorKind::Unsupported` at runtime) and
-/// for hosts that receive model weights as an in-memory buffer rather than a
-/// filesystem path (e.g. bytes handed in from JavaScript).
+/// every mmap construction call returns `io::ErrorKind::Unsupported` at
+/// runtime) and for hosts that receive model weights as an in-memory buffer
+/// rather than a filesystem path (e.g. bytes handed in from JavaScript).
 enum SafetensorsBacking {
     Mapped(Mmap),
     Owned(Vec<u8>),
@@ -218,23 +218,22 @@ impl SafetensorsFile {
         let file = File::open(path).map_err(|e| {
             InferenceError::InvalidSafetensors(format!("failed to open {}: {e}", path.display()))
         })?;
-        crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted(&file, path)
-            .map_err(InferenceError::InvalidSafetensors)?;
-        Self::from_open_file(file, path.display().to_string())
+        Self::from_open_file(file, path)
     }
 
     /// Parse a safetensors file from an already-open [`File`].
     ///
     /// Manifest-derived shards reach this through [`open_manifest_entry_once`], which
-    /// validates the manifest string and opens the file exactly once. Mapping the fd the
-    /// caller already holds is what keeps that single open meaningful; reopening by path
-    /// here would reintroduce the window between the open and the read.
-    pub(crate) fn from_open_file(file: File, display_path: String) -> Result<Self, InferenceError> {
-        // SAFETY: The file descriptor remains alive until the mmap is created,
-        // and the returned Mmap owns the mapping independently of the File.
-        let mmap = unsafe { Mmap::map(&file) }.map_err(|e| {
-            InferenceError::InvalidSafetensors(format!("failed to mmap {display_path}: {e}"))
-        })?;
+    /// opens the file exactly once. Mapping the fd the caller already holds is what keeps
+    /// that single open meaningful; reopening by path here would reintroduce the window
+    /// between the open and the read. `path` is used both to run the mmap trust-boundary
+    /// guard (via [`crate::weights::mmap_trust::map_after_untrusted_open`]) and to name the
+    /// file in error messages -- it should be the resolved real path when the caller has
+    /// one, matching that guard's own `path` requirement.
+    pub(crate) fn from_open_file(file: File, path: &Path) -> Result<Self, InferenceError> {
+        let display_path = path.display().to_string();
+        let mmap = crate::weights::mmap_trust::map_after_untrusted_open(&file, path)
+            .map_err(InferenceError::InvalidSafetensors)?;
 
         Self::from_backing(SafetensorsBacking::Mapped(mmap), display_path)
     }
@@ -1415,7 +1414,7 @@ pub fn load_sharded(model_dir: &Path) -> Result<HashMap<String, Tensor>, Inferen
     let mut tensors = HashMap::with_capacity(index.weight_map.len());
     for (shard_file, tensor_names) in by_shard {
         let (file, real_path) = open_manifest_entry_once(model_dir, &shard_file)?;
-        let shard = SafetensorsFile::from_open_file(file, real_path.display().to_string())?;
+        let shard = SafetensorsFile::from_open_file(file, &real_path)?;
         for tensor_name in tensor_names {
             let (data, shape) = shard.get_f32_tensor(&tensor_name)?;
             tensors.insert(
@@ -1473,7 +1472,7 @@ impl ShardedSafetensors {
     fn open_shard(&mut self, shard_file: &str) -> Result<&SafetensorsFile, InferenceError> {
         if !self.shards.contains_key(shard_file) {
             let (file, real_path) = open_manifest_entry_once(&self.root, shard_file)?;
-            let shard = SafetensorsFile::from_open_file(file, real_path.display().to_string())?;
+            let shard = SafetensorsFile::from_open_file(file, &real_path)?;
             self.shards.insert(shard_file.to_string(), shard);
         }
         self.shards.get(shard_file).ok_or_else(|| {

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -218,6 +218,8 @@ impl SafetensorsFile {
         let file = File::open(path).map_err(|e| {
             InferenceError::InvalidSafetensors(format!("failed to open {}: {e}", path.display()))
         })?;
+        crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted(&file, path)
+            .map_err(InferenceError::InvalidSafetensors)?;
         Self::from_open_file(file, path.display().to_string())
     }
 
@@ -1314,6 +1316,12 @@ pub fn parse_index(model_dir: &Path) -> Result<SafetensorsIndex, InferenceError>
 /// [`contained_shard_path`] before the join: absolute paths and parent-directory components
 /// are rejected, lexically, without consulting any filesystem state.
 ///
+/// The returned file has already passed
+/// [`crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted`] against its resolved
+/// real path -- every caller mmaps this file read-only no-copy, so the same write-boundary
+/// gate every other checkpoint mmap goes through applies here too, without `open_trusted_mmap_file`'s
+/// `O_NOFOLLOW` (see that function's doc comment for why a hub-cache symlink must still resolve).
+///
 /// # Why this opens the file instead of returning a path to reopen
 ///
 /// Resolving a path and handing it back leaves the caller to `open()` it separately, and a
@@ -1341,6 +1349,8 @@ pub(crate) fn open_manifest_entry_once(
         InferenceError::InvalidSafetensors(format!("failed to open {}: {e}", candidate.display()))
     })?;
     let real_path = real_path_of_open_file(&file, &candidate)?;
+    crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted(&file, &real_path)
+        .map_err(InferenceError::InvalidSafetensors)?;
     Ok((file, real_path))
 }
 
@@ -2463,6 +2473,41 @@ mod tests {
         assert_eq!(mat_shape, &[2, 2]);
         assert_eq!(vec_data, &[1.0, 2.0]);
         assert_eq!(mat_data, &[3.0, 4.0, 5.0, 6.0]);
+    }
+
+    // #1368: `SafetensorsFile::open` is a raw-open entry point (used directly
+    // by the runtime model loaders, not just via `open_manifest_entry_once`)
+    // that must route through the mmap trust boundary the same as every
+    // other checkpoint mmap site in this crate. This proves the wiring, not
+    // just the underlying `reject_if_open_mmap_file_untrusted` predicate
+    // (already covered directly in `mmap_trust`'s own tests).
+    #[cfg(unix)]
+    #[test]
+    fn open_rejects_a_group_or_other_writable_checkpoint_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = temp_path("lattice_weights_writable_checkpoint");
+        let header = r#"{"vec":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}"#;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&1.0f32.to_le_bytes());
+
+        let mut file = File::create(&path).expect("test setup: create safetensors file");
+        file.write_all(&bytes)
+            .expect("test setup: write safetensors bytes");
+        drop(file);
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o666)).expect("chmod 0o666");
+
+        let err = SafetensorsFile::open(&path)
+            .expect_err("a group/other-writable checkpoint file must be refused");
+        assert!(
+            matches!(&err, InferenceError::InvalidSafetensors(msg) if msg.contains("refusing to load")),
+            "expected a trust-boundary refusal, got: {err:?}"
+        );
+
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).expect("chmod 0o600");
+        SafetensorsFile::open(&path).expect("an owner-only checkpoint file must still be accepted");
     }
 
     #[test]

--- a/crates/inference/src/weights/mmap_trust.rs
+++ b/crates/inference/src/weights/mmap_trust.rs
@@ -141,6 +141,8 @@
 use std::fs::File;
 use std::path::Path;
 
+use memmap2::Mmap;
+
 /// Pure predicate: does this `(mode, file_uid, process_uid)` triple fall
 /// outside lattice's mode/uid trust boundary for a mmap'd model file? Split
 /// out from the metadata-reading wrapper so it is unit-testable without
@@ -666,6 +668,61 @@ pub(crate) fn verify_mmap_target_unchanged(
     _path: &Path,
 ) -> Result<(), String> {
     Ok(())
+}
+
+/// Map a `File` [`open_trusted_mmap_file`] already opened and trust-gated,
+/// then run [`verify_mmap_target_unchanged`] against the `Metadata` that call
+/// captured before mapping. `prior` must be the `Metadata` from that same
+/// `open_trusted_mmap_file` call on `file`.
+///
+/// This -- not a bare `Mmap::map`/`MmapOptions::new().map` call written out
+/// at each loader -- is one of the two places in this crate a checkpoint
+/// mapping is constructed (see [`map_after_untrusted_open`] for the other).
+/// Folding the map and the post-map recheck into this module makes "guarded
+/// before mapped, rechecked after mapped" a property of *which function a
+/// caller calls*, not a convention each loader has to reproduce correctly on
+/// its own -- the property this module exists to enforce no longer depends
+/// on an external scan finding every call site that got it right.
+///
+/// A caller that needs to read `file`'s contents (a Q4/Q3 header, for
+/// instance) before the mapping is created does so between its
+/// `open_trusted_mmap_file` call and this one; nothing about that ordering
+/// is checked here, since a plain `std::fs::File` read has no bearing on the
+/// mmap trust boundary this module defends.
+#[cfg_attr(not(feature = "metal-gpu"), allow(dead_code))]
+pub(crate) fn map_and_verify_trusted(
+    file: &File,
+    prior: &std::fs::Metadata,
+    path: &Path,
+) -> Result<Mmap, String> {
+    // SAFETY: `file` was opened and trust-gated by `open_trusted_mmap_file`
+    // (the caller's obligation, documented on this function); the model file
+    // must not be mutated while this process runs, the same invariant every
+    // mmap site in this crate relies on.
+    let mmap = unsafe { Mmap::map(file) }
+        .map_err(|e| format!("failed to mmap {}: {e}", path.display()))?;
+    verify_mmap_target_unchanged(file, prior, path)?;
+    Ok(mmap)
+}
+
+/// Guard and map a `File` the caller opened itself through a plain,
+/// symlink-following `File::open` -- the flavor [`reject_if_open_mmap_file_untrusted`]'s
+/// doc comment describes for loaders that must follow a final-component
+/// symlink (a HuggingFace hub-cache checkpoint), which `open_trusted_mmap_file`'s
+/// `O_NOFOLLOW` would reject outright.
+///
+/// This is the second (and last) place in this crate a checkpoint mapping is
+/// constructed -- see [`map_and_verify_trusted`] for the `open_trusted_mmap_file`
+/// flavor. Folding the guard call and the map into one function here keeps
+/// the same structural guarantee: a caller cannot reach a mapping of `file`
+/// without this function having run the guard against it first.
+pub(crate) fn map_after_untrusted_open(file: &File, path: &Path) -> Result<Mmap, String> {
+    reject_if_open_mmap_file_untrusted(file, path)?;
+    // SAFETY: `file` was just trust-gated by `reject_if_open_mmap_file_untrusted`
+    // above, on the same descriptor; the model file must not be mutated while
+    // this process runs, the same invariant every mmap site in this crate
+    // relies on.
+    unsafe { Mmap::map(file) }.map_err(|e| format!("failed to mmap {}: {e}", path.display()))
 }
 
 /// macOS extended-ACL inspection, isolated in its own submodule so the FFI

--- a/crates/inference/src/weights/mmap_trust.rs
+++ b/crates/inference/src/weights/mmap_trust.rs
@@ -139,7 +139,7 @@
 //! regardless of what the path later resolves to.
 
 use std::fs::File;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use memmap2::Mmap;
 
@@ -463,10 +463,62 @@ unsafe extern "C" {
     fn fcntl(fd: i32, cmd: i32, ...) -> i32;
 }
 
-/// Open `path` for a trusted, no-copy mmap and return the still-open
-/// `(File, Metadata)` pair every one of this crate's five mmap loaders needs
-/// -- callers never re-open or re-stat `path` afterward (see this module's
-/// fd-binding invariant).
+/// An already-open checkpoint `File`, together with the pre-map `Metadata`
+/// [`open_trusted_mmap_file`] captured and the resolved `Path` it came from,
+/// bundled behind private fields so the only way to obtain one is
+/// [`open_trusted_mmap_file`] itself.
+///
+/// This exists to close a defeat the previous `(File, Metadata)` tuple
+/// return shape permitted: [`map_and_verify_trusted`] took `file`, `prior`,
+/// and `path` as three independent parameters with no type-level
+/// relationship between them, so nothing stopped a caller from invoking it
+/// directly with a `file` that was never opened through
+/// [`open_trusted_mmap_file`] at all, paired with that same file's own
+/// metadata as `prior` -- [`verify_mmap_target_unchanged`] then saw no
+/// drift (the file had not changed since a stat taken from itself) and
+/// accepted an ungated, group/other-writable file. Bundling the three
+/// into one type whose fields only this module can set makes that
+/// construction unreachable: every `TrustedMmapFile` that exists has
+/// necessarily been through [`open_trusted_mmap_file`]'s mode/uid/ACL and
+/// parent-directory checks, because there is no other way to build one.
+///
+/// [`file_mut`](Self::file_mut) hands out a mutable borrow of the guarded
+/// file so a caller can read a header (Q4/Q3 preflight) between the
+/// trust-gated open and the mapping -- reading bytes off an already-open,
+/// already-guarded fd has no bearing on the mmap trust boundary this module
+/// enforces, only *mapping* does, and mapping stays reachable solely through
+/// [`map_and_verify_trusted`], which this type provides no way around: it is
+/// the only function that can see `prior` or construct a `Mmap` from
+/// `file`. This is not a wider exposure than the type it replaces already
+/// had -- the previous `(File, Metadata)` tuple handed the same `File` to
+/// callers just as directly, governed by the same lexical
+/// `only_the_mmap_trust_boundary_names_a_construction_api` contract test
+/// that still catches a caller writing `Mmap::map`/`MmapOptions` literally
+/// against that borrowed file outside this module; nothing about exposing
+/// `file_mut` changes that contract's coverage.
+#[derive(Debug)]
+#[cfg_attr(not(feature = "metal-gpu"), allow(dead_code))]
+pub(crate) struct TrustedMmapFile {
+    file: File,
+    prior: std::fs::Metadata,
+    path: PathBuf,
+}
+
+impl TrustedMmapFile {
+    /// Mutable access to the guarded file for a header read (Q4/Q3
+    /// preflight) that must happen between the trust-gated open and the
+    /// mapping. See the type doc comment for why this does not reopen the
+    /// hole [`TrustedMmapFile`] exists to close.
+    #[cfg_attr(not(feature = "metal-gpu"), allow(dead_code))]
+    pub(crate) fn file_mut(&mut self) -> &mut File {
+        &mut self.file
+    }
+}
+
+/// Open `path` for a trusted, no-copy mmap and return the still-open,
+/// trust-gated [`TrustedMmapFile`] every one of this crate's five mmap
+/// loaders needs -- callers never re-open or re-stat `path` afterward (see
+/// this module's fd-binding invariant).
 ///
 /// # FIFO / device DoS
 ///
@@ -517,7 +569,7 @@ unsafe extern "C" {
 /// ACL FFI calls at all.
 #[cfg(unix)]
 #[cfg_attr(not(feature = "metal-gpu"), allow(dead_code))]
-pub(crate) fn open_trusted_mmap_file(path: &Path) -> Result<(File, std::fs::Metadata), String> {
+pub(crate) fn open_trusted_mmap_file(path: &Path) -> Result<TrustedMmapFile, String> {
     use std::os::fd::AsRawFd;
     use std::os::unix::fs::OpenOptionsExt;
 
@@ -586,17 +638,25 @@ pub(crate) fn open_trusted_mmap_file(path: &Path) -> Result<(File, std::fs::Meta
     reject_if_mmap_parent_directory_chain_weak(path)?;
     reject_if_mmap_file_trust_boundary_weak(&file, path)?;
 
-    Ok((file, meta))
+    Ok(TrustedMmapFile {
+        file,
+        prior: meta,
+        path: path.to_path_buf(),
+    })
 }
 
 #[cfg(not(unix))]
 #[cfg_attr(not(feature = "metal-gpu"), allow(dead_code))]
-pub(crate) fn open_trusted_mmap_file(path: &Path) -> Result<(File, std::fs::Metadata), String> {
+pub(crate) fn open_trusted_mmap_file(path: &Path) -> Result<TrustedMmapFile, String> {
     let file = File::open(path).map_err(|e| format!("failed to open {}: {e}", path.display()))?;
     let meta = file
         .metadata()
         .map_err(|e| format!("failed to stat {}: {e}", path.display()))?;
-    Ok((file, meta))
+    Ok(TrustedMmapFile {
+        file,
+        prior: meta,
+        path: path.to_path_buf(),
+    })
 }
 
 /// Post-map integrity recheck, replacing a previous
@@ -670,38 +730,48 @@ pub(crate) fn verify_mmap_target_unchanged(
     Ok(())
 }
 
-/// Map a `File` [`open_trusted_mmap_file`] already opened and trust-gated,
-/// then run [`verify_mmap_target_unchanged`] against the `Metadata` that call
-/// captured before mapping. `prior` must be the `Metadata` from that same
-/// `open_trusted_mmap_file` call on `file`.
+/// Map the `File` inside a [`TrustedMmapFile`] -- already opened and
+/// trust-gated by the only function that can construct one,
+/// [`open_trusted_mmap_file`] -- then run [`verify_mmap_target_unchanged`]
+/// against the `Metadata` that call captured before mapping.
 ///
 /// This -- not a bare `Mmap::map`/`MmapOptions::new().map` call written out
 /// at each loader -- is one of the two places in this crate a checkpoint
 /// mapping is constructed (see [`map_after_untrusted_open`] for the other).
-/// Folding the map and the post-map recheck into this module makes "guarded
-/// before mapped, rechecked after mapped" a property of *which function a
-/// caller calls*, not a convention each loader has to reproduce correctly on
-/// its own -- the property this module exists to enforce no longer depends
-/// on an external scan finding every call site that got it right.
+/// Taking `&TrustedMmapFile` rather than separate `file`/`prior`/`path`
+/// parameters (the previous shape) makes "guarded before mapped, rechecked
+/// after mapped" a property the type system enforces, not one this
+/// function's own body merely happens to implement correctly: there is no
+/// `TrustedMmapFile` value that has not been through
+/// [`open_trusted_mmap_file`]'s mode/uid/ACL and parent-directory checks, so
+/// there is no call to this function that can skip them -- previously
+/// nothing stopped a caller from invoking this with an ungated `file`
+/// paired with that same file's own metadata as `prior`, which
+/// [`verify_mmap_target_unchanged`] cannot distinguish from a genuinely
+/// guarded-then-unchanged file. See [`TrustedMmapFile`]'s doc comment for
+/// that defeat in full.
 ///
-/// A caller that needs to read `file`'s contents (a Q4/Q3 header, for
+/// A caller that needs to read the file's contents (a Q4/Q3 header, for
 /// instance) before the mapping is created does so between its
-/// `open_trusted_mmap_file` call and this one; nothing about that ordering
-/// is checked here, since a plain `std::fs::File` read has no bearing on the
-/// mmap trust boundary this module defends.
+/// `open_trusted_mmap_file` call and this one, via
+/// [`TrustedMmapFile::file_mut`]; nothing about that ordering is checked
+/// here, since a plain `std::fs::File` read has no bearing on the mmap
+/// trust boundary this module defends.
 #[cfg_attr(not(feature = "metal-gpu"), allow(dead_code))]
-pub(crate) fn map_and_verify_trusted(
-    file: &File,
-    prior: &std::fs::Metadata,
-    path: &Path,
-) -> Result<Mmap, String> {
-    // SAFETY: `file` was opened and trust-gated by `open_trusted_mmap_file`
-    // (the caller's obligation, documented on this function); the model file
-    // must not be mutated while this process runs, the same invariant every
-    // mmap site in this crate relies on.
-    let mmap = unsafe { Mmap::map(file) }
-        .map_err(|e| format!("failed to mmap {}: {e}", path.display()))?;
-    verify_mmap_target_unchanged(file, prior, path)?;
+pub(crate) fn map_and_verify_trusted(handle: &TrustedMmapFile) -> Result<Mmap, String> {
+    // SAFETY: `handle` is a `TrustedMmapFile`, and `open_trusted_mmap_file`
+    // is the only function that can construct one -- its fields are private
+    // to this module, so nothing outside it can assemble a `TrustedMmapFile`
+    // from a `file` that has not been through `open_trusted_mmap_file`'s
+    // mode/uid/ACL and parent-directory trust checks. This SAFETY argument
+    // rests on that type invariant, not on a caller's documented obligation
+    // to call the right function first. The model file must not be mutated
+    // while this process runs, the same residual invariant every mmap site
+    // in this crate relies on (see the module doc comment's
+    // "Trust-boundary scope" section).
+    let mmap = unsafe { Mmap::map(&handle.file) }
+        .map_err(|e| format!("failed to mmap {}: {e}", handle.path.display()))?;
+    verify_mmap_target_unchanged(&handle.file, &handle.prior, &handle.path)?;
     Ok(mmap)
 }
 
@@ -1610,12 +1680,12 @@ mod tests {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
             .expect("chmod 0o600");
 
-        let (file, meta) =
+        let handle =
             open_trusted_mmap_file(&path).expect("a regular owner-only file must be accepted");
-        assert!(meta.is_file());
+        assert!(handle.prior.is_file());
         assert_eq!(
-            file.metadata().expect("stat returned file").len(),
-            meta.len()
+            handle.file.metadata().expect("stat returned file").len(),
+            handle.prior.len()
         );
     }
 
@@ -1667,10 +1737,9 @@ mod tests {
         let path = tmp.path().join("truncate_race.q4");
         std::fs::write(&path, vec![0xABu8; 4096]).expect("write fixture");
 
-        let (file, prior_meta) =
-            open_trusted_mmap_file(&path).expect("open + trust-gate the fixture");
+        let handle = open_trusted_mmap_file(&path).expect("open + trust-gate the fixture");
         // SAFETY: read-only mmap of a tempfile this test alone controls.
-        let _mmap = unsafe { memmap2::MmapOptions::new().map(&file) }.expect("mmap fixture");
+        let _mmap = unsafe { memmap2::MmapOptions::new().map(&handle.file) }.expect("mmap fixture");
 
         // Simulate a writer truncating the file in the window between the
         // pre-map stat captured above and this recheck -- the exact race
@@ -1682,7 +1751,7 @@ mod tests {
             .set_len(4096 - 8)
             .expect("truncate fixture in place");
 
-        let result = verify_mmap_target_unchanged(&file, &prior_meta, &path);
+        let result = verify_mmap_target_unchanged(&handle.file, &handle.prior, &handle.path);
         assert!(
             result.is_err(),
             "a size change between the pre-map stat and this recheck must be rejected"
@@ -1704,12 +1773,11 @@ mod tests {
         let path = tmp.path().join("unchanged.q4");
         std::fs::write(&path, vec![0xCDu8; 4096]).expect("write fixture");
 
-        let (file, prior_meta) =
-            open_trusted_mmap_file(&path).expect("open + trust-gate the fixture");
-        let _mmap = unsafe { memmap2::MmapOptions::new().map(&file) }.expect("mmap fixture");
+        let handle = open_trusted_mmap_file(&path).expect("open + trust-gate the fixture");
+        let _mmap = unsafe { memmap2::MmapOptions::new().map(&handle.file) }.expect("mmap fixture");
 
         assert!(
-            verify_mmap_target_unchanged(&file, &prior_meta, &path).is_ok(),
+            verify_mmap_target_unchanged(&handle.file, &handle.prior, &handle.path).is_ok(),
             "a file untouched between the pre-map stat and the post-map recheck must be accepted"
         );
     }

--- a/crates/inference/src/weights/mmap_trust.rs
+++ b/crates/inference/src/weights/mmap_trust.rs
@@ -482,20 +482,19 @@ unsafe extern "C" {
 /// necessarily been through [`open_trusted_mmap_file`]'s mode/uid/ACL and
 /// parent-directory checks, because there is no other way to build one.
 ///
-/// [`file_mut`](Self::file_mut) hands out a mutable borrow of the guarded
-/// file so a caller can read a header (Q4/Q3 preflight) between the
-/// trust-gated open and the mapping -- reading bytes off an already-open,
-/// already-guarded fd has no bearing on the mmap trust boundary this module
-/// enforces, only *mapping* does, and mapping stays reachable solely through
-/// [`map_and_verify_trusted`], which this type provides no way around: it is
-/// the only function that can see `prior` or construct a `Mmap` from
-/// `file`. This is not a wider exposure than the type it replaces already
-/// had -- the previous `(File, Metadata)` tuple handed the same `File` to
-/// callers just as directly, governed by the same lexical
-/// `only_the_mmap_trust_boundary_names_a_construction_api` contract test
-/// that still catches a caller writing `Mmap::map`/`MmapOptions` literally
-/// against that borrowed file outside this module; nothing about exposing
-/// `file_mut` changes that contract's coverage.
+/// This module hands out no `File`, `&File`, or `&mut File` for this type --
+/// not even to a `pub(crate)` sibling. A caller that needs to read a header
+/// (Q4/Q3 preflight) between the trust-gated open and the mapping does so
+/// through [`std::io::Read`] and [`std::io::Seek`], which this type
+/// implements by delegating to the private `file` field, plus
+/// [`len`](Self::len) for the file's byte length. None of those three grant
+/// a route to `memmap2::Mmap::map`, whose `MmapAsRawDesc` bound is satisfied
+/// by `&File` (and by a raw fd) but not by `&mut impl Read + Seek` or any
+/// borrow this type exposes -- so a caller can read the guarded bytes but
+/// cannot construct a mapping of them. Mapping stays reachable solely
+/// through [`map_and_verify_trusted`], which this type provides no way
+/// around: it is the only function that can see `prior` or construct a
+/// `Mmap` from `file`.
 #[derive(Debug)]
 #[cfg_attr(not(feature = "metal-gpu"), allow(dead_code))]
 pub(crate) struct TrustedMmapFile {
@@ -505,13 +504,30 @@ pub(crate) struct TrustedMmapFile {
 }
 
 impl TrustedMmapFile {
-    /// Mutable access to the guarded file for a header read (Q4/Q3
-    /// preflight) that must happen between the trust-gated open and the
-    /// mapping. See the type doc comment for why this does not reopen the
-    /// hole [`TrustedMmapFile`] exists to close.
+    /// The guarded file's current on-disk length, for a header parser that
+    /// needs to bounds-check a declared payload against the real file size
+    /// without a route to the `File` itself.
     #[cfg_attr(not(feature = "metal-gpu"), allow(dead_code))]
-    pub(crate) fn file_mut(&mut self) -> &mut File {
-        &mut self.file
+    pub(crate) fn len(&self) -> std::io::Result<u64> {
+        Ok(self.file.metadata()?.len())
+    }
+}
+
+/// Delegates to the private `file` field so a header parser can read the
+/// guarded bytes without ever holding a `File`, `&File`, or `&mut File` --
+/// `Read` alone cannot satisfy `memmap2`'s `MmapAsRawDesc` bound, so this
+/// impl grants no route to a mapping.
+impl std::io::Read for TrustedMmapFile {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        std::io::Read::read(&mut self.file, buf)
+    }
+}
+
+/// Delegates to the private `file` field for the same reason [`Read`](std::io::Read)
+/// does above: a header parser needs to seek, not map.
+impl std::io::Seek for TrustedMmapFile {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        std::io::Seek::seek(&mut self.file, pos)
     }
 }
 
@@ -753,22 +769,31 @@ pub(crate) fn verify_mmap_target_unchanged(
 ///
 /// A caller that needs to read the file's contents (a Q4/Q3 header, for
 /// instance) before the mapping is created does so between its
-/// `open_trusted_mmap_file` call and this one, via
-/// [`TrustedMmapFile::file_mut`]; nothing about that ordering is checked
-/// here, since a plain `std::fs::File` read has no bearing on the mmap
-/// trust boundary this module defends.
+/// `open_trusted_mmap_file` call and this one, via [`std::io::Read`] and
+/// [`std::io::Seek`] on the `&mut TrustedMmapFile` itself; nothing about
+/// that ordering is checked here, since reading bytes off an already-open,
+/// already-guarded fd has no bearing on the mmap trust boundary this module
+/// defends, only *mapping* does -- and `Read`/`Seek` grant no route to a
+/// mapping, since `memmap2::Mmap::map` requires `&File` (or a raw
+/// descriptor), which this type never surrenders.
 #[cfg_attr(not(feature = "metal-gpu"), allow(dead_code))]
 pub(crate) fn map_and_verify_trusted(handle: &TrustedMmapFile) -> Result<Mmap, String> {
-    // SAFETY: `handle` is a `TrustedMmapFile`, and `open_trusted_mmap_file`
-    // is the only function that can construct one -- its fields are private
-    // to this module, so nothing outside it can assemble a `TrustedMmapFile`
-    // from a `file` that has not been through `open_trusted_mmap_file`'s
-    // mode/uid/ACL and parent-directory trust checks. This SAFETY argument
-    // rests on that type invariant, not on a caller's documented obligation
-    // to call the right function first. The model file must not be mutated
-    // while this process runs, the same residual invariant every mmap site
-    // in this crate relies on (see the module doc comment's
-    // "Trust-boundary scope" section).
+    // SAFETY: this function is the only place in the crate that can name
+    // `handle.file` -- the field is private to this module, `TrustedMmapFile`
+    // has no public constructor besides `open_trusted_mmap_file`, and the
+    // type exposes no method, trait impl, or `Deref` that hands back a
+    // `File`, `&File`, `&mut File`, or raw descriptor (its only accessors are
+    // `len`, `Read`, and `Seek`, none of which satisfy `memmap2`'s
+    // `MmapAsRawDesc` bound). So every `Mmap::map` call reachable from a
+    // `TrustedMmapFile` runs through this function, on a `file` that
+    // `open_trusted_mmap_file` has already put through its mode/uid/ACL and
+    // parent-directory trust checks -- the invariant is now carried by the
+    // type's field privacy plus its accessor surface, not by a caller's
+    // documented obligation to call the right function first. What this does
+    // NOT enforce: same-UID mutation through a second fd the owning process
+    // itself opens, and a foreign principal that already held a writable fd
+    // before this gate's hardening took effect, remain accepted residual
+    // risk -- see the module doc comment's "Trust-boundary scope" section.
     let mmap = unsafe { Mmap::map(&handle.file) }
         .map_err(|e| format!("failed to mmap {}: {e}", handle.path.display()))?;
     verify_mmap_target_unchanged(&handle.file, &handle.prior, &handle.path)?;
@@ -783,16 +808,44 @@ pub(crate) fn map_and_verify_trusted(handle: &TrustedMmapFile) -> Result<Mmap, S
 ///
 /// This is the second (and last) place in this crate a checkpoint mapping is
 /// constructed -- see [`map_and_verify_trusted`] for the `open_trusted_mmap_file`
-/// flavor. Folding the guard call and the map into one function here keeps
-/// the same structural guarantee: a caller cannot reach a mapping of `file`
-/// without this function having run the guard against it first.
+/// flavor. Folding the snapshot, guard, map, and recheck into one function
+/// here keeps the same structural guarantee that flavor gets from
+/// [`TrustedMmapFile`]: a caller cannot reach a mapping of `file` without
+/// this function having run the guard against it first, and the mapping is
+/// rechecked against a pre-guard metadata snapshot exactly as
+/// [`map_and_verify_trusted`] rechecks against the snapshot
+/// `open_trusted_mmap_file` captured -- the two producers were asymmetric
+/// before this fix, with only the `open_trusted_mmap_file` flavor rechecking
+/// post-map identity; this closes that gap.
 pub(crate) fn map_after_untrusted_open(file: &File, path: &Path) -> Result<Mmap, String> {
+    // Snapshot before the guard, matching `open_trusted_mmap_file`'s
+    // stat-then-check order, so the post-map recheck below has a baseline
+    // taken before any of this function's own work could observe a change.
+    let prior = file
+        .metadata()
+        .map_err(|e| format!("failed to stat {}: {e}", path.display()))?;
     reject_if_open_mmap_file_untrusted(file, path)?;
-    // SAFETY: `file` was just trust-gated by `reject_if_open_mmap_file_untrusted`
-    // above, on the same descriptor; the model file must not be mutated while
-    // this process runs, the same invariant every mmap site in this crate
-    // relies on.
-    unsafe { Mmap::map(file) }.map_err(|e| format!("failed to mmap {}: {e}", path.display()))
+    map_and_recheck(file, &prior, path)
+}
+
+/// Map `file` and immediately run the post-map identity recheck against
+/// `prior`. Factored out of [`map_after_untrusted_open`] so a caller who
+/// already ran the guard on a stale snapshot can be exercised -- this
+/// module's own regression test drives this exact "map, then recheck"
+/// sequence with a truncation injected between the guard and this call,
+/// the same shape [`map_and_verify_trusted`] gets for free from taking an
+/// already-guarded [`TrustedMmapFile`].
+fn map_and_recheck(file: &File, prior: &std::fs::Metadata, path: &Path) -> Result<Mmap, String> {
+    // SAFETY: the caller ran `reject_if_open_mmap_file_untrusted` against
+    // `file` before calling this, on the same descriptor; `prior` is the
+    // metadata snapshot taken before that guard ran, so the recheck below
+    // catches a truncate-or-replace race landed in the guard-to-map window.
+    // The model file must not be mutated while this process runs, the same
+    // residual invariant every mmap site in this crate relies on.
+    let mmap = unsafe { Mmap::map(file) }
+        .map_err(|e| format!("failed to mmap {}: {e}", path.display()))?;
+    verify_mmap_target_unchanged(file, prior, path)?;
+    Ok(mmap)
 }
 
 /// macOS extended-ACL inspection, isolated in its own submodule so the FFI
@@ -1779,6 +1832,74 @@ mod tests {
         assert!(
             verify_mmap_target_unchanged(&handle.file, &handle.prior, &handle.path).is_ok(),
             "a file untouched between the pre-map stat and the post-map recheck must be accepted"
+        );
+    }
+
+    // Regression for the second producer's post-map recheck (previously
+    // absent): `map_after_untrusted_open` -- the symlink-following flavor
+    // used by the F32/BF16 safetensors and QuaRot loaders -- must reject a
+    // truncate that lands between `reject_if_open_mmap_file_untrusted`
+    // passing and the mapping, exactly as `map_and_verify_trusted` already
+    // does for the `open_trusted_mmap_file` flavor. Drives
+    // `map_and_recheck` directly with a stale `prior` -- the same two
+    // building blocks `map_after_untrusted_open` composes -- because a test
+    // cannot otherwise land a mutation inside a single synchronous function
+    // call; this mirrors `verify_mmap_target_unchanged_rejects_a_truncate_after_validate_race`'s
+    // decomposition for the other producer.
+    #[test]
+    fn map_after_untrusted_open_rejects_a_truncate_between_guard_and_map() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().expect("tempdir create");
+        let path = tmp.path().join("untrusted_open_race.safetensors");
+        std::fs::write(&path, vec![0xEFu8; 4096]).expect("write fixture");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .expect("chmod 0o600");
+
+        let file = std::fs::File::open(&path).expect("open fixture");
+        let prior = file.metadata().expect("stat fixture");
+        reject_if_open_mmap_file_untrusted(&file, &path)
+            .expect("guard must accept an owner-only fixture");
+
+        // Simulate a writer truncating the file in the window between the
+        // guard passing and the map -- the exact race the missing recheck
+        // (Defect 2) previously let through unnoticed.
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("reopen fixture for truncation")
+            .set_len(4096 - 8)
+            .expect("truncate fixture in place");
+
+        let result = map_and_recheck(&file, &prior, &path);
+        assert!(
+            result.is_err(),
+            "a size change between the guard and the map must be rejected"
+        );
+        let msg = result.expect_err("checked is_err above");
+        assert!(
+            msg.contains("refusing to trust mapped") && msg.contains("size"),
+            "error must state the mapping is untrusted and cite the size mismatch; got: {msg}"
+        );
+    }
+
+    // Control for the above: an unmodified file must still be accepted by
+    // `map_after_untrusted_open` end-to-end, proving the added snapshot +
+    // recheck do not simply reject everything.
+    #[test]
+    fn map_after_untrusted_open_accepts_an_unmodified_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().expect("tempdir create");
+        let path = tmp.path().join("untrusted_open_unchanged.safetensors");
+        std::fs::write(&path, vec![0x11u8; 4096]).expect("write fixture");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .expect("chmod 0o600");
+
+        let file = std::fs::File::open(&path).expect("open fixture");
+        assert!(
+            map_after_untrusted_open(&file, &path).is_ok(),
+            "an owner-only, untouched file reached via a plain File::open must be accepted"
         );
     }
 

--- a/crates/inference/src/weights/mmap_trust.rs
+++ b/crates/inference/src/weights/mmap_trust.rs
@@ -7,9 +7,18 @@
 //! the process itself (or root, for shared root-deployed model directories)
 //! for as long as the mmap is alive, because a mutation after validation but
 //! before -- or during -- GPU reads bypasses every shape/bounds check this
-//! crate performs. [`open_trusted_mmap_file`] is the single chokepoint all
-//! five load sites route through so that guarantee holds identically for
-//! each of them.
+//! crate performs. [`open_trusted_mmap_file`] and
+//! [`reject_if_open_mmap_file_untrusted`] are the two chokepoints every load
+//! site routes through: the former opens the path itself under
+//! `O_NOFOLLOW`+`O_NONBLOCK` (Q4, Q3 -- lattice-produced quantized files that
+//! are never a HuggingFace hub-cache symlink), the latter takes a `File` the
+//! caller already opened by a path that must be allowed to resolve a
+//! final-component symlink (the F32/BF16 safetensors loader and the QuaRot
+//! reader both load HuggingFace hub-cache checkpoints, which symlink
+//! `model.safetensors` itself to blob storage -- `O_NOFOLLOW` would reject
+//! every such checkpoint outright). Both apply the identical mode/uid/ACL
+//! and parent-directory checks, so the trust guarantee holds the same way
+//! regardless of which open path a loader needs.
 //!
 //! POSIX mode bits + uid alone are not sufficient on macOS: an extended ACL
 //! (`chmod +a "someuser allow write" <path>`) can grant another principal
@@ -398,6 +407,32 @@ pub(crate) fn reject_if_mmap_file_trust_boundary_weak(
     _path: &Path,
 ) -> Result<(), String> {
     Ok(())
+}
+
+/// Run the same mode/uid/ACL and parent-directory trust checks
+/// [`open_trusted_mmap_file`] applies, against a `File` the caller already
+/// opened itself -- without that function's `O_NOFOLLOW`/`O_NONBLOCK`
+/// open-time guards.
+///
+/// Some loaders cannot use [`open_trusted_mmap_file`] because they must
+/// follow a symlink at the checkpoint's final path component: a
+/// HuggingFace-hub-cache checkpoint directory is a symlink farm
+/// (`snapshots/<rev>/model.safetensors -> ../../blobs/<sha>`), so
+/// `O_NOFOLLOW` would reject every hub-cache checkpoint outright, not just an
+/// attacker-planted one. Those loaders open the path with a plain, symlink-
+/// following `File::open` themselves (accepting the narrower TOCTOU window
+/// that implies, same as before this gate existed) and pass the resulting
+/// file here for the write-boundary checks this module exists to add:
+/// group/other-writable, foreign non-root ownership, a writable ancestor
+/// directory, or -- macOS only -- a permission-granting extended ACL. `file`
+/// must be the descriptor the caller is about to mmap (the fd-binding
+/// invariant applies here identically -- see the module doc comment), and
+/// `path` should be the resolved real path when the caller has one (so the
+/// parent-directory walk inspects the directories the mapped file actually
+/// lives under, not a symlink's location).
+pub(crate) fn reject_if_open_mmap_file_untrusted(file: &File, path: &Path) -> Result<(), String> {
+    reject_if_mmap_parent_directory_chain_weak(path)?;
+    reject_if_mmap_file_trust_boundary_weak(file, path)
 }
 
 /// `O_NONBLOCK`, `O_NOFOLLOW`, and `ELOOP` come from `libc` rather than a
@@ -1263,6 +1298,51 @@ mod tests {
         assert!(
             reject_if_mmap_file_trust_boundary_weak(&private_file, &path).is_ok(),
             "an owner-only file owned by the current process must be accepted"
+        );
+    }
+
+    // #1368: `reject_if_open_mmap_file_untrusted` is the chokepoint for
+    // loaders that must follow a final-component symlink (HuggingFace
+    // hub-cache checkpoints) and so cannot use `open_trusted_mmap_file`'s
+    // `O_NOFOLLOW` open. This proves it still closes the write-boundary gap
+    // that matters: a group/other-writable target file is refused even
+    // though the caller opened it through a symlink.
+    #[cfg(unix)]
+    #[test]
+    fn reject_if_open_mmap_file_untrusted_fails_closed_on_writable_file_reached_via_symlink() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::tempdir().expect("tempdir create");
+        let real_path = tmp.path().join("real_shard.safetensors");
+        std::fs::write(
+            &real_path,
+            b"not a real checkpoint, only permissions matter here",
+        )
+        .expect("write real fixture");
+        std::fs::set_permissions(&real_path, std::fs::Permissions::from_mode(0o666))
+            .expect("chmod 0o666");
+
+        let symlink_path = tmp.path().join("model.safetensors");
+        std::os::unix::fs::symlink(&real_path, &symlink_path).expect("create symlink fixture");
+
+        // The loaders this function serves open the path with a plain,
+        // symlink-following `File::open` -- not `open_trusted_mmap_file`,
+        // which would reject this symlink outright via `O_NOFOLLOW`.
+        let file = File::open(&symlink_path).expect("open through the symlink");
+        let result = reject_if_open_mmap_file_untrusted(&file, &symlink_path);
+        assert!(
+            result.is_err(),
+            "a group/other-writable target reached via a final-component symlink \
+             must still be refused"
+        );
+
+        std::fs::set_permissions(&real_path, std::fs::Permissions::from_mode(0o600))
+            .expect("chmod 0o600");
+        let private_file = File::open(&symlink_path).expect("reopen through the symlink");
+        assert!(
+            reject_if_open_mmap_file_untrusted(&private_file, &symlink_path).is_ok(),
+            "an owner-only target reached via a final-component symlink must be accepted -- \
+             this function exists precisely so the symlink itself is not the rejection cause"
         );
     }
 

--- a/crates/inference/src/weights/q3_weights.rs
+++ b/crates/inference/src/weights/q3_weights.rs
@@ -564,6 +564,19 @@ fn checked_alloc_bytes(
     Ok(bytes)
 }
 
+/// Byte length of `stream`, leaving its cursor position unchanged. `Seek`'s
+/// own `stream_len` is not yet stable (`seek_stream_len`,
+/// rust-lang/rust#59359), and this is the only length a generic
+/// `Read + Seek` bound can observe -- there is no `.metadata()` to call once
+/// the caller is no longer necessarily a concrete `std::fs::File`.
+fn stream_len<S: std::io::Seek>(stream: &mut S) -> std::io::Result<u64> {
+    use std::io::SeekFrom;
+    let cur = stream.stream_position()?;
+    let len = stream.seek(SeekFrom::End(0))?;
+    stream.seek(SeekFrom::Start(cur))?;
+    Ok(len)
+}
+
 /// Parse the header of a `.q3` file without reading the block payload.
 ///
 /// On return the file cursor is positioned at the start of the block data.
@@ -571,11 +584,11 @@ fn checked_alloc_bytes(
 /// # Errors
 ///
 /// Returns an error on I/O failure, unrecognized magic bytes, or unsupported version.
-pub fn read_q3_header(
-    file: &mut std::fs::File,
+pub fn read_q3_header<R: std::io::Read + std::io::Seek>(
+    file: &mut R,
 ) -> Result<Q3FileHeader, Box<dyn std::error::Error>> {
-    use std::io::{Read, Seek, SeekFrom};
-    let file_len = file.metadata()?.len();
+    use std::io::{Read, SeekFrom};
+    let file_len = stream_len(file)?;
 
     let (shape, original_len, payload_offset) = {
         let mut f = std::io::BufReader::new(&mut *file);

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -966,11 +966,11 @@ pub(crate) fn open_and_mmap_q4_file(
     expected_shape: Option<&[usize]>,
     check: Q4BlockCheck<'_>,
 ) -> Result<(Q4FileHeader, memmap2::Mmap, Option<Q4BlocksChecked>), String> {
-    let (mut file, metadata) = crate::weights::mmap_trust::open_trusted_mmap_file(path)?;
-    let header = validate_q4_file(&mut file, path, expected_shape)
+    let mut handle = crate::weights::mmap_trust::open_trusted_mmap_file(path)?;
+    let header = validate_q4_file(handle.file_mut(), path, expected_shape)
         .map_err(|e| format!("failed to validate Q4 payload {}: {e}", path.display()))?;
 
-    let mmap = crate::weights::mmap_trust::map_and_verify_trusted(&file, &metadata, path)?;
+    let mmap = crate::weights::mmap_trust::map_and_verify_trusted(&handle)?;
 
     let payload = mmap.get(header.payload_offset as usize..).ok_or_else(|| {
         format!(

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -970,12 +970,7 @@ pub(crate) fn open_and_mmap_q4_file(
     let header = validate_q4_file(&mut file, path, expected_shape)
         .map_err(|e| format!("failed to validate Q4 payload {}: {e}", path.display()))?;
 
-    // SAFETY: read-only mapping of a file this process does not mutate while
-    // running; the caller upholds the "model files are immutable for the
-    // process lifetime" invariant documented above.
-    let mmap = unsafe { memmap2::MmapOptions::new().map(&file) }
-        .map_err(|e| format!("failed to mmap {}: {e}", path.display()))?;
-    crate::weights::mmap_trust::verify_mmap_target_unchanged(&file, &metadata, path)?;
+    let mmap = crate::weights::mmap_trust::map_and_verify_trusted(&file, &metadata, path)?;
 
     let payload = mmap.get(header.payload_offset as usize..).ok_or_else(|| {
         format!(

--- a/crates/inference/src/weights/q4_weights.rs
+++ b/crates/inference/src/weights/q4_weights.rs
@@ -686,6 +686,19 @@ fn checked_alloc_bytes(
     Ok(bytes)
 }
 
+/// Byte length of `stream`, leaving its cursor position unchanged. `Seek`'s
+/// own `stream_len` is not yet stable (`seek_stream_len`,
+/// rust-lang/rust#59359), and this is the only length a generic
+/// `Read + Seek` bound can observe -- there is no `.metadata()` to call once
+/// the caller is no longer necessarily a concrete `std::fs::File`.
+fn stream_len<S: std::io::Seek>(stream: &mut S) -> std::io::Result<u64> {
+    use std::io::SeekFrom;
+    let cur = stream.stream_position()?;
+    let len = stream.seek(SeekFrom::End(0))?;
+    stream.seek(SeekFrom::Start(cur))?;
+    Ok(len)
+}
+
 /// Parse the header of a `.q4` file without reading the block payload.
 ///
 /// On return the file cursor is positioned at the start of the block data.
@@ -693,11 +706,11 @@ fn checked_alloc_bytes(
 /// # Errors
 ///
 /// Returns an error on I/O failure, unrecognized magic bytes, or unsupported version.
-pub fn read_q4_header(
-    file: &mut std::fs::File,
+pub fn read_q4_header<R: std::io::Read + std::io::Seek>(
+    file: &mut R,
 ) -> Result<Q4FileHeader, Box<dyn std::error::Error>> {
-    use std::io::{Read, Seek, SeekFrom};
-    let file_len = file.metadata()?.len();
+    use std::io::{Read, SeekFrom};
+    let file_len = stream_len(file)?;
 
     let (shape, original_len, payload_offset) = {
         let mut f = std::io::BufReader::new(&mut *file);
@@ -821,15 +834,15 @@ pub(crate) fn validate_q4_header_payload_bounds(
 /// Returns an error on I/O failure, unrecognized magic bytes, unsupported
 /// version, a truncated/oversized payload, or a shape mismatch against
 /// `expected_shape`.
-pub(crate) fn validate_q4_file(
-    file: &mut std::fs::File,
+pub(crate) fn validate_q4_file<R: std::io::Read + std::io::Seek>(
+    file: &mut R,
     path: &std::path::Path,
     expected_shape: Option<&[usize]>,
 ) -> Result<Q4FileHeader, Box<dyn std::error::Error>> {
-    use std::io::{Seek, SeekFrom};
+    use std::io::SeekFrom;
 
     let header = read_q4_header(file)?;
-    let file_len = file.metadata()?.len();
+    let file_len = stream_len(file)?;
     validate_q4_header_payload_bounds(&header, file_len, path)?;
 
     if let Some(expected_shape) = expected_shape {
@@ -967,7 +980,7 @@ pub(crate) fn open_and_mmap_q4_file(
     check: Q4BlockCheck<'_>,
 ) -> Result<(Q4FileHeader, memmap2::Mmap, Option<Q4BlocksChecked>), String> {
     let mut handle = crate::weights::mmap_trust::open_trusted_mmap_file(path)?;
-    let header = validate_q4_file(handle.file_mut(), path, expected_shape)
+    let header = validate_q4_file(&mut handle, path, expected_shape)
         .map_err(|e| format!("failed to validate Q4 payload {}: {e}", path.display()))?;
 
     let mmap = crate::weights::mmap_trust::map_and_verify_trusted(&handle)?;

--- a/crates/inference/tests/mmap_trust_boundary_contract.rs
+++ b/crates/inference/tests/mmap_trust_boundary_contract.rs
@@ -1,0 +1,288 @@
+//! Contract test for #1368: every site in this crate that constructs a
+//! memory map from a checkpoint file (`memmap2::Mmap::map(&file)` or
+//! `memmap2::MmapOptions::new().map(&file)`) must first call one of this
+//! crate's two mmap trust-boundary chokepoints --
+//! [`lattice_inference`]'s `weights::mmap_trust::open_trusted_mmap_file` or
+//! `reject_if_open_mmap_file_untrusted` -- in the same enclosing function, or
+//! carry an explicit, reviewed [`MmapConstructionExemption`] naming why not.
+//!
+//! Modeled on `metal_measurement_lock_contract.rs`'s construction-site
+//! inventory: a site is named by the program structure enclosing it
+//! (`mod`/`impl`/`fn` path, plus an ordinal disambiguating repeated calls in
+//! the same function) rather than by source line/column, so an edit that
+//! only shifts line numbers cannot silently invalidate an exemption or
+//! duplicate an entry -- a position-keyed guard has to be repaired by
+//! exactly the motion that would silence it. The full discovered inventory
+//! (guarded sites plus exempted sites) is asserted against a declared
+//! expected set so an added or removed construction site always requires a
+//! conscious update here, whether or not it happens to be guarded.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+use syn::visit::{self, Visit};
+use syn::{Expr, ExprCall, ExprMethodCall, ImplItem, Item};
+
+/// Free functions this crate's mmap trust boundary exposes. A call to either
+/// one, anywhere in the function enclosing a construction site, counts as
+/// that site being guarded.
+const GUARD_FUNCTION_NAMES: &[&str] = &[
+    "open_trusted_mmap_file",
+    "reject_if_open_mmap_file_untrusted",
+];
+
+/// A construction site exempted from the guard-call requirement, keyed by
+/// program structure (see module doc comment), with a reviewed reason on
+/// record for why routing it through a guard call directly is unnecessary
+/// or incorrect.
+struct MmapConstructionExemption {
+    site: &'static str,
+    reason: &'static str,
+}
+
+const MMAP_CONSTRUCTION_EXEMPTIONS: &[MmapConstructionExemption] = &[MmapConstructionExemption {
+    site: "src/weights/f32_weights.rs::SafetensorsFile::from_open_file::Mmap::map()#1",
+    reason: "from_open_file takes an already-open File specifically so it never re-opens \
+             by path (reopening would reintroduce the window between open and read its own \
+             doc comment describes). Its only callers -- SafetensorsFile::open and \
+             ShardedSafetensors::open_shard (via open_manifest_entry_once) -- both call \
+             reject_if_open_mmap_file_untrusted on that same File before handing it here, \
+             so the guard call sits in the caller, not in this function.",
+}];
+
+/// The complete population of mmap-construction sites this crate contains,
+/// whether guarded directly or exempted above. Discovering a site not in
+/// this set, or failing to discover one that is, fails the contract --
+/// forcing a conscious update here for any added, removed, or newly
+/// (un)guarded site.
+const EXPECTED_MMAP_CONSTRUCTION_SITES: &[&str] = &[
+    "src/forward/metal_qwen35.rs::inner::mmap_q3_weight::MmapOptions::new().map()#1",
+    "src/quant/quarot/io.rs::Shard::open::Mmap::map()#1",
+    "src/weights/f32_weights.rs::SafetensorsFile::from_open_file::Mmap::map()#1",
+    "src/weights/mmap_trust.rs::tests::verify_mmap_target_unchanged_accepts_an_unmodified_file::MmapOptions::new().map()#1",
+    "src/weights/mmap_trust.rs::tests::verify_mmap_target_unchanged_rejects_a_truncate_after_validate_race::MmapOptions::new().map()#1",
+    "src/weights/q4_weights.rs::open_and_mmap_q4_file::MmapOptions::new().map()#1",
+];
+
+fn rust_sources_under(root: &Path) -> Vec<PathBuf> {
+    let mut pending = vec![root.to_path_buf()];
+    let mut sources = Vec::new();
+    while let Some(dir) = pending.pop() {
+        for entry in std::fs::read_dir(&dir).expect("read source directory") {
+            let path = entry.expect("read source entry").path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                sources.push(path);
+            }
+        }
+    }
+    sources.sort();
+    sources
+}
+
+fn path_ends_with(path: &syn::Path, tail: &[&str]) -> bool {
+    let segments: Vec<String> = path.segments.iter().map(|s| s.ident.to_string()).collect();
+    if segments.len() < tail.len() {
+        return false;
+    }
+    segments[segments.len() - tail.len()..]
+        .iter()
+        .zip(tail.iter())
+        .all(|(have, want)| have == want)
+}
+
+/// The receiver type name for an `impl` block, mirroring the sibling Metal
+/// contract test's `impl_self_type_label` so a method's stable key includes
+/// its type even when two `impl` blocks define a method with the same name.
+fn impl_self_type_label(self_ty: &syn::Type) -> String {
+    if let syn::Type::Path(type_path) = self_ty
+        && let Some(segment) = type_path.path.segments.last()
+    {
+        return segment.ident.to_string();
+    }
+    "impl".to_string()
+}
+
+/// Every free function and `impl` method in a parsed file, named by its
+/// enclosing `mod`/`impl` path (matching `EXPECTED_MMAP_CONSTRUCTION_SITES`'
+/// key format) and paired with its body for the two finder visitors below.
+fn collect_functions<'a>(
+    items: &'a [Item],
+    path: &mut Vec<String>,
+    out: &mut Vec<(String, &'a syn::Block)>,
+) {
+    for item in items {
+        match item {
+            Item::Fn(function) => {
+                path.push(function.sig.ident.to_string());
+                out.push((path.join("::"), &function.block));
+                path.pop();
+            }
+            Item::Mod(module) => {
+                if let Some((_, contents)) = &module.content {
+                    path.push(module.ident.to_string());
+                    collect_functions(contents, path, out);
+                    path.pop();
+                }
+            }
+            Item::Impl(item_impl) => {
+                path.push(impl_self_type_label(&item_impl.self_ty));
+                for impl_item in &item_impl.items {
+                    if let ImplItem::Fn(method) = impl_item {
+                        path.push(method.sig.ident.to_string());
+                        out.push((path.join("::"), &method.block));
+                        path.pop();
+                    }
+                }
+                path.pop();
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Finds every `Mmap::map(..)` / `MmapOptions::new().map(..)` construction
+/// call in a function body, in visitation order, labeled by which of the two
+/// idioms matched.
+#[derive(Default)]
+struct MmapConstructionFinder {
+    sites: Vec<&'static str>,
+}
+
+impl<'ast> Visit<'ast> for MmapConstructionFinder {
+    fn visit_expr_call(&mut self, node: &'ast ExprCall) {
+        if let Expr::Path(callee) = &*node.func
+            && path_ends_with(&callee.path, &["Mmap", "map"])
+        {
+            self.sites.push("Mmap::map()");
+        }
+        visit::visit_expr_call(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
+        if node.method == "map"
+            && let Expr::Call(receiver_call) = &*node.receiver
+            && receiver_call.args.is_empty()
+            && let Expr::Path(receiver_callee) = &*receiver_call.func
+            && path_ends_with(&receiver_callee.path, &["MmapOptions", "new"])
+        {
+            self.sites.push("MmapOptions::new().map()");
+        }
+        visit::visit_expr_method_call(self, node);
+    }
+}
+
+/// Whether a function body calls one of `GUARD_FUNCTION_NAMES`, anywhere in
+/// its body (including nested blocks/closures) -- these loaders are
+/// straight-line open-then-mmap functions, so "called somewhere in this
+/// function" is the property the mutation-arm test in #1368's PR actually
+/// exercises, not a stricter before/after ordering.
+#[derive(Default)]
+struct GuardCallFinder {
+    found: bool,
+}
+
+impl<'ast> Visit<'ast> for GuardCallFinder {
+    fn visit_expr_call(&mut self, node: &'ast ExprCall) {
+        if let Expr::Path(callee) = &*node.func
+            && let Some(last) = callee.path.segments.last()
+            && GUARD_FUNCTION_NAMES.contains(&last.ident.to_string().as_str())
+        {
+            self.found = true;
+        }
+        visit::visit_expr_call(self, node);
+    }
+}
+
+#[test]
+fn every_mmap_construction_site_is_guarded_or_explicitly_exempted() {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let src_root = manifest_dir.join("src");
+
+    let mut discovered: BTreeSet<String> = BTreeSet::new();
+    let mut violations: Vec<String> = Vec::new();
+
+    for path in rust_sources_under(&src_root) {
+        let relative = path
+            .strip_prefix(manifest_dir)
+            .expect("source under manifest directory")
+            .to_string_lossy()
+            .into_owned();
+        let source = std::fs::read_to_string(&path)
+            .unwrap_or_else(|reason| panic!("could not read {relative}: {reason}"));
+        let syntax = syn::parse_file(&source).unwrap_or_else(|reason| {
+            panic!("{relative}: Rust syntax could not be parsed: {reason}")
+        });
+
+        let mut functions = Vec::new();
+        let mut path_stack = Vec::new();
+        collect_functions(&syntax.items, &mut path_stack, &mut functions);
+
+        for (function_path, body) in functions {
+            let mut construction = MmapConstructionFinder::default();
+            construction.visit_block(body);
+            if construction.sites.is_empty() {
+                continue;
+            }
+
+            let mut guard = GuardCallFinder::default();
+            guard.visit_block(body);
+
+            let mut ordinals: BTreeMap<&str, usize> = BTreeMap::new();
+            for selector in &construction.sites {
+                let ordinal = ordinals.entry(selector).or_insert(0);
+                *ordinal += 1;
+                let key = format!("{relative}::{function_path}::{selector}#{ordinal}");
+                discovered.insert(key.clone());
+
+                if !guard.found
+                    && !MMAP_CONSTRUCTION_EXEMPTIONS
+                        .iter()
+                        .any(|exemption| exemption.site == key)
+                {
+                    violations.push(key);
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "mmap construction site(s) with neither a trust-boundary guard call in the same \
+         function nor a reviewed MmapConstructionExemption:\n{}",
+        violations.join("\n")
+    );
+
+    let expected: BTreeSet<String> = EXPECTED_MMAP_CONSTRUCTION_SITES
+        .iter()
+        .map(|site| (*site).to_string())
+        .collect();
+    assert_eq!(
+        discovered, expected,
+        "mmap construction-site inventory changed; classify every added or removed site \
+         explicitly -- guard it with open_trusted_mmap_file / \
+         reject_if_open_mmap_file_untrusted, or add a reviewed MmapConstructionExemption \
+         naming why not, then update EXPECTED_MMAP_CONSTRUCTION_SITES"
+    );
+}
+
+/// Every exemption entry must actually correspond to a discovered
+/// construction site: a stale entry (the site was fixed, renamed, or
+/// deleted) would silently stop meaning anything.
+#[test]
+fn every_exemption_matches_a_currently_expected_site() {
+    let expected: BTreeSet<&str> = EXPECTED_MMAP_CONSTRUCTION_SITES.iter().copied().collect();
+    for exemption in MMAP_CONSTRUCTION_EXEMPTIONS {
+        assert!(
+            expected.contains(exemption.site),
+            "exemption `{}` does not match any site in EXPECTED_MMAP_CONSTRUCTION_SITES -- \
+             it is stale and should be removed",
+            exemption.site
+        );
+        assert!(
+            !exemption.reason.is_empty(),
+            "exemption `{}` must state a reason",
+            exemption.site
+        );
+    }
+}

--- a/crates/inference/tests/mmap_trust_boundary_contract.rs
+++ b/crates/inference/tests/mmap_trust_boundary_contract.rs
@@ -1,10 +1,15 @@
 //! Contract test for #1368: every site in this crate that constructs a
 //! memory map from a checkpoint file (`memmap2::Mmap::map(&file)` or
-//! `memmap2::MmapOptions::new().map(&file)`) must first call one of this
-//! crate's two mmap trust-boundary chokepoints --
-//! [`lattice_inference`]'s `weights::mmap_trust::open_trusted_mmap_file` or
-//! `reject_if_open_mmap_file_untrusted` -- in the same enclosing function, or
-//! carry an explicit, reviewed [`MmapConstructionExemption`] naming why not.
+//! `memmap2::MmapOptions::new().map(&file)`) must call one of this crate's
+//! two mmap trust-boundary chokepoints -- [`lattice_inference`]'s
+//! `weights::mmap_trust::open_trusted_mmap_file` or
+//! `reject_if_open_mmap_file_untrusted` -- **earlier in the same enclosing
+//! function, on a path that necessarily executes before the construction
+//! call** (see [`walk_expr`]'s doc comment for exactly what that does and
+//! does not cover), or carry an explicit, reviewed
+//! [`MmapConstructionExemption`] naming why not. A guard call that runs
+//! after the construction call, or only on a sibling branch that does not
+//! run before it, does not satisfy this.
 //!
 //! Modeled on `metal_measurement_lock_contract.rs`'s construction-site
 //! inventory: a site is named by the program structure enclosing it
@@ -19,8 +24,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use syn::visit::{self, Visit};
-use syn::{Expr, ExprCall, ExprMethodCall, ImplItem, Item};
+use syn::{Block, Expr, ExprCall, ExprMethodCall, ImplItem, Item, Stmt};
 
 /// Free functions this crate's mmap trust boundary exposes. A call to either
 /// one, anywhere in the function enclosing a construction site, counts as
@@ -141,57 +145,245 @@ fn collect_functions<'a>(
     }
 }
 
-/// Finds every `Mmap::map(..)` / `MmapOptions::new().map(..)` construction
-/// call in a function body, in visitation order, labeled by which of the two
-/// idioms matched.
-#[derive(Default)]
-struct MmapConstructionFinder {
-    sites: Vec<&'static str>,
+/// Whether an `Expr::Call` node calls one of [`GUARD_FUNCTION_NAMES`].
+fn is_guard_call(call: &ExprCall) -> bool {
+    matches!(&*call.func, Expr::Path(callee)
+    if callee.path.segments.last().is_some_and(|segment| {
+        GUARD_FUNCTION_NAMES.contains(&segment.ident.to_string().as_str())
+    }))
 }
 
-impl<'ast> Visit<'ast> for MmapConstructionFinder {
-    fn visit_expr_call(&mut self, node: &'ast ExprCall) {
-        if let Expr::Path(callee) = &*node.func
-            && path_ends_with(&callee.path, &["Mmap", "map"])
-        {
-            self.sites.push("Mmap::map()");
-        }
-        visit::visit_expr_call(self, node);
-    }
+/// Whether an `Expr::Call` node is the free-function `Mmap::map(..)` mmap
+/// construction idiom.
+fn is_mmap_map_call(call: &ExprCall) -> bool {
+    matches!(&*call.func, Expr::Path(callee) if path_ends_with(&callee.path, &["Mmap", "map"]))
+}
 
-    fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
-        if node.method == "map"
-            && let Expr::Call(receiver_call) = &*node.receiver
-            && receiver_call.args.is_empty()
-            && let Expr::Path(receiver_callee) = &*receiver_call.func
-            && path_ends_with(&receiver_callee.path, &["MmapOptions", "new"])
-        {
-            self.sites.push("MmapOptions::new().map()");
+/// Whether an `Expr::MethodCall` node is the `MmapOptions::new().map(..)`
+/// mmap construction idiom.
+fn is_mmap_options_map_call(method_call: &ExprMethodCall) -> bool {
+    method_call.method == "map"
+        && matches!(&*method_call.receiver, Expr::Call(receiver_call)
+            if receiver_call.args.is_empty()
+                && matches!(&*receiver_call.func, Expr::Path(receiver_callee)
+                    if path_ends_with(&receiver_callee.path, &["MmapOptions", "new"])))
+}
+
+/// A discovered mmap construction call, in the order [`walk_expr`] visits
+/// it, paired with whether a guard call was seen on a path that necessarily
+/// executes before it.
+struct SiteObservation {
+    selector: &'static str,
+    dominated_by_guard: bool,
+}
+
+/// Walks an expression in source order, threading a `guarded` flag that
+/// becomes (and stays) `true` once a guard call has been seen on a path that
+/// *necessarily* executes before the current point -- the "first" the module
+/// doc comment requires. This is a textual/structural approximation of
+/// control-flow dominance, not a real control-flow-graph analysis; it is
+/// sufficient for this crate's loaders, which are straight-line
+/// open-then-map functions, but the following cases are explicitly NOT
+/// treated as dominance:
+///
+/// - **`if`/`else` branches and `match` arms.** A guard call inside one arm
+///   is scoped to that arm alone: it is never credited to a sibling arm, nor
+///   to the statements that follow the conditional, because the *other* arm
+///   might have run instead. This is what catches "one branch guards,
+///   another maps unguarded". A conditional that guards on *every* arm is
+///   (conservatively) still not credited outside the conditional -- doing
+///   that soundly needs real control-flow reachability, which this AST walk
+///   does not build.
+/// - **Loop bodies** (`loop`/`while`/`for`). A loop may run zero times, so a
+///   guard call inside one is never credited to code after the loop, and a
+///   site inside the loop only sees guard calls from strictly before the
+///   loop, never from an earlier iteration of the same loop.
+/// - **Closures and `async`/`const` blocks.** Their bodies run later (or not
+///   at all) relative to the enclosing function, so each starts its own,
+///   independently threaded `guarded = false` and never reads or writes the
+///   surrounding flow's flag in either direction.
+/// - **Early `return`/`break`.** This walk has no notion of unreachable code
+///   after a diverging expression: it keeps threading `guarded` through the
+///   statements that textually follow one in the same block. A guard call
+///   placed after an unconditional `return` would (incorrectly) still be
+///   credited to sites after it, even though that guard call can never
+///   actually run. None of this crate's loaders do that; it is recorded here
+///   as a known gap rather than silently assumed away.
+///
+/// What DOES count as "necessarily executes before" and so threads the flag
+/// straight through: sequential statements in the same block, `unsafe { .. }`
+/// and bare `{ .. }` blocks, `?`, casts, references, field/index access, and
+/// method-call/call receivers and arguments (in left-to-right evaluation
+/// order), and binary/assignment operands.
+fn walk_expr(expr: &Expr, guarded_in: bool, sites: &mut Vec<SiteObservation>) -> bool {
+    match expr {
+        Expr::Block(block) => walk_block(&block.block, guarded_in, sites),
+        Expr::Unsafe(block) => walk_block(&block.block, guarded_in, sites),
+        Expr::Call(call) => {
+            let mut guarded = walk_expr(&call.func, guarded_in, sites);
+            for arg in &call.args {
+                guarded = walk_expr(arg, guarded, sites);
+            }
+            if is_mmap_map_call(call) {
+                sites.push(SiteObservation {
+                    selector: "Mmap::map()",
+                    dominated_by_guard: guarded,
+                });
+            }
+            if is_guard_call(call) {
+                guarded = true;
+            }
+            guarded
         }
-        visit::visit_expr_method_call(self, node);
+        Expr::MethodCall(method_call) => {
+            let mut guarded = walk_expr(&method_call.receiver, guarded_in, sites);
+            for arg in &method_call.args {
+                guarded = walk_expr(arg, guarded, sites);
+            }
+            if is_mmap_options_map_call(method_call) {
+                sites.push(SiteObservation {
+                    selector: "MmapOptions::new().map()",
+                    dominated_by_guard: guarded,
+                });
+            }
+            guarded
+        }
+        Expr::If(if_expr) => {
+            let guarded = walk_expr(&if_expr.cond, guarded_in, sites);
+            walk_block(&if_expr.then_branch, guarded, sites);
+            if let Some((_, else_expr)) = &if_expr.else_branch {
+                walk_expr(else_expr, guarded, sites);
+            }
+            guarded
+        }
+        Expr::Match(match_expr) => {
+            let guarded = walk_expr(&match_expr.expr, guarded_in, sites);
+            for arm in &match_expr.arms {
+                if let Some((_, guard_cond)) = &arm.guard {
+                    walk_expr(guard_cond, guarded, sites);
+                }
+                walk_expr(&arm.body, guarded, sites);
+            }
+            guarded
+        }
+        Expr::Loop(loop_expr) => {
+            walk_block(&loop_expr.body, guarded_in, sites);
+            guarded_in
+        }
+        Expr::While(while_expr) => {
+            let guarded = walk_expr(&while_expr.cond, guarded_in, sites);
+            walk_block(&while_expr.body, guarded, sites);
+            guarded_in
+        }
+        Expr::ForLoop(for_loop) => {
+            let guarded = walk_expr(&for_loop.expr, guarded_in, sites);
+            walk_block(&for_loop.body, guarded, sites);
+            guarded_in
+        }
+        Expr::Closure(closure) => {
+            walk_expr(&closure.body, false, sites);
+            guarded_in
+        }
+        Expr::Try(try_expr) => walk_expr(&try_expr.expr, guarded_in, sites),
+        Expr::Paren(paren) => walk_expr(&paren.expr, guarded_in, sites),
+        Expr::Group(group) => walk_expr(&group.expr, guarded_in, sites),
+        Expr::Reference(reference) => walk_expr(&reference.expr, guarded_in, sites),
+        Expr::Unary(unary) => walk_expr(&unary.expr, guarded_in, sites),
+        Expr::Cast(cast) => walk_expr(&cast.expr, guarded_in, sites),
+        Expr::Field(field) => walk_expr(&field.base, guarded_in, sites),
+        Expr::Await(await_expr) => walk_expr(&await_expr.base, guarded_in, sites),
+        Expr::Let(let_expr) => walk_expr(&let_expr.expr, guarded_in, sites),
+        Expr::Return(return_expr) => match &return_expr.expr {
+            Some(inner) => walk_expr(inner, guarded_in, sites),
+            None => guarded_in,
+        },
+        Expr::Break(break_expr) => match &break_expr.expr {
+            Some(inner) => walk_expr(inner, guarded_in, sites),
+            None => guarded_in,
+        },
+        Expr::Index(index) => {
+            let guarded = walk_expr(&index.expr, guarded_in, sites);
+            walk_expr(&index.index, guarded, sites)
+        }
+        Expr::Binary(binary) => {
+            let guarded = walk_expr(&binary.left, guarded_in, sites);
+            walk_expr(&binary.right, guarded, sites)
+        }
+        Expr::Assign(assign) => {
+            let guarded = walk_expr(&assign.left, guarded_in, sites);
+            walk_expr(&assign.right, guarded, sites)
+        }
+        Expr::Repeat(repeat) => {
+            let guarded = walk_expr(&repeat.expr, guarded_in, sites);
+            walk_expr(&repeat.len, guarded, sites)
+        }
+        Expr::Range(range) => {
+            let mut guarded = guarded_in;
+            if let Some(start) = &range.start {
+                guarded = walk_expr(start, guarded, sites);
+            }
+            if let Some(end) = &range.end {
+                guarded = walk_expr(end, guarded, sites);
+            }
+            guarded
+        }
+        Expr::Tuple(tuple) => {
+            let mut guarded = guarded_in;
+            for elem in &tuple.elems {
+                guarded = walk_expr(elem, guarded, sites);
+            }
+            guarded
+        }
+        Expr::Array(array) => {
+            let mut guarded = guarded_in;
+            for elem in &array.elems {
+                guarded = walk_expr(elem, guarded, sites);
+            }
+            guarded
+        }
+        Expr::Struct(struct_expr) => {
+            let mut guarded = guarded_in;
+            for field in &struct_expr.fields {
+                guarded = walk_expr(&field.expr, guarded, sites);
+            }
+            if let Some(rest) = &struct_expr.rest {
+                guarded = walk_expr(rest, guarded, sites);
+            }
+            guarded
+        }
+        // Every other expression kind (literals, paths, macros, `async`/
+        // `const` blocks, ...) is either a leaf with nothing to recurse into,
+        // or -- for `async`/`const` blocks -- runs later/independently like a
+        // closure and is out of scope for the loaders this test discovers.
+        _ => guarded_in,
     }
 }
 
-/// Whether a function body calls one of `GUARD_FUNCTION_NAMES`, anywhere in
-/// its body (including nested blocks/closures) -- these loaders are
-/// straight-line open-then-mmap functions, so "called somewhere in this
-/// function" is the property the mutation-arm test in #1368's PR actually
-/// exercises, not a stricter before/after ordering.
-#[derive(Default)]
-struct GuardCallFinder {
-    found: bool,
-}
-
-impl<'ast> Visit<'ast> for GuardCallFinder {
-    fn visit_expr_call(&mut self, node: &'ast ExprCall) {
-        if let Expr::Path(callee) = &*node.func
-            && let Some(last) = callee.path.segments.last()
-            && GUARD_FUNCTION_NAMES.contains(&last.ident.to_string().as_str())
-        {
-            self.found = true;
-        }
-        visit::visit_expr_call(self, node);
+/// Walks a block's statements in source order, threading `guarded` the same
+/// way [`walk_expr`] does.
+fn walk_block(block: &Block, guarded_in: bool, sites: &mut Vec<SiteObservation>) -> bool {
+    let mut guarded = guarded_in;
+    for stmt in &block.stmts {
+        guarded = match stmt {
+            Stmt::Local(local) => {
+                let mut guarded_after = guarded;
+                if let Some(init) = &local.init {
+                    guarded_after = walk_expr(&init.expr, guarded_after, sites);
+                    if let Some((_, diverge)) = &init.diverge {
+                        // `let ... else { diverge }`: the diverge block only
+                        // runs when the pattern does NOT match, so -- like an
+                        // `if`/`match` arm -- it is internal-only and never
+                        // propagated to the statements that follow.
+                        walk_expr(diverge, guarded_after, sites);
+                    }
+                }
+                guarded_after
+            }
+            Stmt::Expr(expr, _) => walk_expr(expr, guarded, sites),
+            Stmt::Macro(_) | Stmt::Item(_) => guarded,
+        };
     }
+    guarded
 }
 
 #[test]
@@ -219,23 +411,21 @@ fn every_mmap_construction_site_is_guarded_or_explicitly_exempted() {
         collect_functions(&syntax.items, &mut path_stack, &mut functions);
 
         for (function_path, body) in functions {
-            let mut construction = MmapConstructionFinder::default();
-            construction.visit_block(body);
-            if construction.sites.is_empty() {
+            let mut sites = Vec::new();
+            walk_block(body, false, &mut sites);
+            if sites.is_empty() {
                 continue;
             }
 
-            let mut guard = GuardCallFinder::default();
-            guard.visit_block(body);
-
             let mut ordinals: BTreeMap<&str, usize> = BTreeMap::new();
-            for selector in &construction.sites {
-                let ordinal = ordinals.entry(selector).or_insert(0);
+            for site in &sites {
+                let ordinal = ordinals.entry(site.selector).or_insert(0);
                 *ordinal += 1;
+                let selector = site.selector;
                 let key = format!("{relative}::{function_path}::{selector}#{ordinal}");
                 discovered.insert(key.clone());
 
-                if !guard.found
+                if !site.dominated_by_guard
                     && !MMAP_CONSTRUCTION_EXEMPTIONS
                         .iter()
                         .any(|exemption| exemption.site == key)
@@ -248,8 +438,9 @@ fn every_mmap_construction_site_is_guarded_or_explicitly_exempted() {
 
     assert!(
         violations.is_empty(),
-        "mmap construction site(s) with neither a trust-boundary guard call in the same \
-         function nor a reviewed MmapConstructionExemption:\n{}",
+        "mmap construction site(s) with neither a trust-boundary guard call earlier in the \
+         same function on a path that necessarily reaches the site, nor a reviewed \
+         MmapConstructionExemption:\n{}",
         violations.join("\n")
     );
 

--- a/crates/inference/tests/mmap_trust_boundary_contract.rs
+++ b/crates/inference/tests/mmap_trust_boundary_contract.rs
@@ -9,7 +9,25 @@
 //! does not cover), or carry an explicit, reviewed
 //! [`MmapConstructionExemption`] naming why not. A guard call that runs
 //! after the construction call, or only on a sibling branch that does not
-//! run before it, does not satisfy this.
+//! run before it, does not satisfy this. Nor does *visiting* a guard call
+//! textually: the guard returns a `Result`, and only a form that actually
+//! propagates its failure -- `?`, `.expect(..)`, `.unwrap()` -- credits the
+//! statements after it as guarded. Collapsing that `Result` to a `bool`
+//! first (`.is_ok()`, `.is_err()`) and branching on the bool does not, even
+//! though the raw guard call is still textually present somewhere in the
+//! condition (see [`is_guard_result_chain`]).
+//!
+//! A function whose body contains an opaque form this walk cannot see into
+//! (a macro invocation, or a `Verbatim` fragment syn itself could not
+//! classify) is also a violation **if that function contains at least one
+//! discovered construction site** -- the opaque form might expand to hide
+//! another one, or a guard call this walk would otherwise have credited,
+//! and there is no way to tell from the AST alone. A function with no
+//! construction site has nothing for an opaque form to hide, so it is not
+//! flagged; without that qualifier, this crate's ordinary use of `assert!`/
+//! `format!`/`vec!` outside closures anywhere in `src/` would fail every
+//! function that happens to use one, not just loaders (see
+//! [`every_mmap_construction_site_is_guarded_or_explicitly_exempted`]).
 //!
 //! Modeled on `metal_measurement_lock_contract.rs`'s construction-site
 //! inventory: a site is named by the program structure enclosing it
@@ -24,7 +42,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use syn::{BinOp, Block, Expr, ExprCall, ExprMethodCall, ImplItem, Item, Stmt};
+use syn::{BinOp, Block, Expr, ExprCall, ExprMethodCall, ImplItem, Item, Stmt, TraitItem};
 
 /// Free functions this crate's mmap trust boundary exposes. A call to either
 /// one counts as guarding a construction site when [`walk_expr`] determines
@@ -36,6 +54,68 @@ const GUARD_FUNCTION_NAMES: &[&str] = &[
     "open_trusted_mmap_file",
     "reject_if_open_mmap_file_untrusted",
 ];
+
+/// Macros this walk trusts as pure, control-flow-transparent value
+/// producers with no bearing on the mmap trust boundary -- all from `std`,
+/// none able to expand into a hidden item, `let`, or arbitrary user call.
+/// This crate's real guarded loaders use several of these directly (not
+/// only inside a closure) for error-message construction, e.g.
+/// `return Err(InferenceError::InvalidSafetensors(format!(".."))))` in
+/// `quant/quarot/io.rs::Shard::open`, and `assert!`/`debug_assert!` as bare
+/// validation statements in `weights/q4_weights.rs::open_and_mmap_q4_file`
+/// and `weights/mmap_trust.rs`'s own tests. Any macro NOT on this list is
+/// opaque (see [`walk_expr`]'s `Expr::Macro` arm and the module doc
+/// comment): this is a reviewed, deliberate scope decision, not an
+/// oversight -- treating literally every macro invocation in the crate as
+/// disqualifying would fail functions that have nothing to do with mmap
+/// construction at all (see
+/// [`every_mmap_construction_site_is_guarded_or_explicitly_exempted`]'s doc
+/// comment), which is a different failure mode than the one this test
+/// exists to catch.
+const TRANSPARENT_MACRO_NAMES: &[&str] = &[
+    "format",
+    "write",
+    "writeln",
+    "vec",
+    "matches",
+    "assert",
+    "assert_eq",
+    "assert_ne",
+    "debug_assert",
+    "debug_assert_eq",
+    "debug_assert_ne",
+    "panic",
+    "unreachable",
+    "todo",
+    "unimplemented",
+    "println",
+    "eprintln",
+    "print",
+    "eprint",
+    "dbg",
+];
+
+/// Whether a macro path names one of [`TRANSPARENT_MACRO_NAMES`]. Matches
+/// only a bare single-segment path (`format!(..)`), consistent with how all
+/// of these are actually invoked -- a qualified path to a same-named macro
+/// (`some_module::format!(..)`, vanishingly rare and not used anywhere in
+/// this crate) is deliberately NOT trusted, the same "don't trust a bare
+/// name across a module boundary" posture [`is_guard_call`] takes for the
+/// opposite reason (there, to avoid crediting a decoy; here, to avoid
+/// trusting one).
+fn is_transparent_macro(path: &syn::Path) -> bool {
+    path.get_ident()
+        .is_some_and(|ident| TRANSPARENT_MACRO_NAMES.contains(&ident.to_string().as_str()))
+}
+
+/// The module (relative to the manifest directory) that defines
+/// [`GUARD_FUNCTION_NAMES`]. Every caller outside this file spells the guard
+/// call with the full crate-qualified path (`crate::weights::mmap_trust::..`
+/// or `weights::mmap_trust::..`); only this module's own `mod tests` (via
+/// `use super::*`) calls a guard bare. A bare, unqualified call anywhere
+/// else in the crate cannot be trusted to name the real guard rather than a
+/// same-named local shadow (see [`is_guard_call`]).
+const GUARD_DEFINITION_MODULE: &str = "src/weights/mmap_trust.rs";
 
 /// A construction site exempted from the guard-call requirement, keyed by
 /// program structure (see module doc comment), with a reviewed reason on
@@ -98,6 +178,16 @@ fn path_ends_with(path: &syn::Path, tail: &[&str]) -> bool {
         .all(|(have, want)| have == want)
 }
 
+/// Renders a `syn::Path` as `a::b::c`, for the opaque-form messages this
+/// walk records.
+fn path_to_string(path: &syn::Path) -> String {
+    path.segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect::<Vec<_>>()
+        .join("::")
+}
+
 /// The receiver type name for an `impl` block, mirroring the sibling Metal
 /// contract test's `impl_self_type_label` so a method's stable key includes
 /// its type even when two `impl` blocks define a method with the same name.
@@ -110,10 +200,18 @@ fn impl_self_type_label(self_ty: &syn::Type) -> String {
     "impl".to_string()
 }
 
-/// Every free function and `impl` method in a parsed file, named by its
-/// enclosing `mod`/`impl` path (matching `EXPECTED_MMAP_CONSTRUCTION_SITES`'
-/// key format) and paired with its body for [`walk_block`]/[`walk_expr`]
-/// below.
+/// Every free function, `impl` method, and default `trait` method body in a
+/// parsed file, named by its enclosing `mod`/`impl`/`trait` path (matching
+/// `EXPECTED_MMAP_CONSTRUCTION_SITES`' key format) and paired with its body
+/// for [`walk_block`]/[`walk_expr`] below. Also descends one level into each
+/// collected body's own top-level statements looking for a nested `fn`
+/// item, so `fn outer() { fn inner() { .. } .. }` reaches `inner` as its own
+/// entry rather than vanishing into `Stmt::Item`'s pass-through in
+/// [`walk_block`]. A nested item declared inside an `if`/`match`/loop body
+/// rather than directly in the function's own block is a further,
+/// documented gap: reaching it needs the same block-walking [`walk_expr`]
+/// already does, which this discovery pass deliberately keeps separate from
+/// (rather than duplicating).
 fn collect_functions<'a>(
     items: &'a [Item],
     path: &mut Vec<String>,
@@ -124,6 +222,7 @@ fn collect_functions<'a>(
             Item::Fn(function) => {
                 path.push(function.sig.ident.to_string());
                 out.push((path.join("::"), &function.block));
+                collect_nested_function_items(&function.block, path, out);
                 path.pop();
             }
             Item::Mod(module) => {
@@ -139,6 +238,21 @@ fn collect_functions<'a>(
                     if let ImplItem::Fn(method) = impl_item {
                         path.push(method.sig.ident.to_string());
                         out.push((path.join("::"), &method.block));
+                        collect_nested_function_items(&method.block, path, out);
+                        path.pop();
+                    }
+                }
+                path.pop();
+            }
+            Item::Trait(item_trait) => {
+                path.push(item_trait.ident.to_string());
+                for trait_item in &item_trait.items {
+                    if let TraitItem::Fn(method) = trait_item
+                        && let Some(default) = &method.default
+                    {
+                        path.push(method.sig.ident.to_string());
+                        out.push((path.join("::"), default));
+                        collect_nested_function_items(default, path, out);
                         path.pop();
                     }
                 }
@@ -149,28 +263,112 @@ fn collect_functions<'a>(
     }
 }
 
-/// Whether an `Expr::Call` node calls one of [`GUARD_FUNCTION_NAMES`].
-fn is_guard_call(call: &ExprCall) -> bool {
-    matches!(&*call.func, Expr::Path(callee)
-    if callee.path.segments.last().is_some_and(|segment| {
-        GUARD_FUNCTION_NAMES.contains(&segment.ident.to_string().as_str())
-    }))
+/// Scans a block's own top-level statements (not nested blocks -- see
+/// [`collect_functions`]'s doc comment) for a nested `fn`/`impl`/`trait`
+/// item and feeds it back through [`collect_functions`] under the enclosing
+/// path, so it gets its own inventory entry instead of silently vanishing.
+fn collect_nested_function_items<'a>(
+    block: &'a syn::Block,
+    path: &mut Vec<String>,
+    out: &mut Vec<(String, &'a syn::Block)>,
+) {
+    for stmt in &block.stmts {
+        if let Stmt::Item(item) = stmt {
+            collect_functions(std::slice::from_ref(item), path, out);
+        }
+    }
+}
+
+/// Whether an `Expr::Call` node calls one of [`GUARD_FUNCTION_NAMES`],
+/// resolved through the crate-qualified path rather than the final path
+/// segment alone. A bare, single-segment call is only accepted when scanning
+/// [`GUARD_DEFINITION_MODULE`] itself (see that constant's doc comment) --
+/// everywhere else a bare identifier could name a same-named local shadow,
+/// and a multi-segment path that isn't the real `weights::mmap_trust::..`
+/// suffix definitely does.
+fn is_guard_call(call: &ExprCall, ctx: &WalkCtx) -> bool {
+    let Expr::Path(callee) = &*call.func else {
+        return false;
+    };
+    let segments: Vec<String> = callee
+        .path
+        .segments
+        .iter()
+        .map(|segment| segment.ident.to_string())
+        .collect();
+    let Some(name) = segments.last() else {
+        return false;
+    };
+    if !GUARD_FUNCTION_NAMES.contains(&name.as_str()) {
+        return false;
+    }
+    match segments.len() {
+        1 => ctx.in_guard_definition_module,
+        _ => {
+            let tail: &[String] = if segments[0] == "crate" {
+                &segments[1..]
+            } else {
+                &segments[..]
+            };
+            tail.len() == 3 && tail[0] == "weights" && tail[1] == "mmap_trust"
+        }
+    }
+}
+
+/// Whether `expr` is a `Result`-valued chain rooted at a guard call and
+/// carried through zero or more combinators that preserve its `Ok`-ness
+/// (currently just `.map_err(..)`, the only one this crate's callers use).
+/// Deliberately does NOT recognize `.is_ok()`/`.is_err()` or any other
+/// combinator that collapses the `Result` to something else: those launder
+/// the guard's outcome into a value whose truthiness this walk cannot
+/// soundly connect back to "the guard succeeded" (see [`walk_expr`]'s
+/// `Expr::Try`/`Expr::MethodCall` handling, which are the only places this
+/// predicate feeds into the `guarded` flag).
+fn is_guard_result_chain(expr: &Expr, ctx: &WalkCtx) -> bool {
+    match expr {
+        Expr::Call(call) => is_guard_call(call, ctx),
+        Expr::MethodCall(method_call) if method_call.method == "map_err" => {
+            is_guard_result_chain(&method_call.receiver, ctx)
+        }
+        Expr::Paren(paren) => is_guard_result_chain(&paren.expr, ctx),
+        Expr::Group(group) => is_guard_result_chain(&group.expr, ctx),
+        _ => false,
+    }
+}
+
+/// Whether an `Expr::Call` node is the inline `MmapOptions::new()` idiom.
+fn is_mmap_options_new_call(call: &ExprCall) -> bool {
+    call.args.is_empty()
+        && matches!(&*call.func, Expr::Path(callee) if path_ends_with(&callee.path, &["MmapOptions", "new"]))
 }
 
 /// Whether an `Expr::Call` node is the free-function `Mmap::map(..)` mmap
-/// construction idiom.
+/// construction idiom. Syntactic, like [`is_mmap_options_new_call`]: an
+/// alias or function-item indirection of `Mmap::map` (`let f = Mmap::map; f
+/// (&file)`) is not recognized, and is a documented residual gap rather than
+/// a silently assumed-away one -- no construction site in this crate uses
+/// that shape today.
 fn is_mmap_map_call(call: &ExprCall) -> bool {
     matches!(&*call.func, Expr::Path(callee) if path_ends_with(&callee.path, &["Mmap", "map"]))
 }
 
 /// Whether an `Expr::MethodCall` node is the `MmapOptions::new().map(..)`
-/// mmap construction idiom.
-fn is_mmap_options_map_call(method_call: &ExprMethodCall) -> bool {
-    method_call.method == "map"
-        && matches!(&*method_call.receiver, Expr::Call(receiver_call)
-            if receiver_call.args.is_empty()
-                && matches!(&*receiver_call.func, Expr::Path(receiver_callee)
-                    if path_ends_with(&receiver_callee.path, &["MmapOptions", "new"])))
+/// mmap construction idiom, including when the `MmapOptions::new()` value
+/// was bound to a local variable first (`let opts = MmapOptions::new();
+/// opts.map(..)`) -- tracked via [`WalkCtx::bound_mmap_options`], populated
+/// by [`walk_block`] as it processes `let` statements.
+fn is_mmap_options_map_call(method_call: &ExprMethodCall, ctx: &WalkCtx) -> bool {
+    if method_call.method != "map" {
+        return false;
+    }
+    match &*method_call.receiver {
+        Expr::Call(receiver_call) => is_mmap_options_new_call(receiver_call),
+        Expr::Path(receiver_path) => receiver_path
+            .path
+            .get_ident()
+            .is_some_and(|ident| ctx.bound_mmap_options.contains(&ident.to_string())),
+        _ => false,
+    }
 }
 
 /// A discovered mmap construction call, in the order [`walk_expr`] visits
@@ -181,14 +379,46 @@ struct SiteObservation {
     dominated_by_guard: bool,
 }
 
+/// Context threaded through [`walk_expr`]/[`walk_block`] alongside the
+/// per-branch `guarded` flag: state that is scoped to (part of) a function
+/// rather than to one control-flow branch.
+#[derive(Clone)]
+struct WalkCtx<'a> {
+    /// `{relative_path}::{function_path}`, named in an opaque-form message
+    /// so it points at the function, not just "somewhere".
+    location: &'a str,
+    /// See [`GUARD_DEFINITION_MODULE`].
+    in_guard_definition_module: bool,
+    /// True once inside a closure/`async`/`const` block. These run later,
+    /// independently of the enclosing function -- see the "Closures and
+    /// `async`/`const` blocks" bullet in [`walk_expr`]'s doc comment -- so
+    /// an opaque macro/`Verbatim` form inside one cannot hide code that runs
+    /// on *this* function's own guard-to-map path, and is not recorded (see
+    /// the `Expr::Macro`/`Expr::Verbatim` arms below).
+    in_deferred_scope: bool,
+    /// Local variables in the current scope bound directly to
+    /// `MmapOptions::new()` (see [`is_mmap_options_map_call`]).
+    bound_mmap_options: BTreeSet<String>,
+}
+
+fn empty_ctx(location: &str) -> WalkCtx<'_> {
+    WalkCtx {
+        location,
+        in_guard_definition_module: false,
+        in_deferred_scope: false,
+        bound_mmap_options: BTreeSet::new(),
+    }
+}
+
 /// Walks an expression in source order, threading a `guarded` flag that
 /// becomes (and stays) `true` once a guard call has been seen on a path that
 /// *necessarily* executes before the current point -- the "first" the module
-/// doc comment requires. This is a textual/structural approximation of
-/// control-flow dominance, not a real control-flow-graph analysis; it is
-/// sufficient for this crate's loaders, which are straight-line
-/// open-then-map functions, but the following cases are explicitly NOT
-/// treated as dominance:
+/// doc comment requires -- AND whose success is actually propagated, not
+/// merely observed (see [`is_guard_result_chain`]). This is a
+/// textual/structural approximation of control-flow dominance, not a real
+/// control-flow-graph analysis; it is sufficient for this crate's loaders,
+/// which are straight-line open-then-map functions, but the following cases
+/// are explicitly NOT treated as dominance:
 ///
 /// - **`if`/`else` branches and `match` arms.** A guard call inside one arm
 ///   is scoped to that arm alone: it is never credited to a sibling arm, nor
@@ -213,10 +443,18 @@ struct SiteObservation {
 ///   credited to sites after it, even though that guard call can never
 ///   actually run. None of this crate's loaders do that; it is recorded here
 ///   as a known gap rather than silently assumed away.
+/// - **A guard call collapsed to a `bool`.** `guard(..).is_ok()` or
+///   `guard(..).is_err()`, used as an `if`/`&&`/`||` operand, does NOT credit
+///   the guard: visiting the call is not the same as observing that it
+///   succeeded and having that success actually gate what runs next. Only
+///   `guard(..)?`, `guard(..).expect(..)`, `guard(..).unwrap()` (optionally
+///   through `.map_err(..)`) do that -- see [`is_guard_result_chain`] and the
+///   `Expr::Try`/`Expr::MethodCall` arms below.
 ///
 /// What DOES count as "necessarily executes before" and so threads the flag
 /// straight through: sequential statements in the same block, `unsafe { .. }`
-/// and bare `{ .. }` blocks, `?`, casts, references, field/index access,
+/// and bare `{ .. }` blocks, `try { .. }` blocks, `?`, casts, references,
+/// raw address-of (`&raw const`/`&raw mut`), field/index access,
 /// method-call/call receivers and arguments (in left-to-right evaluation
 /// order), assignment operands, and the operands of every binary operator
 /// that Rust evaluates unconditionally (arithmetic, comparison, bitwise, ...).
@@ -231,14 +469,34 @@ struct SiteObservation {
 /// discovered and, symmetrically, still sees the left operand's guard state
 /// as input, since the left operand necessarily runs first whenever the
 /// right one runs at all.
-fn walk_expr(expr: &Expr, guarded_in: bool, sites: &mut Vec<SiteObservation>) -> bool {
+///
+/// **Every `Expr` variant syn 2.0.119 defines is matched explicitly.** A
+/// pure leaf with nothing to recurse into (`Continue`, `Infer`, `Lit`,
+/// `Path`) passes `guarded_in` straight through. An opaque form this walk
+/// cannot see into -- `Macro`, `Verbatim` -- is recorded into `opaque`
+/// (unless `ctx.in_deferred_scope`, see [`WalkCtx::in_deferred_scope`]);
+/// [`every_mmap_construction_site_is_guarded_or_explicitly_exempted`] turns
+/// that into a violation for any function that also has a discovered
+/// construction site. `Expr` is `#[non_exhaustive]`, so a `_` arm is still
+/// required for a future syn version's new variant; unlike the two known
+/// opaque forms, that arm panics immediately -- a variant this walk has
+/// never seen is not something the deferred, per-function judgment above
+/// can safely reason about at all.
+fn walk_expr(
+    expr: &Expr,
+    guarded_in: bool,
+    ctx: &WalkCtx,
+    sites: &mut Vec<SiteObservation>,
+    opaque: &mut Vec<String>,
+) -> bool {
     match expr {
-        Expr::Block(block) => walk_block(&block.block, guarded_in, sites),
-        Expr::Unsafe(block) => walk_block(&block.block, guarded_in, sites),
+        Expr::Block(block) => walk_block(&block.block, guarded_in, ctx, sites, opaque),
+        Expr::Unsafe(block) => walk_block(&block.block, guarded_in, ctx, sites, opaque),
+        Expr::TryBlock(try_block) => walk_block(&try_block.block, guarded_in, ctx, sites, opaque),
         Expr::Call(call) => {
-            let mut guarded = walk_expr(&call.func, guarded_in, sites);
+            let mut guarded = walk_expr(&call.func, guarded_in, ctx, sites, opaque);
             for arg in &call.args {
-                guarded = walk_expr(arg, guarded, sites);
+                guarded = walk_expr(arg, guarded, ctx, sites, opaque);
             }
             if is_mmap_map_call(call) {
                 sites.push(SiteObservation {
@@ -246,83 +504,112 @@ fn walk_expr(expr: &Expr, guarded_in: bool, sites: &mut Vec<SiteObservation>) ->
                     dominated_by_guard: guarded,
                 });
             }
-            if is_guard_call(call) {
-                guarded = true;
-            }
             guarded
         }
         Expr::MethodCall(method_call) => {
-            let mut guarded = walk_expr(&method_call.receiver, guarded_in, sites);
+            let mut guarded = walk_expr(&method_call.receiver, guarded_in, ctx, sites, opaque);
             for arg in &method_call.args {
-                guarded = walk_expr(arg, guarded, sites);
+                guarded = walk_expr(arg, guarded, ctx, sites, opaque);
             }
-            if is_mmap_options_map_call(method_call) {
+            if is_mmap_options_map_call(method_call, ctx) {
                 sites.push(SiteObservation {
                     selector: "MmapOptions::new().map()",
                     dominated_by_guard: guarded,
                 });
             }
+            if (method_call.method == "expect" || method_call.method == "unwrap")
+                && is_guard_result_chain(&method_call.receiver, ctx)
+            {
+                guarded = true;
+            }
             guarded
         }
+        Expr::Try(try_expr) => {
+            let guarded = walk_expr(&try_expr.expr, guarded_in, ctx, sites, opaque);
+            if is_guard_result_chain(&try_expr.expr, ctx) {
+                true
+            } else {
+                guarded
+            }
+        }
         Expr::If(if_expr) => {
-            let guarded = walk_expr(&if_expr.cond, guarded_in, sites);
-            walk_block(&if_expr.then_branch, guarded, sites);
+            let guarded = walk_expr(&if_expr.cond, guarded_in, ctx, sites, opaque);
+            walk_block(&if_expr.then_branch, guarded, ctx, sites, opaque);
             if let Some((_, else_expr)) = &if_expr.else_branch {
-                walk_expr(else_expr, guarded, sites);
+                walk_expr(else_expr, guarded, ctx, sites, opaque);
             }
             guarded
         }
         Expr::Match(match_expr) => {
-            let guarded = walk_expr(&match_expr.expr, guarded_in, sites);
+            let guarded = walk_expr(&match_expr.expr, guarded_in, ctx, sites, opaque);
             for arm in &match_expr.arms {
                 if let Some((_, guard_cond)) = &arm.guard {
-                    walk_expr(guard_cond, guarded, sites);
+                    walk_expr(guard_cond, guarded, ctx, sites, opaque);
                 }
-                walk_expr(&arm.body, guarded, sites);
+                walk_expr(&arm.body, guarded, ctx, sites, opaque);
             }
             guarded
         }
         Expr::Loop(loop_expr) => {
-            walk_block(&loop_expr.body, guarded_in, sites);
+            walk_block(&loop_expr.body, guarded_in, ctx, sites, opaque);
             guarded_in
         }
         Expr::While(while_expr) => {
-            let guarded = walk_expr(&while_expr.cond, guarded_in, sites);
-            walk_block(&while_expr.body, guarded, sites);
+            let guarded = walk_expr(&while_expr.cond, guarded_in, ctx, sites, opaque);
+            walk_block(&while_expr.body, guarded, ctx, sites, opaque);
             guarded_in
         }
         Expr::ForLoop(for_loop) => {
-            let guarded = walk_expr(&for_loop.expr, guarded_in, sites);
-            walk_block(&for_loop.body, guarded, sites);
+            let guarded = walk_expr(&for_loop.expr, guarded_in, ctx, sites, opaque);
+            walk_block(&for_loop.body, guarded, ctx, sites, opaque);
             guarded_in
         }
         Expr::Closure(closure) => {
-            walk_expr(&closure.body, false, sites);
+            let mut deferred = ctx.clone();
+            deferred.in_deferred_scope = true;
+            walk_expr(&closure.body, false, &deferred, sites, opaque);
             guarded_in
         }
-        Expr::Try(try_expr) => walk_expr(&try_expr.expr, guarded_in, sites),
-        Expr::Paren(paren) => walk_expr(&paren.expr, guarded_in, sites),
-        Expr::Group(group) => walk_expr(&group.expr, guarded_in, sites),
-        Expr::Reference(reference) => walk_expr(&reference.expr, guarded_in, sites),
-        Expr::Unary(unary) => walk_expr(&unary.expr, guarded_in, sites),
-        Expr::Cast(cast) => walk_expr(&cast.expr, guarded_in, sites),
-        Expr::Field(field) => walk_expr(&field.base, guarded_in, sites),
-        Expr::Await(await_expr) => walk_expr(&await_expr.base, guarded_in, sites),
-        Expr::Let(let_expr) => walk_expr(&let_expr.expr, guarded_in, sites),
+        Expr::Async(async_expr) => {
+            let mut deferred = ctx.clone();
+            deferred.in_deferred_scope = true;
+            walk_block(&async_expr.block, false, &deferred, sites, opaque);
+            guarded_in
+        }
+        Expr::Const(const_expr) => {
+            let mut deferred = ctx.clone();
+            deferred.in_deferred_scope = true;
+            walk_block(&const_expr.block, false, &deferred, sites, opaque);
+            guarded_in
+        }
+        Expr::Paren(paren) => walk_expr(&paren.expr, guarded_in, ctx, sites, opaque),
+        Expr::Group(group) => walk_expr(&group.expr, guarded_in, ctx, sites, opaque),
+        Expr::Reference(reference) => walk_expr(&reference.expr, guarded_in, ctx, sites, opaque),
+        Expr::RawAddr(raw_addr) => walk_expr(&raw_addr.expr, guarded_in, ctx, sites, opaque),
+        Expr::Unary(unary) => walk_expr(&unary.expr, guarded_in, ctx, sites, opaque),
+        Expr::Cast(cast) => walk_expr(&cast.expr, guarded_in, ctx, sites, opaque),
+        Expr::Field(field) => walk_expr(&field.base, guarded_in, ctx, sites, opaque),
+        Expr::Await(await_expr) => walk_expr(&await_expr.base, guarded_in, ctx, sites, opaque),
+        Expr::Let(let_expr) => walk_expr(&let_expr.expr, guarded_in, ctx, sites, opaque),
         Expr::Return(return_expr) => match &return_expr.expr {
-            Some(inner) => walk_expr(inner, guarded_in, sites),
+            Some(inner) => walk_expr(inner, guarded_in, ctx, sites, opaque),
             None => guarded_in,
         },
         Expr::Break(break_expr) => match &break_expr.expr {
-            Some(inner) => walk_expr(inner, guarded_in, sites),
+            Some(inner) => walk_expr(inner, guarded_in, ctx, sites, opaque),
             None => guarded_in,
         },
+        Expr::Yield(yield_expr) => match &yield_expr.expr {
+            Some(inner) => walk_expr(inner, guarded_in, ctx, sites, opaque),
+            None => guarded_in,
+        },
+        Expr::Continue(_) | Expr::Infer(_) | Expr::Lit(_) | Expr::Path(_) => guarded_in,
         Expr::Index(index) => {
-            let guarded = walk_expr(&index.expr, guarded_in, sites);
-            walk_expr(&index.index, guarded, sites)
+            let guarded = walk_expr(&index.expr, guarded_in, ctx, sites, opaque);
+            walk_expr(&index.index, guarded, ctx, sites, opaque)
         }
         Expr::Binary(binary) => {
-            let guarded = walk_expr(&binary.left, guarded_in, sites);
+            let guarded = walk_expr(&binary.left, guarded_in, ctx, sites, opaque);
             match binary.op {
                 BinOp::And(_) | BinOp::Or(_) => {
                     // `&&`/`||` short-circuit: the right operand may never run.
@@ -330,84 +617,145 @@ fn walk_expr(expr: &Expr, guarded_in: bool, sites: &mut Vec<SiteObservation>) ->
                     // but a guard call inside it must not be credited to sites
                     // that follow the whole expression -- only `guarded` (the
                     // state after the left operand, which always runs) does.
-                    walk_expr(&binary.right, guarded, sites);
+                    walk_expr(&binary.right, guarded, ctx, sites, opaque);
                     guarded
                 }
-                _ => walk_expr(&binary.right, guarded, sites),
+                _ => walk_expr(&binary.right, guarded, ctx, sites, opaque),
             }
         }
         Expr::Assign(assign) => {
-            let guarded = walk_expr(&assign.left, guarded_in, sites);
-            walk_expr(&assign.right, guarded, sites)
+            let guarded = walk_expr(&assign.left, guarded_in, ctx, sites, opaque);
+            walk_expr(&assign.right, guarded, ctx, sites, opaque)
         }
         Expr::Repeat(repeat) => {
-            let guarded = walk_expr(&repeat.expr, guarded_in, sites);
-            walk_expr(&repeat.len, guarded, sites)
+            let guarded = walk_expr(&repeat.expr, guarded_in, ctx, sites, opaque);
+            walk_expr(&repeat.len, guarded, ctx, sites, opaque)
         }
         Expr::Range(range) => {
             let mut guarded = guarded_in;
             if let Some(start) = &range.start {
-                guarded = walk_expr(start, guarded, sites);
+                guarded = walk_expr(start, guarded, ctx, sites, opaque);
             }
             if let Some(end) = &range.end {
-                guarded = walk_expr(end, guarded, sites);
+                guarded = walk_expr(end, guarded, ctx, sites, opaque);
             }
             guarded
         }
         Expr::Tuple(tuple) => {
             let mut guarded = guarded_in;
             for elem in &tuple.elems {
-                guarded = walk_expr(elem, guarded, sites);
+                guarded = walk_expr(elem, guarded, ctx, sites, opaque);
             }
             guarded
         }
         Expr::Array(array) => {
             let mut guarded = guarded_in;
             for elem in &array.elems {
-                guarded = walk_expr(elem, guarded, sites);
+                guarded = walk_expr(elem, guarded, ctx, sites, opaque);
             }
             guarded
         }
         Expr::Struct(struct_expr) => {
             let mut guarded = guarded_in;
             for field in &struct_expr.fields {
-                guarded = walk_expr(&field.expr, guarded, sites);
+                guarded = walk_expr(&field.expr, guarded, ctx, sites, opaque);
             }
             if let Some(rest) = &struct_expr.rest {
-                guarded = walk_expr(rest, guarded, sites);
+                guarded = walk_expr(rest, guarded, ctx, sites, opaque);
             }
             guarded
         }
-        // Every other expression kind (literals, paths, macros, `async`/
-        // `const` blocks, ...) is either a leaf with nothing to recurse into,
-        // or -- for `async`/`const` blocks -- runs later/independently like a
-        // closure and is out of scope for the loaders this test discovers.
-        _ => guarded_in,
+        Expr::Macro(macro_expr) => {
+            if !ctx.in_deferred_scope && !is_transparent_macro(&macro_expr.mac.path) {
+                opaque.push(format!(
+                    "{}: a macro invocation (`{}!(..)`) is opaque to this AST walk",
+                    ctx.location,
+                    path_to_string(&macro_expr.mac.path)
+                ));
+            }
+            guarded_in
+        }
+        Expr::Verbatim(_) => {
+            if !ctx.in_deferred_scope {
+                opaque.push(format!(
+                    "{}: syn could not classify this expression into a known AST form \
+                     (Verbatim)",
+                    ctx.location
+                ));
+            }
+            guarded_in
+        }
+        // `Expr` is `#[non_exhaustive]`: every variant syn 2.0.119 defines is
+        // matched explicitly above (see this function's doc comment). A
+        // variant this match doesn't recognize -- from a newer syn version --
+        // fails closed immediately rather than being folded into the
+        // deferred `opaque` judgment above: upgrading syn to a version with
+        // a genuinely new `Expr` variant needs a conscious update here, not
+        // a per-function pass/fail call this walk cannot make blind.
+        _ => panic!(
+            "{}: an expression form this AST walk does not recognize (syn may have added a new \
+             `Expr` variant) -- update `walk_expr` to handle it explicitly before trusting this \
+             contract again",
+            ctx.location
+        ),
     }
 }
 
 /// Walks a block's statements in source order, threading `guarded` the same
-/// way [`walk_expr`] does.
-fn walk_block(block: &Block, guarded_in: bool, sites: &mut Vec<SiteObservation>) -> bool {
+/// way [`walk_expr`] does, and extending `ctx.bound_mmap_options` as `let`
+/// bindings to `MmapOptions::new()` are seen (scoped to this block and its
+/// children; not merged back into the caller's scope, matching how `guarded`
+/// itself is not threaded back out of a nested block's own control-flow
+/// forms).
+fn walk_block(
+    block: &Block,
+    guarded_in: bool,
+    ctx: &WalkCtx,
+    sites: &mut Vec<SiteObservation>,
+    opaque: &mut Vec<String>,
+) -> bool {
     let mut guarded = guarded_in;
+    let mut ctx = ctx.clone();
     for stmt in &block.stmts {
         guarded = match stmt {
             Stmt::Local(local) => {
                 let mut guarded_after = guarded;
                 if let Some(init) = &local.init {
-                    guarded_after = walk_expr(&init.expr, guarded_after, sites);
+                    guarded_after = walk_expr(&init.expr, guarded_after, &ctx, sites, opaque);
+                    if let syn::Pat::Ident(pat_ident) = &local.pat
+                        && let Expr::Call(call) = &*init.expr
+                        && is_mmap_options_new_call(call)
+                    {
+                        ctx.bound_mmap_options.insert(pat_ident.ident.to_string());
+                    }
                     if let Some((_, diverge)) = &init.diverge {
                         // `let ... else { diverge }`: the diverge block only
                         // runs when the pattern does NOT match, so -- like an
                         // `if`/`match` arm -- it is internal-only and never
                         // propagated to the statements that follow.
-                        walk_expr(diverge, guarded_after, sites);
+                        walk_expr(diverge, guarded_after, &ctx, sites, opaque);
                     }
                 }
                 guarded_after
             }
-            Stmt::Expr(expr, _) => walk_expr(expr, guarded, sites),
-            Stmt::Macro(_) | Stmt::Item(_) => guarded,
+            Stmt::Expr(expr, _) => walk_expr(expr, guarded, &ctx, sites, opaque),
+            // A nested item (e.g. `fn inner() { .. }`) is discovered and
+            // walked separately, as its own entry, by
+            // `collect_nested_function_items` -- it is a distinct callable
+            // unit that does not run inline with these statements, so it is
+            // correctly a no-op here rather than something to recurse into.
+            Stmt::Item(_) => guarded,
+            Stmt::Macro(stmt_macro) => {
+                if !ctx.in_deferred_scope && !is_transparent_macro(&stmt_macro.mac.path) {
+                    opaque.push(format!(
+                        "{}: a macro invocation (`{}!(..)`) in statement position is opaque to \
+                         this AST walk",
+                        ctx.location,
+                        path_to_string(&stmt_macro.mac.path)
+                    ));
+                }
+                guarded
+            }
         };
     }
     guarded
@@ -432,7 +780,9 @@ fn walk_expr_does_not_credit_a_guard_call_inside_an_or_short_circuit() {
     )
     .expect("parse `||` short-circuit fixture");
     let mut sites = Vec::new();
-    walk_block(&block, false, &mut sites);
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::or_short_circuit");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
     assert_eq!(
         sites.len(),
         1,
@@ -458,7 +808,9 @@ fn walk_expr_does_not_credit_a_guard_call_inside_an_and_short_circuit() {
     )
     .expect("parse `&&` short-circuit fixture");
     let mut sites = Vec::new();
-    walk_block(&block, false, &mut sites);
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::and_short_circuit");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
     assert_eq!(
         sites.len(),
         1,
@@ -470,6 +822,524 @@ fn walk_expr_does_not_credit_a_guard_call_inside_an_and_short_circuit() {
         "a guard call reachable only through the right operand of `&&` must not be credited: \
          `false && open_trusted_mmap_file(..)` never evaluates the guard at runtime"
     );
+}
+
+/// F1 regression: `guard(..).is_ok() || unsafe { Mmap::map(&file) }` runs the
+/// mmap exactly when the guard's `.is_ok()` is `false` -- i.e. exactly when
+/// the guard FAILED. Visiting the raw guard call inside `.is_ok()` must not
+/// be credited: only a form that propagates the guard's success
+/// (`?`/`.expect`/`.unwrap`) may.
+#[test]
+fn walk_expr_does_not_credit_a_guard_call_collapsed_to_bool_via_is_ok_in_or() {
+    let block: Block = syn::parse_str(
+        r#"{
+            reject_if_open_mmap_file_untrusted(&file, path).is_ok() || unsafe { Mmap::map(&file) };
+        }"#,
+    )
+    .expect("parse F1 fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f1_is_ok_or");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "fixture must discover exactly one Mmap::map() site"
+    );
+    assert!(
+        !sites[0].dominated_by_guard,
+        "`guard(..).is_ok() || map(..)` runs the map exactly when the guard FAILED; the guard \
+         call being textually present must not be credited"
+    );
+}
+
+/// F2 regression: `if guard(..).is_err() { unsafe { Mmap::map(&file) }; }`
+/// runs the mmap exactly in the branch where the guard failed. Same root
+/// cause as F1.
+#[test]
+fn walk_expr_does_not_credit_a_guard_call_collapsed_to_bool_via_is_err_in_if() {
+    let block: Block = syn::parse_str(
+        r#"{
+            if reject_if_open_mmap_file_untrusted(&file, path).is_err() {
+                unsafe { Mmap::map(&file) };
+            }
+        }"#,
+    )
+    .expect("parse F2 fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f2_is_err_if");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "fixture must discover exactly one Mmap::map() site"
+    );
+    assert!(
+        !sites[0].dominated_by_guard,
+        "`if guard(..).is_err() {{ map(..) }}` runs the map exactly when the guard FAILED; the \
+         guard call being textually present in the condition must not be credited"
+    );
+}
+
+/// Control for F1/F2: the real idiom this crate's loaders use --
+/// `crate::weights::mmap_trust::guard(..).map_err(..)?;` followed by the
+/// construction -- must still be credited. Proves the fix distinguishes
+/// "propagated via `?`" from "collapsed to bool", rather than simply never
+/// crediting a guard call again.
+#[test]
+fn walk_expr_still_credits_a_guard_call_propagated_via_try_and_map_err() {
+    let block: Block = syn::parse_str(
+        r#"{
+            crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted(&file, path)
+                .map_err(Into::into)?;
+            unsafe { Mmap::map(&file) }
+        }"#,
+    )
+    .expect("parse guard-then-map control fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::guard_then_map_control");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "fixture must discover exactly one Mmap::map() site"
+    );
+    assert!(
+        sites[0].dominated_by_guard,
+        "`guard(..).map_err(..)?;` propagates the guard's success via `?` and must still be \
+         credited to the construction call that follows"
+    );
+}
+
+/// Control for F1/F2, `.expect`/`.unwrap` form: `guard(..).expect(msg);`
+/// panics on failure, so continuation past it guarantees success -- the
+/// pattern this crate's own `mmap_trust.rs` tests use (bare, since they are
+/// scanned with `in_guard_definition_module: true`).
+#[test]
+fn walk_expr_still_credits_a_guard_call_propagated_via_expect() {
+    let block: Block = syn::parse_str(
+        r#"{
+            let (file, meta) = open_trusted_mmap_file(&path).expect("fixture");
+            unsafe { MmapOptions::new().map(&file) }
+        }"#,
+    )
+    .expect("parse expect() control fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = WalkCtx {
+        in_guard_definition_module: true,
+        ..empty_ctx("fixture::guard_expect_control")
+    };
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "fixture must discover exactly one MmapOptions::new().map() site"
+    );
+    assert!(
+        sites[0].dominated_by_guard,
+        "`guard(..).expect(..)` panics on failure, so it must still be credited to the \
+         construction call that follows"
+    );
+}
+
+/// F3 regression: `MmapOptions::new()` bound to a local before `.map(..)` is
+/// called on it must still be discovered as a construction site -- and,
+/// being unguarded here, flagged as a violation.
+#[test]
+fn walk_expr_discovers_mmap_options_map_call_through_a_local_binding() {
+    let block: Block = syn::parse_str(
+        r#"{
+            let options = MmapOptions::new();
+            unsafe { options.map(&file) };
+        }"#,
+    )
+    .expect("parse F3 fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f3_bound_options");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "a `MmapOptions::new()` bound to a local before `.map(..)` must still be discovered as \
+         a construction site, not silently vanish"
+    );
+    assert_eq!(sites[0].selector, "MmapOptions::new().map()");
+    assert!(
+        !sites[0].dominated_by_guard,
+        "the fixture has no guard call at all; the site must be reported unguarded"
+    );
+}
+
+/// F5 regression: a locally shadowed function sharing the guard's bare name,
+/// defined and called unqualified inside a module that is NOT
+/// `weights::mmap_trust`, must not satisfy the guard-call requirement --
+/// only [`GUARD_DEFINITION_MODULE`]'s own bare calls may.
+#[test]
+fn walk_expr_does_not_credit_a_locally_shadowed_guard_function() {
+    let block: Block = syn::parse_str(
+        r#"{
+            fn reject_if_open_mmap_file_untrusted(
+                _file: &std::fs::File,
+                _path: &std::path::Path,
+            ) -> Result<(), String> {
+                Ok(())
+            }
+            reject_if_open_mmap_file_untrusted(&file, path)?;
+            unsafe { Mmap::map(&file) }
+        }"#,
+    )
+    .expect("parse F5 shadow fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    // `in_guard_definition_module: false` -- this fixture models a call site
+    // OUTSIDE `weights/mmap_trust.rs`, where a bare call cannot be trusted.
+    let ctx = empty_ctx("fixture::f5_bare_shadow");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "fixture must discover exactly one Mmap::map() site"
+    );
+    assert!(
+        !sites[0].dominated_by_guard,
+        "a bare call to a locally shadowed function sharing the guard's name, outside the \
+         guard's own defining module, must not be credited"
+    );
+}
+
+/// F5 regression, qualified-path form: a decoy function reached through a
+/// path whose LAST segment matches a guard name but whose full path is not
+/// `weights::mmap_trust::..` must not satisfy the guard-call requirement.
+#[test]
+fn walk_expr_does_not_credit_a_wrongly_qualified_same_named_function() {
+    let block: Block = syn::parse_str(
+        r#"{
+            mod decoy {
+                pub(crate) fn reject_if_open_mmap_file_untrusted(
+                    _file: &std::fs::File,
+                    _path: &std::path::Path,
+                ) -> Result<(), String> {
+                    Ok(())
+                }
+            }
+            decoy::reject_if_open_mmap_file_untrusted(&file, path)?;
+            unsafe { Mmap::map(&file) }
+        }"#,
+    )
+    .expect("parse F5 qualified-decoy fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f5_qualified_decoy");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "fixture must discover exactly one Mmap::map() site"
+    );
+    assert!(
+        !sites[0].dominated_by_guard,
+        "`decoy::reject_if_open_mmap_file_untrusted` shares only the guard's last path segment; \
+         it must not be credited"
+    );
+}
+
+/// Control for F5: the crate-qualified path this crate's real callers use
+/// must still be credited.
+#[test]
+fn walk_expr_still_credits_the_crate_qualified_guard_path() {
+    let block: Block = syn::parse_str(
+        r#"{
+            crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted(&file, path)
+                .map_err(Into::into)?;
+            unsafe { Mmap::map(&file) }
+        }"#,
+    )
+    .expect("parse crate-qualified control fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f5_qualified_control");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "fixture must discover exactly one Mmap::map() site"
+    );
+    assert!(
+        sites[0].dominated_by_guard,
+        "`crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted(..)` is the real \
+         crate-qualified guard path and must be credited"
+    );
+}
+
+/// F4 regression: an unguarded construction reachable only through
+/// `Expr::RawAddr` (`&raw const`/`&raw mut`) must still be discovered.
+#[test]
+fn walk_expr_recurses_into_raw_addr_operand() {
+    let block: Block = syn::parse_str(
+        r#"{
+            let _p = &raw const unsafe { Mmap::map(&file) };
+        }"#,
+    )
+    .expect("parse RawAddr fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f4_raw_addr");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "an Mmap::map() call reachable only through the operand of `&raw const` must still be \
+         discovered"
+    );
+    assert!(!sites[0].dominated_by_guard);
+}
+
+/// F4 regression: an unguarded construction reachable only through
+/// `Expr::TryBlock` (`try { .. }`) must still be discovered.
+#[test]
+fn walk_expr_recurses_into_try_block() {
+    let block: Block = syn::parse_str(
+        r#"{
+            let _r = try {
+                unsafe { Mmap::map(&file) }?
+            };
+        }"#,
+    )
+    .expect("parse TryBlock fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f4_try_block");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "an Mmap::map() call reachable only through a `try {{ .. }}` block must still be \
+         discovered"
+    );
+    assert!(!sites[0].dominated_by_guard);
+}
+
+/// F4 regression: an unguarded construction reachable only through
+/// `Expr::Yield` must still be discovered.
+#[test]
+fn walk_expr_recurses_into_yield_operand() {
+    let block: Block = syn::parse_str(
+        r#"{
+            yield unsafe { Mmap::map(&file) };
+        }"#,
+    )
+    .expect("parse Yield fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f4_yield");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "an Mmap::map() call reachable only through the operand of `yield` must still be \
+         discovered"
+    );
+    assert!(!sites[0].dominated_by_guard);
+}
+
+/// F4 regression: an unguarded construction inside an `async { .. }` block
+/// must still be discovered (independently scoped, per `walk_expr`'s doc
+/// comment -- it runs later, not inline -- but must not vanish outright).
+#[test]
+fn walk_expr_recurses_into_async_block() {
+    let block: Block = syn::parse_str(
+        r#"{
+            let _fut = async {
+                unsafe { Mmap::map(&file) }
+            };
+        }"#,
+    )
+    .expect("parse Async fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f4_async");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "an Mmap::map() call reachable only through an `async {{ .. }}` block must still be \
+         discovered"
+    );
+    assert!(!sites[0].dominated_by_guard);
+}
+
+/// F4 regression: an unguarded construction inside a `const { .. }` block
+/// (expression position) must still be discovered.
+#[test]
+fn walk_expr_recurses_into_const_block() {
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f4_const");
+    let expr: Expr = syn::parse_str("const { unsafe { Mmap::map(&file) } }")
+        .expect("parse Const expression fixture");
+    walk_expr(&expr, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "an Mmap::map() call reachable only through a `const {{ .. }}` block must still be \
+         discovered"
+    );
+    assert!(!sites[0].dominated_by_guard);
+}
+
+/// F4 regression: a macro invocation in expression position, in a function
+/// that also has a real construction site, must be recorded as opaque --
+/// the combination [`every_mmap_construction_site_is_guarded_or_explicitly_exempted`]
+/// treats as a violation, since the macro's expansion could be hiding
+/// another site or a guard call this walk cannot see.
+#[test]
+fn walk_expr_records_an_opaque_macro_invocation_alongside_a_real_site() {
+    let block: Block = syn::parse_str(
+        r#"{
+            some_hiding_macro!();
+            unsafe { Mmap::map(&file) };
+        }"#,
+    )
+    .expect("parse Macro fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f4_macro");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "the real construction site must still be discovered"
+    );
+    assert_eq!(
+        opaque.len(),
+        1,
+        "the macro invocation must be recorded as opaque now that the function also has a \
+         discovered construction site"
+    );
+    assert!(opaque[0].contains("some_hiding_macro"));
+}
+
+/// Companion to the fixture above: a macro invocation is recorded as opaque
+/// even when the function has NO construction site of its own -- the
+/// decision about whether that matters belongs to the caller (see
+/// `every_mmap_construction_site_is_guarded_or_explicitly_exempted`'s doc
+/// comment: a function with no site is not flagged even though `opaque`
+/// here is non-empty).
+#[test]
+fn walk_block_records_an_opaque_macro_statement() {
+    let block: Block = syn::parse_str(
+        r#"{
+            some_hiding_macro!();
+        }"#,
+    )
+    .expect("parse Stmt::Macro fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f4_stmt_macro");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert!(sites.is_empty());
+    assert_eq!(opaque.len(), 1);
+    assert!(opaque[0].contains("some_hiding_macro"));
+}
+
+/// Control for the two fixtures above: a macro invocation inside a
+/// closure/`async`/`const` (deferred scope) must NOT be recorded as opaque,
+/// since ordinary, harmless idioms like `.map_err(|e| format!(".."))` --
+/// used throughout this crate's real guarded loaders -- are exactly this
+/// shape, and would otherwise make every one of them unable to pass.
+#[test]
+fn walk_expr_does_not_record_a_macro_inside_a_deferred_closure_as_opaque() {
+    let block: Block = syn::parse_str(
+        r#"{
+            crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted(&file, path)
+                .map_err(|e| format!("failed: {e}"))?;
+            unsafe { Mmap::map(&file) }
+        }"#,
+    )
+    .expect("parse deferred-macro control fixture");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f4_deferred_macro_control");
+    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(sites.len(), 1);
+    assert!(sites[0].dominated_by_guard);
+    assert!(
+        opaque.is_empty(),
+        "a macro invocation inside a closure passed to `.map_err(..)` must not be recorded as \
+         opaque -- it is deferred, not part of this function's own synchronous path"
+    );
+}
+
+/// F4 regression: a nested `fn` item, invisible to `collect_functions`
+/// before this fix, must be discovered as its own inventory entry.
+#[test]
+fn collect_functions_discovers_a_nested_fn_item() {
+    let file: syn::File = syn::parse_str(
+        r#"
+        fn outer(file: &std::fs::File) {
+            fn inner(file: &std::fs::File) {
+                unsafe { Mmap::map(file) };
+            }
+            inner(file);
+        }
+        "#,
+    )
+    .expect("parse nested-fn fixture");
+    let mut functions = Vec::new();
+    let mut path_stack = Vec::new();
+    collect_functions(&file.items, &mut path_stack, &mut functions);
+    let inner = functions
+        .iter()
+        .find(|(path, _)| path == "outer::inner")
+        .expect("nested `fn inner` must be discovered as its own entry (`outer::inner`)");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f4_nested_fn::outer::inner");
+    walk_block(inner.1, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "the nested fn's own Mmap::map() call must be discovered"
+    );
+    assert!(!sites[0].dominated_by_guard);
+}
+
+/// F4 regression: a trait default method body, invisible to
+/// `collect_functions` before this fix (only `Item::Fn`/`Item::Impl` were
+/// handled), must be discovered as its own inventory entry.
+#[test]
+fn collect_functions_discovers_a_trait_default_method() {
+    let file: syn::File = syn::parse_str(
+        r#"
+        trait Loader {
+            fn load(&self, file: &std::fs::File) {
+                unsafe { Mmap::map(file) };
+            }
+        }
+        "#,
+    )
+    .expect("parse trait-default-method fixture");
+    let mut functions = Vec::new();
+    let mut path_stack = Vec::new();
+    collect_functions(&file.items, &mut path_stack, &mut functions);
+    let load = functions
+        .iter()
+        .find(|(path, _)| path == "Loader::load")
+        .expect("trait default method must be discovered as its own entry (`Loader::load`)");
+    let mut sites = Vec::new();
+    let mut opaque = Vec::new();
+    let ctx = empty_ctx("fixture::f4_trait_default::Loader::load");
+    walk_block(load.1, false, &ctx, &mut sites, &mut opaque);
+    assert_eq!(
+        sites.len(),
+        1,
+        "the trait default method's own Mmap::map() call must be discovered"
+    );
+    assert!(!sites[0].dominated_by_guard);
 }
 
 #[test]
@@ -492,15 +1362,35 @@ fn every_mmap_construction_site_is_guarded_or_explicitly_exempted() {
             panic!("{relative}: Rust syntax could not be parsed: {reason}")
         });
 
+        let in_guard_definition_module = relative == GUARD_DEFINITION_MODULE;
+
         let mut functions = Vec::new();
         let mut path_stack = Vec::new();
         collect_functions(&syntax.items, &mut path_stack, &mut functions);
 
         for (function_path, body) in functions {
+            let location = format!("{relative}::{function_path}");
+            let ctx = WalkCtx {
+                location: &location,
+                in_guard_definition_module,
+                in_deferred_scope: false,
+                bound_mmap_options: BTreeSet::new(),
+            };
             let mut sites = Vec::new();
-            walk_block(body, false, &mut sites);
+            let mut opaque = Vec::new();
+            walk_block(body, false, &ctx, &mut sites, &mut opaque);
             if sites.is_empty() {
+                // Nothing here for an opaque form to hide from this
+                // contract's perspective -- see the module doc comment.
                 continue;
+            }
+
+            // An opaque form (macro/Verbatim) anywhere in a function that
+            // DOES construct an mmap can't be certified: it might expand to
+            // hide another construction, or a guard call this walk would
+            // otherwise have credited.
+            for opaque_form in &opaque {
+                violations.push(opaque_form.clone());
             }
 
             let mut ordinals: BTreeMap<&str, usize> = BTreeMap::new();
@@ -526,7 +1416,8 @@ fn every_mmap_construction_site_is_guarded_or_explicitly_exempted() {
         violations.is_empty(),
         "mmap construction site(s) with neither a trust-boundary guard call earlier in the \
          same function on a path that necessarily reaches the site, nor a reviewed \
-         MmapConstructionExemption:\n{}",
+         MmapConstructionExemption -- or a function with a construction site that also \
+         contains an opaque form this walk cannot certify:\n{}",
         violations.join("\n")
     );
 

--- a/crates/inference/tests/mmap_trust_boundary_contract.rs
+++ b/crates/inference/tests/mmap_trust_boundary_contract.rs
@@ -1,154 +1,123 @@
-//! Contract test for #1368: every site in this crate that constructs a
-//! memory map from a checkpoint file (`memmap2::Mmap::map(&file)` or
-//! `memmap2::MmapOptions::new().map(&file)`) must call one of this crate's
-//! two mmap trust-boundary chokepoints -- [`lattice_inference`]'s
-//! `weights::mmap_trust::open_trusted_mmap_file` or
-//! `reject_if_open_mmap_file_untrusted` -- **earlier in the same enclosing
-//! function, on a path that necessarily executes before the construction
-//! call** (see [`walk_expr`]'s doc comment for exactly what that does and
-//! does not cover), or carry an explicit, reviewed
-//! [`MmapConstructionExemption`] naming why not. A guard call that runs
-//! after the construction call, or only on a sibling branch that does not
-//! run before it, does not satisfy this. Nor does *visiting* a guard call
-//! textually: the guard returns a `Result`, and only a form that actually
-//! propagates its failure -- `?`, `.expect(..)`, `.unwrap()` -- credits the
-//! statements after it as guarded. Collapsing that `Result` to a `bool`
-//! first (`.is_ok()`, `.is_err()`) and branching on the bool does not, even
-//! though the raw guard call is still textually present somewhere in the
-//! condition (see [`is_guard_result_chain`]).
+//! Module-boundary contract for the mmap trust boundary (#1368/#1369).
 //!
-//! A function whose body contains an opaque form this walk cannot see into
-//! (a macro invocation, or a `Verbatim` fragment syn itself could not
-//! classify) is also a violation **if that function contains at least one
-//! discovered construction site** -- the opaque form might expand to hide
-//! another one, or a guard call this walk would otherwise have credited,
-//! and there is no way to tell from the AST alone. A function with no
-//! construction site has nothing for an opaque form to hide, so it is not
-//! flagged; without that qualifier, this crate's ordinary use of `assert!`/
-//! `format!`/`vec!` outside closures anywhere in `src/` would fail every
-//! function that happens to use one, not just loaders (see
-//! [`every_mmap_construction_site_is_guarded_or_explicitly_exempted`]).
+//! Three rounds hardened an AST walker that parsed this crate's own `src/`
+//! with `syn`, found every mmap construction site, and asserted each was
+//! dominated by a call to a guard in `src/weights/mmap_trust.rs`. Each round
+//! closed real fail-open classes the walker's dominance analysis missed, and
+//! each round's successor found new ones: a macro invocation whose expansion
+//! might hide a construction site or a guard call, an `Expr::TryBlock` that
+//! returned its inner guarded state directly, a `fn` item nested inside a
+//! conditional body, a `MmapOptions::new()` bound to a local before `.map`
+//! was called on it, and (latent, no real call site used the shape) a
+//! `let mapper = Mmap::map; mapper(&file)` function-item alias. The walker
+//! was trying to prove a property about **expression shapes**, and the space
+//! of expression shapes that can reach a function call is not enumerable by
+//! anything short of the compiler's own control-flow graph.
 //!
-//! Modeled on `metal_measurement_lock_contract.rs`'s construction-site
-//! inventory: a site is named by the program structure enclosing it
-//! (`mod`/`impl`/`fn` path, plus an ordinal disambiguating repeated calls in
-//! the same function) rather than by source line/column, so an edit that
-//! only shifts line numbers cannot silently invalidate an exemption or
-//! duplicate an entry -- a position-keyed guard has to be repaired by
-//! exactly the motion that would silence it. The full discovered inventory
-//! (guarded sites plus exempted sites) is asserted against a declared
-//! expected set so an added or removed construction site always requires a
-//! conscious update here, whether or not it happens to be guarded.
+//! This file replaces that walker with a property about **module
+//! boundaries** instead, which is a small, countable space: [`weights::mmap_trust`]
+//! is now the *only* place in this crate permitted to construct a memory map
+//! (`memmap2::Mmap::map(..)` or `memmap2::MmapOptions::new()...map(..)`) from
+//! a checkpoint file. Every production construction site that used to call
+//! `Mmap::map`/`MmapOptions` directly (`quant/quarot/io.rs`,
+//! `weights/f32_weights.rs`, `weights/q4_weights.rs`,
+//! `forward/metal_qwen35.rs`) now calls one of `mmap_trust`'s own
+//! `map_and_verify_trusted` / `map_after_untrusted_open` functions, which
+//! fold the trust-boundary guard call and the map into a single function --
+//! see their doc comments for why that makes "guarded before mapped"
+//! structural rather than a per-call-site convention an external walker has
+//! to keep reverifying. Storing an already-constructed mapping (a
+//! `memmap2::Mmap` struct field, as `forward/moe_expert_cache.rs` and
+//! `forward/metal_qwen35.rs`'s `Q3WeightBuf`/`Q4WeightBuf` types both do)
+//! stays legal everywhere: construction is what this boundary protects, not
+//! possession.
+//!
+//! # Why a plain per-line text scan, not another AST walk
+//!
+//! Every one of the five evasions the round-4 review constructed against the
+//! old walker -- a macro-hidden call, a try-block, a nested `fn`, an unusual
+//! `MmapOptions` binding, a function-item alias -- still has to **name**
+//! `Mmap::map` or `MmapOptions` as literal characters somewhere in the file
+//! that invokes it. Rust has no syntax for constructing a `memmap2` mapping
+//! without spelling one of those two identifiers out. A macro invocation
+//! expands *after* this scan runs, a `try` block is still lexically present
+//! in the source, a nested `fn` is still text in the same file, a
+//! `MmapOptions` bound to a local still contains the word `MmapOptions`, and
+//! a function-item alias (`let mapper = Mmap::map;`) still writes `Mmap::map`
+//! at the point it captures the function pointer. None of the AST shapes
+//! that made the walker's *dominance* analysis hard have any bearing on
+//! whether the *token* is present -- which is exactly what a per-line scan
+//! checks, with no control-flow reasoning at all.
+//!
+//! # What this does NOT get for free
+//!
+//! - **A macro *defined* in this crate (or an external crate) whose
+//!   expansion synthesizes `Mmap::map`/`MmapOptions` without either literal
+//!   token appearing at the invocation site** would evade this scan the same
+//!   way it would evade any textual tool (`grep`, `ast-grep` without macro
+//!   expansion, etc.). This crate defines no `macro_rules!` of its own under
+//!   `src/` that expands to either token (this scan reads raw source text,
+//!   the same text a declarative macro's definition itself is written in, so
+//!   such a macro's *definition* would still be caught even though a use of
+//!   it elsewhere would not be) and takes no production dependency that
+//!   could inject one into a checkpoint-loading path. Recorded here as a
+//!   residual, not a silently assumed-away gap.
+//! - **A `use memmap2::{Mmap as X, MmapOptions as Y}` rename** at a call site
+//!   outside the boundary would let a caller invoke `X::map`/`Y::new()`
+//!   without either token matching. No file in this crate imports either
+//!   name under an alias today (verified by `grep -n 'use memmap2' -- every
+//!   hit binds the bare names), and doing so is a far more conspicuous,
+//!   review-visible act than any of the five AST evasions this design
+//!   closes -- those hid inside completely idiomatic Rust; a rename import
+//!   announces itself. Not defended against here; recorded as a residual
+//!   for the same reason as the macro case above.
+//! - **Ordering of the guard relative to the map** is no longer something
+//!   this *test* checks at all -- it is enforced by `mmap_trust.rs`'s own
+//!   function bodies (`map_and_verify_trusted`, `map_after_untrusted_open`
+//!   each call the guard, unconditionally, as the first statement, before
+//!   the `unsafe { Mmap::map(..) }` that follows). That is a stronger
+//!   guarantee than the walker's dominance analysis ever gave -- a single
+//!   straight-line function has no branches for a guard-only-on-one-arm bug
+//!   to hide in -- but it now lives as an invariant of that module's source,
+//!   not as something an external instrument re-derives on every run. A
+//!   regression there would have to be caught by `mmap_trust.rs`'s own unit
+//!   tests or code review, not by this file.
+//!
+//! # What is intentionally NOT preserved from the walker
+//!
+//! The walker's per-function inventory (`EXPECTED_MMAP_CONSTRUCTION_SITES`,
+//! keyed by `mod`/`impl`/`fn` path) forced a conscious update whenever a
+//! construction site was added, removed, or newly (un)guarded anywhere in
+//! the crate. This contract needs no equivalent allowlist: the rule outside
+//! `mmap_trust.rs` is simply "zero", unconditionally, so there is nothing to
+//! enumerate or keep in sync. A new construction site anywhere outside the
+//! boundary fails this test immediately, with no exemption list to remember
+//! to update -- a *stronger* property than the walker's inventory gave, not
+//! a weaker one dropped for convenience. Similarly dropped: the walker's own
+//! regression fixtures for its dominance analysis (`||`/`&&` short-circuit,
+//! guard-collapsed-to-bool, bare-vs-qualified guard names, opaque-macro
+//! detection) tested the walker's *implementation*, not the crate's actual
+//! security property -- with the walker deleted, there is nothing left for
+//! them to regress-test.
 
-use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use syn::{BinOp, Block, Expr, ExprCall, ExprMethodCall, ImplItem, Item, Stmt, TraitItem};
 
-/// Free functions this crate's mmap trust boundary exposes. A call to either
-/// one counts as guarding a construction site when [`walk_expr`] determines
-/// it runs on a path that necessarily executes before the site, in the same
-/// enclosing function -- not merely "anywhere in the function" (see
-/// [`walk_expr`]'s doc comment for exactly what "necessarily executes before"
-/// does and does not cover).
-const GUARD_FUNCTION_NAMES: &[&str] = &[
-    "open_trusted_mmap_file",
-    "reject_if_open_mmap_file_untrusted",
-];
+/// The two lexical tokens that name lattice's mmap **construction** API:
+/// `memmap2::Mmap::map(..)` and `memmap2::MmapOptions::new()...`. Naming the
+/// *type* (`memmap2::Mmap` as a struct field, a function parameter or return
+/// type) never matches either token -- `Mmap::map` requires the literal
+/// `::map` suffix, `MmapOptions` names a different type entirely -- so
+/// storing an already-constructed mapping stays unrestricted everywhere in
+/// this crate; only building one outside the boundary is what these tokens
+/// catch. See [`naming_the_mmap_type_without_constructing_one_stays_legal`]
+/// for a direct proof of that distinction.
+const CONSTRUCTION_TOKENS: &[&str] = &["Mmap::map", "MmapOptions"];
 
-/// Macros this walk trusts as pure, control-flow-transparent value
-/// producers with no bearing on the mmap trust boundary -- all from `std`,
-/// none able to expand into a hidden item, `let`, or arbitrary user call.
-/// This crate's real guarded loaders use several of these directly (not
-/// only inside a closure) for error-message construction, e.g.
-/// `return Err(InferenceError::InvalidSafetensors(format!(".."))))` in
-/// `quant/quarot/io.rs::Shard::open`, and `assert!`/`debug_assert!` as bare
-/// validation statements in `weights/q4_weights.rs::open_and_mmap_q4_file`
-/// and `weights/mmap_trust.rs`'s own tests. Any macro NOT on this list is
-/// opaque (see [`walk_expr`]'s `Expr::Macro` arm and the module doc
-/// comment): this is a reviewed, deliberate scope decision, not an
-/// oversight -- treating literally every macro invocation in the crate as
-/// disqualifying would fail functions that have nothing to do with mmap
-/// construction at all (see
-/// [`every_mmap_construction_site_is_guarded_or_explicitly_exempted`]'s doc
-/// comment), which is a different failure mode than the one this test
-/// exists to catch.
-const TRANSPARENT_MACRO_NAMES: &[&str] = &[
-    "format",
-    "write",
-    "writeln",
-    "vec",
-    "matches",
-    "assert",
-    "assert_eq",
-    "assert_ne",
-    "debug_assert",
-    "debug_assert_eq",
-    "debug_assert_ne",
-    "panic",
-    "unreachable",
-    "todo",
-    "unimplemented",
-    "println",
-    "eprintln",
-    "print",
-    "eprint",
-    "dbg",
-];
-
-/// Whether a macro path names one of [`TRANSPARENT_MACRO_NAMES`]. Matches
-/// only a bare single-segment path (`format!(..)`), consistent with how all
-/// of these are actually invoked -- a qualified path to a same-named macro
-/// (`some_module::format!(..)`, vanishingly rare and not used anywhere in
-/// this crate) is deliberately NOT trusted, the same "don't trust a bare
-/// name across a module boundary" posture [`is_guard_call`] takes for the
-/// opposite reason (there, to avoid crediting a decoy; here, to avoid
-/// trusting one).
-fn is_transparent_macro(path: &syn::Path) -> bool {
-    path.get_ident()
-        .is_some_and(|ident| TRANSPARENT_MACRO_NAMES.contains(&ident.to_string().as_str()))
-}
-
-/// The module (relative to the manifest directory) that defines
-/// [`GUARD_FUNCTION_NAMES`]. Every caller outside this file spells the guard
-/// call with the full crate-qualified path (`crate::weights::mmap_trust::..`
-/// or `weights::mmap_trust::..`); only this module's own `mod tests` (via
-/// `use super::*`) calls a guard bare. A bare, unqualified call anywhere
-/// else in the crate cannot be trusted to name the real guard rather than a
-/// same-named local shadow (see [`is_guard_call`]).
-const GUARD_DEFINITION_MODULE: &str = "src/weights/mmap_trust.rs";
-
-/// A construction site exempted from the guard-call requirement, keyed by
-/// program structure (see module doc comment), with a reviewed reason on
-/// record for why routing it through a guard call directly is unnecessary
-/// or incorrect.
-struct MmapConstructionExemption {
-    site: &'static str,
-    reason: &'static str,
-}
-
-const MMAP_CONSTRUCTION_EXEMPTIONS: &[MmapConstructionExemption] = &[MmapConstructionExemption {
-    site: "src/weights/f32_weights.rs::SafetensorsFile::from_open_file::Mmap::map()#1",
-    reason: "from_open_file takes an already-open File specifically so it never re-opens \
-             by path (reopening would reintroduce the window between open and read its own \
-             doc comment describes). Its only callers -- SafetensorsFile::open and \
-             ShardedSafetensors::open_shard (via open_manifest_entry_once) -- both call \
-             reject_if_open_mmap_file_untrusted on that same File before handing it here, \
-             so the guard call sits in the caller, not in this function.",
-}];
-
-/// The complete population of mmap-construction sites this crate contains,
-/// whether guarded directly or exempted above. Discovering a site not in
-/// this set, or failing to discover one that is, fails the contract --
-/// forcing a conscious update here for any added, removed, or newly
-/// (un)guarded site.
-const EXPECTED_MMAP_CONSTRUCTION_SITES: &[&str] = &[
-    "src/forward/metal_qwen35.rs::inner::mmap_q3_weight::MmapOptions::new().map()#1",
-    "src/quant/quarot/io.rs::Shard::open::Mmap::map()#1",
-    "src/weights/f32_weights.rs::SafetensorsFile::from_open_file::Mmap::map()#1",
-    "src/weights/mmap_trust.rs::tests::verify_mmap_target_unchanged_accepts_an_unmodified_file::MmapOptions::new().map()#1",
-    "src/weights/mmap_trust.rs::tests::verify_mmap_target_unchanged_rejects_a_truncate_after_validate_race::MmapOptions::new().map()#1",
-    "src/weights/q4_weights.rs::open_and_mmap_q4_file::MmapOptions::new().map()#1",
-];
+/// The sole file permitted to name a [`CONSTRUCTION_TOKENS`] token anywhere
+/// in this crate's `src/` tree (code, doc comment, or otherwise -- see the
+/// module doc comment's "plain per-line text scan" section for why this
+/// contract does not distinguish them).
+const TRUST_BOUNDARY_FILE: &str = "src/weights/mmap_trust.rs";
 
 fn rust_sources_under(root: &Path) -> Vec<PathBuf> {
     let mut pending = vec![root.to_path_buf()];
@@ -167,1187 +136,35 @@ fn rust_sources_under(root: &Path) -> Vec<PathBuf> {
     sources
 }
 
-fn path_ends_with(path: &syn::Path, tail: &[&str]) -> bool {
-    let segments: Vec<String> = path.segments.iter().map(|s| s.ident.to_string()).collect();
-    if segments.len() < tail.len() {
-        return false;
-    }
-    segments[segments.len() - tail.len()..]
-        .iter()
-        .zip(tail.iter())
-        .all(|(have, want)| have == want)
-}
-
-/// Renders a `syn::Path` as `a::b::c`, for the opaque-form messages this
-/// walk records.
-fn path_to_string(path: &syn::Path) -> String {
-    path.segments
-        .iter()
-        .map(|segment| segment.ident.to_string())
-        .collect::<Vec<_>>()
-        .join("::")
-}
-
-/// The receiver type name for an `impl` block, mirroring the sibling Metal
-/// contract test's `impl_self_type_label` so a method's stable key includes
-/// its type even when two `impl` blocks define a method with the same name.
-fn impl_self_type_label(self_ty: &syn::Type) -> String {
-    if let syn::Type::Path(type_path) = self_ty
-        && let Some(segment) = type_path.path.segments.last()
-    {
-        return segment.ident.to_string();
-    }
-    "impl".to_string()
-}
-
-/// Every free function, `impl` method, and default `trait` method body in a
-/// parsed file, named by its enclosing `mod`/`impl`/`trait` path (matching
-/// `EXPECTED_MMAP_CONSTRUCTION_SITES`' key format) and paired with its body
-/// for [`walk_block`]/[`walk_expr`] below. Also descends one level into each
-/// collected body's own top-level statements looking for a nested `fn`
-/// item, so `fn outer() { fn inner() { .. } .. }` reaches `inner` as its own
-/// entry rather than vanishing into `Stmt::Item`'s pass-through in
-/// [`walk_block`]. A nested item declared inside an `if`/`match`/loop body
-/// rather than directly in the function's own block is a further,
-/// documented gap: reaching it needs the same block-walking [`walk_expr`]
-/// already does, which this discovery pass deliberately keeps separate from
-/// (rather than duplicating).
-fn collect_functions<'a>(
-    items: &'a [Item],
-    path: &mut Vec<String>,
-    out: &mut Vec<(String, &'a syn::Block)>,
-) {
-    for item in items {
-        match item {
-            Item::Fn(function) => {
-                path.push(function.sig.ident.to_string());
-                out.push((path.join("::"), &function.block));
-                collect_nested_function_items(&function.block, path, out);
-                path.pop();
+/// Every `(1-indexed line number, token)` pair found by scanning `source`
+/// line by line for [`CONSTRUCTION_TOKENS`]. A plain substring scan, not an
+/// AST walk -- see the module doc comment for why that is the point, not a
+/// simplification made at the expense of soundness.
+fn construction_token_hits(source: &str) -> Vec<(usize, &'static str)> {
+    let mut hits = Vec::new();
+    for (zero_indexed_line, line) in source.lines().enumerate() {
+        for token in CONSTRUCTION_TOKENS {
+            if line.contains(token) {
+                hits.push((zero_indexed_line + 1, *token));
             }
-            Item::Mod(module) => {
-                if let Some((_, contents)) = &module.content {
-                    path.push(module.ident.to_string());
-                    collect_functions(contents, path, out);
-                    path.pop();
-                }
-            }
-            Item::Impl(item_impl) => {
-                path.push(impl_self_type_label(&item_impl.self_ty));
-                for impl_item in &item_impl.items {
-                    if let ImplItem::Fn(method) = impl_item {
-                        path.push(method.sig.ident.to_string());
-                        out.push((path.join("::"), &method.block));
-                        collect_nested_function_items(&method.block, path, out);
-                        path.pop();
-                    }
-                }
-                path.pop();
-            }
-            Item::Trait(item_trait) => {
-                path.push(item_trait.ident.to_string());
-                for trait_item in &item_trait.items {
-                    if let TraitItem::Fn(method) = trait_item
-                        && let Some(default) = &method.default
-                    {
-                        path.push(method.sig.ident.to_string());
-                        out.push((path.join("::"), default));
-                        collect_nested_function_items(default, path, out);
-                        path.pop();
-                    }
-                }
-                path.pop();
-            }
-            _ => {}
         }
     }
+    hits
 }
 
-/// Scans a block's own top-level statements (not nested blocks -- see
-/// [`collect_functions`]'s doc comment) for a nested `fn`/`impl`/`trait`
-/// item and feeds it back through [`collect_functions`] under the enclosing
-/// path, so it gets its own inventory entry instead of silently vanishing.
-fn collect_nested_function_items<'a>(
-    block: &'a syn::Block,
-    path: &mut Vec<String>,
-    out: &mut Vec<(String, &'a syn::Block)>,
-) {
-    for stmt in &block.stmts {
-        if let Stmt::Item(item) = stmt {
-            collect_functions(std::slice::from_ref(item), path, out);
-        }
-    }
-}
-
-/// Whether an `Expr::Call` node calls one of [`GUARD_FUNCTION_NAMES`],
-/// resolved through the crate-qualified path rather than the final path
-/// segment alone. A bare, single-segment call is only accepted when scanning
-/// [`GUARD_DEFINITION_MODULE`] itself (see that constant's doc comment) --
-/// everywhere else a bare identifier could name a same-named local shadow,
-/// and a multi-segment path that isn't the real `weights::mmap_trust::..`
-/// suffix definitely does.
-fn is_guard_call(call: &ExprCall, ctx: &WalkCtx) -> bool {
-    let Expr::Path(callee) = &*call.func else {
-        return false;
-    };
-    let segments: Vec<String> = callee
-        .path
-        .segments
-        .iter()
-        .map(|segment| segment.ident.to_string())
-        .collect();
-    let Some(name) = segments.last() else {
-        return false;
-    };
-    if !GUARD_FUNCTION_NAMES.contains(&name.as_str()) {
-        return false;
-    }
-    match segments.len() {
-        1 => ctx.in_guard_definition_module,
-        _ => {
-            let tail: &[String] = if segments[0] == "crate" {
-                &segments[1..]
-            } else {
-                &segments[..]
-            };
-            tail.len() == 3 && tail[0] == "weights" && tail[1] == "mmap_trust"
-        }
-    }
-}
-
-/// Whether `expr` is a `Result`-valued chain rooted at a guard call and
-/// carried through zero or more combinators that preserve its `Ok`-ness
-/// (currently just `.map_err(..)`, the only one this crate's callers use).
-/// Deliberately does NOT recognize `.is_ok()`/`.is_err()` or any other
-/// combinator that collapses the `Result` to something else: those launder
-/// the guard's outcome into a value whose truthiness this walk cannot
-/// soundly connect back to "the guard succeeded" (see [`walk_expr`]'s
-/// `Expr::Try`/`Expr::MethodCall` handling, which are the only places this
-/// predicate feeds into the `guarded` flag).
-fn is_guard_result_chain(expr: &Expr, ctx: &WalkCtx) -> bool {
-    match expr {
-        Expr::Call(call) => is_guard_call(call, ctx),
-        Expr::MethodCall(method_call) if method_call.method == "map_err" => {
-            is_guard_result_chain(&method_call.receiver, ctx)
-        }
-        Expr::Paren(paren) => is_guard_result_chain(&paren.expr, ctx),
-        Expr::Group(group) => is_guard_result_chain(&group.expr, ctx),
-        _ => false,
-    }
-}
-
-/// Whether an `Expr::Call` node is the inline `MmapOptions::new()` idiom.
-fn is_mmap_options_new_call(call: &ExprCall) -> bool {
-    call.args.is_empty()
-        && matches!(&*call.func, Expr::Path(callee) if path_ends_with(&callee.path, &["MmapOptions", "new"]))
-}
-
-/// Whether an `Expr::Call` node is the free-function `Mmap::map(..)` mmap
-/// construction idiom. Syntactic, like [`is_mmap_options_new_call`]: an
-/// alias or function-item indirection of `Mmap::map` (`let f = Mmap::map; f
-/// (&file)`) is not recognized, and is a documented residual gap rather than
-/// a silently assumed-away one -- no construction site in this crate uses
-/// that shape today.
-fn is_mmap_map_call(call: &ExprCall) -> bool {
-    matches!(&*call.func, Expr::Path(callee) if path_ends_with(&callee.path, &["Mmap", "map"]))
-}
-
-/// Whether an `Expr::MethodCall` node is the `MmapOptions::new().map(..)`
-/// mmap construction idiom, including when the `MmapOptions::new()` value
-/// was bound to a local variable first (`let opts = MmapOptions::new();
-/// opts.map(..)`) -- tracked via [`WalkCtx::bound_mmap_options`], populated
-/// by [`walk_block`] as it processes `let` statements.
-fn is_mmap_options_map_call(method_call: &ExprMethodCall, ctx: &WalkCtx) -> bool {
-    if method_call.method != "map" {
-        return false;
-    }
-    match &*method_call.receiver {
-        Expr::Call(receiver_call) => is_mmap_options_new_call(receiver_call),
-        Expr::Path(receiver_path) => receiver_path
-            .path
-            .get_ident()
-            .is_some_and(|ident| ctx.bound_mmap_options.contains(&ident.to_string())),
-        _ => false,
-    }
-}
-
-/// A discovered mmap construction call, in the order [`walk_expr`] visits
-/// it, paired with whether a guard call was seen on a path that necessarily
-/// executes before it.
-struct SiteObservation {
-    selector: &'static str,
-    dominated_by_guard: bool,
-}
-
-/// Context threaded through [`walk_expr`]/[`walk_block`] alongside the
-/// per-branch `guarded` flag: state that is scoped to (part of) a function
-/// rather than to one control-flow branch.
-#[derive(Clone)]
-struct WalkCtx<'a> {
-    /// `{relative_path}::{function_path}`, named in an opaque-form message
-    /// so it points at the function, not just "somewhere".
-    location: &'a str,
-    /// See [`GUARD_DEFINITION_MODULE`].
-    in_guard_definition_module: bool,
-    /// True once inside a closure/`async`/`const` block. These run later,
-    /// independently of the enclosing function -- see the "Closures and
-    /// `async`/`const` blocks" bullet in [`walk_expr`]'s doc comment -- so
-    /// an opaque macro/`Verbatim` form inside one cannot hide code that runs
-    /// on *this* function's own guard-to-map path, and is not recorded (see
-    /// the `Expr::Macro`/`Expr::Verbatim` arms below).
-    in_deferred_scope: bool,
-    /// Local variables in the current scope bound directly to
-    /// `MmapOptions::new()` (see [`is_mmap_options_map_call`]).
-    bound_mmap_options: BTreeSet<String>,
-}
-
-fn empty_ctx(location: &str) -> WalkCtx<'_> {
-    WalkCtx {
-        location,
-        in_guard_definition_module: false,
-        in_deferred_scope: false,
-        bound_mmap_options: BTreeSet::new(),
-    }
-}
-
-/// Walks an expression in source order, threading a `guarded` flag that
-/// becomes (and stays) `true` once a guard call has been seen on a path that
-/// *necessarily* executes before the current point -- the "first" the module
-/// doc comment requires -- AND whose success is actually propagated, not
-/// merely observed (see [`is_guard_result_chain`]). This is a
-/// textual/structural approximation of control-flow dominance, not a real
-/// control-flow-graph analysis; it is sufficient for this crate's loaders,
-/// which are straight-line open-then-map functions, but the following cases
-/// are explicitly NOT treated as dominance:
-///
-/// - **`if`/`else` branches and `match` arms.** A guard call inside one arm
-///   is scoped to that arm alone: it is never credited to a sibling arm, nor
-///   to the statements that follow the conditional, because the *other* arm
-///   might have run instead. This is what catches "one branch guards,
-///   another maps unguarded". A conditional that guards on *every* arm is
-///   (conservatively) still not credited outside the conditional -- doing
-///   that soundly needs real control-flow reachability, which this AST walk
-///   does not build.
-/// - **Loop bodies** (`loop`/`while`/`for`). A loop may run zero times, so a
-///   guard call inside one is never credited to code after the loop, and a
-///   site inside the loop only sees guard calls from strictly before the
-///   loop, never from an earlier iteration of the same loop.
-/// - **Closures and `async`/`const` blocks.** Their bodies run later (or not
-///   at all) relative to the enclosing function, so each starts its own,
-///   independently threaded `guarded = false` and never reads or writes the
-///   surrounding flow's flag in either direction.
-/// - **Early `return`/`break`.** This walk has no notion of unreachable code
-///   after a diverging expression: it keeps threading `guarded` through the
-///   statements that textually follow one in the same block. A guard call
-///   placed after an unconditional `return` would (incorrectly) still be
-///   credited to sites after it, even though that guard call can never
-///   actually run. None of this crate's loaders do that; it is recorded here
-///   as a known gap rather than silently assumed away.
-/// - **A guard call collapsed to a `bool`.** `guard(..).is_ok()` or
-///   `guard(..).is_err()`, used as an `if`/`&&`/`||` operand, does NOT credit
-///   the guard: visiting the call is not the same as observing that it
-///   succeeded and having that success actually gate what runs next. Only
-///   `guard(..)?`, `guard(..).expect(..)`, `guard(..).unwrap()` (optionally
-///   through `.map_err(..)`) do that -- see [`is_guard_result_chain`] and the
-///   `Expr::Try`/`Expr::MethodCall` arms below.
-///
-/// What DOES count as "necessarily executes before" and so threads the flag
-/// straight through: sequential statements in the same block, `unsafe { .. }`
-/// and bare `{ .. }` blocks, `try { .. }` blocks, `?`, casts, references,
-/// raw address-of (`&raw const`/`&raw mut`), field/index access,
-/// method-call/call receivers and arguments (in left-to-right evaluation
-/// order), assignment operands, and the operands of every binary operator
-/// that Rust evaluates unconditionally (arithmetic, comparison, bitwise, ...).
-///
-/// **`&&`/`||` are handled as a branch boundary, not threaded through.** Like
-/// `if`/`else`, Rust may skip the right operand entirely (`true || x` never
-/// runs `x`; `false && x` never runs `x`), so a guard call inside the right
-/// operand of `&&`/`||` is never credited to the binary expression's own
-/// outgoing state, and so never reaches sites after it -- only whatever
-/// `guarded` state the left operand (which always runs) produced does. The
-/// right operand is still walked so a construction site inside it is
-/// discovered and, symmetrically, still sees the left operand's guard state
-/// as input, since the left operand necessarily runs first whenever the
-/// right one runs at all.
-///
-/// **Every `Expr` variant syn 2.0.119 defines is matched explicitly.** A
-/// pure leaf with nothing to recurse into (`Continue`, `Infer`, `Lit`,
-/// `Path`) passes `guarded_in` straight through. An opaque form this walk
-/// cannot see into -- `Macro`, `Verbatim` -- is recorded into `opaque`
-/// (unless `ctx.in_deferred_scope`, see [`WalkCtx::in_deferred_scope`]);
-/// [`every_mmap_construction_site_is_guarded_or_explicitly_exempted`] turns
-/// that into a violation for any function that also has a discovered
-/// construction site. `Expr` is `#[non_exhaustive]`, so a `_` arm is still
-/// required for a future syn version's new variant; unlike the two known
-/// opaque forms, that arm panics immediately -- a variant this walk has
-/// never seen is not something the deferred, per-function judgment above
-/// can safely reason about at all.
-fn walk_expr(
-    expr: &Expr,
-    guarded_in: bool,
-    ctx: &WalkCtx,
-    sites: &mut Vec<SiteObservation>,
-    opaque: &mut Vec<String>,
-) -> bool {
-    match expr {
-        Expr::Block(block) => walk_block(&block.block, guarded_in, ctx, sites, opaque),
-        Expr::Unsafe(block) => walk_block(&block.block, guarded_in, ctx, sites, opaque),
-        Expr::TryBlock(try_block) => walk_block(&try_block.block, guarded_in, ctx, sites, opaque),
-        Expr::Call(call) => {
-            let mut guarded = walk_expr(&call.func, guarded_in, ctx, sites, opaque);
-            for arg in &call.args {
-                guarded = walk_expr(arg, guarded, ctx, sites, opaque);
-            }
-            if is_mmap_map_call(call) {
-                sites.push(SiteObservation {
-                    selector: "Mmap::map()",
-                    dominated_by_guard: guarded,
-                });
-            }
-            guarded
-        }
-        Expr::MethodCall(method_call) => {
-            let mut guarded = walk_expr(&method_call.receiver, guarded_in, ctx, sites, opaque);
-            for arg in &method_call.args {
-                guarded = walk_expr(arg, guarded, ctx, sites, opaque);
-            }
-            if is_mmap_options_map_call(method_call, ctx) {
-                sites.push(SiteObservation {
-                    selector: "MmapOptions::new().map()",
-                    dominated_by_guard: guarded,
-                });
-            }
-            if (method_call.method == "expect" || method_call.method == "unwrap")
-                && is_guard_result_chain(&method_call.receiver, ctx)
-            {
-                guarded = true;
-            }
-            guarded
-        }
-        Expr::Try(try_expr) => {
-            let guarded = walk_expr(&try_expr.expr, guarded_in, ctx, sites, opaque);
-            if is_guard_result_chain(&try_expr.expr, ctx) {
-                true
-            } else {
-                guarded
-            }
-        }
-        Expr::If(if_expr) => {
-            let guarded = walk_expr(&if_expr.cond, guarded_in, ctx, sites, opaque);
-            walk_block(&if_expr.then_branch, guarded, ctx, sites, opaque);
-            if let Some((_, else_expr)) = &if_expr.else_branch {
-                walk_expr(else_expr, guarded, ctx, sites, opaque);
-            }
-            guarded
-        }
-        Expr::Match(match_expr) => {
-            let guarded = walk_expr(&match_expr.expr, guarded_in, ctx, sites, opaque);
-            for arm in &match_expr.arms {
-                if let Some((_, guard_cond)) = &arm.guard {
-                    walk_expr(guard_cond, guarded, ctx, sites, opaque);
-                }
-                walk_expr(&arm.body, guarded, ctx, sites, opaque);
-            }
-            guarded
-        }
-        Expr::Loop(loop_expr) => {
-            walk_block(&loop_expr.body, guarded_in, ctx, sites, opaque);
-            guarded_in
-        }
-        Expr::While(while_expr) => {
-            let guarded = walk_expr(&while_expr.cond, guarded_in, ctx, sites, opaque);
-            walk_block(&while_expr.body, guarded, ctx, sites, opaque);
-            guarded_in
-        }
-        Expr::ForLoop(for_loop) => {
-            let guarded = walk_expr(&for_loop.expr, guarded_in, ctx, sites, opaque);
-            walk_block(&for_loop.body, guarded, ctx, sites, opaque);
-            guarded_in
-        }
-        Expr::Closure(closure) => {
-            let mut deferred = ctx.clone();
-            deferred.in_deferred_scope = true;
-            walk_expr(&closure.body, false, &deferred, sites, opaque);
-            guarded_in
-        }
-        Expr::Async(async_expr) => {
-            let mut deferred = ctx.clone();
-            deferred.in_deferred_scope = true;
-            walk_block(&async_expr.block, false, &deferred, sites, opaque);
-            guarded_in
-        }
-        Expr::Const(const_expr) => {
-            let mut deferred = ctx.clone();
-            deferred.in_deferred_scope = true;
-            walk_block(&const_expr.block, false, &deferred, sites, opaque);
-            guarded_in
-        }
-        Expr::Paren(paren) => walk_expr(&paren.expr, guarded_in, ctx, sites, opaque),
-        Expr::Group(group) => walk_expr(&group.expr, guarded_in, ctx, sites, opaque),
-        Expr::Reference(reference) => walk_expr(&reference.expr, guarded_in, ctx, sites, opaque),
-        Expr::RawAddr(raw_addr) => walk_expr(&raw_addr.expr, guarded_in, ctx, sites, opaque),
-        Expr::Unary(unary) => walk_expr(&unary.expr, guarded_in, ctx, sites, opaque),
-        Expr::Cast(cast) => walk_expr(&cast.expr, guarded_in, ctx, sites, opaque),
-        Expr::Field(field) => walk_expr(&field.base, guarded_in, ctx, sites, opaque),
-        Expr::Await(await_expr) => walk_expr(&await_expr.base, guarded_in, ctx, sites, opaque),
-        Expr::Let(let_expr) => walk_expr(&let_expr.expr, guarded_in, ctx, sites, opaque),
-        Expr::Return(return_expr) => match &return_expr.expr {
-            Some(inner) => walk_expr(inner, guarded_in, ctx, sites, opaque),
-            None => guarded_in,
-        },
-        Expr::Break(break_expr) => match &break_expr.expr {
-            Some(inner) => walk_expr(inner, guarded_in, ctx, sites, opaque),
-            None => guarded_in,
-        },
-        Expr::Yield(yield_expr) => match &yield_expr.expr {
-            Some(inner) => walk_expr(inner, guarded_in, ctx, sites, opaque),
-            None => guarded_in,
-        },
-        Expr::Continue(_) | Expr::Infer(_) | Expr::Lit(_) | Expr::Path(_) => guarded_in,
-        Expr::Index(index) => {
-            let guarded = walk_expr(&index.expr, guarded_in, ctx, sites, opaque);
-            walk_expr(&index.index, guarded, ctx, sites, opaque)
-        }
-        Expr::Binary(binary) => {
-            let guarded = walk_expr(&binary.left, guarded_in, ctx, sites, opaque);
-            match binary.op {
-                BinOp::And(_) | BinOp::Or(_) => {
-                    // `&&`/`||` short-circuit: the right operand may never run.
-                    // Walk it so a construction site inside is still discovered,
-                    // but a guard call inside it must not be credited to sites
-                    // that follow the whole expression -- only `guarded` (the
-                    // state after the left operand, which always runs) does.
-                    walk_expr(&binary.right, guarded, ctx, sites, opaque);
-                    guarded
-                }
-                _ => walk_expr(&binary.right, guarded, ctx, sites, opaque),
-            }
-        }
-        Expr::Assign(assign) => {
-            let guarded = walk_expr(&assign.left, guarded_in, ctx, sites, opaque);
-            walk_expr(&assign.right, guarded, ctx, sites, opaque)
-        }
-        Expr::Repeat(repeat) => {
-            let guarded = walk_expr(&repeat.expr, guarded_in, ctx, sites, opaque);
-            walk_expr(&repeat.len, guarded, ctx, sites, opaque)
-        }
-        Expr::Range(range) => {
-            let mut guarded = guarded_in;
-            if let Some(start) = &range.start {
-                guarded = walk_expr(start, guarded, ctx, sites, opaque);
-            }
-            if let Some(end) = &range.end {
-                guarded = walk_expr(end, guarded, ctx, sites, opaque);
-            }
-            guarded
-        }
-        Expr::Tuple(tuple) => {
-            let mut guarded = guarded_in;
-            for elem in &tuple.elems {
-                guarded = walk_expr(elem, guarded, ctx, sites, opaque);
-            }
-            guarded
-        }
-        Expr::Array(array) => {
-            let mut guarded = guarded_in;
-            for elem in &array.elems {
-                guarded = walk_expr(elem, guarded, ctx, sites, opaque);
-            }
-            guarded
-        }
-        Expr::Struct(struct_expr) => {
-            let mut guarded = guarded_in;
-            for field in &struct_expr.fields {
-                guarded = walk_expr(&field.expr, guarded, ctx, sites, opaque);
-            }
-            if let Some(rest) = &struct_expr.rest {
-                guarded = walk_expr(rest, guarded, ctx, sites, opaque);
-            }
-            guarded
-        }
-        Expr::Macro(macro_expr) => {
-            if !ctx.in_deferred_scope && !is_transparent_macro(&macro_expr.mac.path) {
-                opaque.push(format!(
-                    "{}: a macro invocation (`{}!(..)`) is opaque to this AST walk",
-                    ctx.location,
-                    path_to_string(&macro_expr.mac.path)
-                ));
-            }
-            guarded_in
-        }
-        Expr::Verbatim(_) => {
-            if !ctx.in_deferred_scope {
-                opaque.push(format!(
-                    "{}: syn could not classify this expression into a known AST form \
-                     (Verbatim)",
-                    ctx.location
-                ));
-            }
-            guarded_in
-        }
-        // `Expr` is `#[non_exhaustive]`: every variant syn 2.0.119 defines is
-        // matched explicitly above (see this function's doc comment). A
-        // variant this match doesn't recognize -- from a newer syn version --
-        // fails closed immediately rather than being folded into the
-        // deferred `opaque` judgment above: upgrading syn to a version with
-        // a genuinely new `Expr` variant needs a conscious update here, not
-        // a per-function pass/fail call this walk cannot make blind.
-        _ => panic!(
-            "{}: an expression form this AST walk does not recognize (syn may have added a new \
-             `Expr` variant) -- update `walk_expr` to handle it explicitly before trusting this \
-             contract again",
-            ctx.location
-        ),
-    }
-}
-
-/// Walks a block's statements in source order, threading `guarded` the same
-/// way [`walk_expr`] does, and extending `ctx.bound_mmap_options` as `let`
-/// bindings to `MmapOptions::new()` are seen (scoped to this block and its
-/// children; not merged back into the caller's scope, matching how `guarded`
-/// itself is not threaded back out of a nested block's own control-flow
-/// forms).
-fn walk_block(
-    block: &Block,
-    guarded_in: bool,
-    ctx: &WalkCtx,
-    sites: &mut Vec<SiteObservation>,
-    opaque: &mut Vec<String>,
-) -> bool {
-    let mut guarded = guarded_in;
-    let mut ctx = ctx.clone();
-    for stmt in &block.stmts {
-        guarded = match stmt {
-            Stmt::Local(local) => {
-                let mut guarded_after = guarded;
-                if let Some(init) = &local.init {
-                    guarded_after = walk_expr(&init.expr, guarded_after, &ctx, sites, opaque);
-                    if let syn::Pat::Ident(pat_ident) = &local.pat
-                        && let Expr::Call(call) = &*init.expr
-                        && is_mmap_options_new_call(call)
-                    {
-                        ctx.bound_mmap_options.insert(pat_ident.ident.to_string());
-                    }
-                    if let Some((_, diverge)) = &init.diverge {
-                        // `let ... else { diverge }`: the diverge block only
-                        // runs when the pattern does NOT match, so -- like an
-                        // `if`/`match` arm -- it is internal-only and never
-                        // propagated to the statements that follow.
-                        walk_expr(diverge, guarded_after, &ctx, sites, opaque);
-                    }
-                }
-                guarded_after
-            }
-            Stmt::Expr(expr, _) => walk_expr(expr, guarded, &ctx, sites, opaque),
-            // A nested item (e.g. `fn inner() { .. }`) is discovered and
-            // walked separately, as its own entry, by
-            // `collect_nested_function_items` -- it is a distinct callable
-            // unit that does not run inline with these statements, so it is
-            // correctly a no-op here rather than something to recurse into.
-            Stmt::Item(_) => guarded,
-            Stmt::Macro(stmt_macro) => {
-                if !ctx.in_deferred_scope && !is_transparent_macro(&stmt_macro.mac.path) {
-                    opaque.push(format!(
-                        "{}: a macro invocation (`{}!(..)`) in statement position is opaque to \
-                         this AST walk",
-                        ctx.location,
-                        path_to_string(&stmt_macro.mac.path)
-                    ));
-                }
-                guarded
-            }
-        };
-    }
-    guarded
-}
-
-/// Regression fixture for the `||` short-circuit hole: `true || guard(..)`
-/// never evaluates the guard at runtime, so it must not be credited to the
-/// `Mmap::map()` call that follows. Parses a synthetic [`Block`] directly and
-/// drives [`walk_block`] on it, rather than routing through the `src/` scan
-/// and [`EXPECTED_MMAP_CONSTRUCTION_SITES`] inventory used by the tests
-/// below -- this file has no existing indirection for exercising a shape
-/// without a real construction site in `src/`, and adding a `src/`-only
-/// fixture would touch production source for a case that has nothing to do
-/// with a real loader.
+/// The contract: outside [`TRUST_BOUNDARY_FILE`], no file under this crate's
+/// `src/` names a mmap construction API -- and, in the same invocation, the
+/// scan finds at least one such name *inside* that file. The second half is
+/// the must-MATCH arm: a scan that finds nothing exits the same way whether
+/// the crate is clean or the scan itself is broken (wrong root, wrong
+/// extension filter, a typo'd token), and only a positive control run
+/// alongside the negative one tells those apart.
 #[test]
-fn walk_expr_does_not_credit_a_guard_call_inside_an_or_short_circuit() {
-    let block: Block = syn::parse_str(
-        r#"{
-            true || open_trusted_mmap_file(&file).is_ok();
-            Mmap::map(&file)
-        }"#,
-    )
-    .expect("parse `||` short-circuit fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::or_short_circuit");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "fixture must discover exactly the Mmap::map() construction site"
-    );
-    assert_eq!(sites[0].selector, "Mmap::map()");
-    assert!(
-        !sites[0].dominated_by_guard,
-        "a guard call reachable only through the right operand of `||` must not be credited: \
-         `true || open_trusted_mmap_file(..)` never evaluates the guard at runtime"
-    );
-}
-
-/// Mirror of the `||` fixture above for `&&`: `false && guard(..)` never
-/// evaluates the guard at runtime either.
-#[test]
-fn walk_expr_does_not_credit_a_guard_call_inside_an_and_short_circuit() {
-    let block: Block = syn::parse_str(
-        r#"{
-            false && open_trusted_mmap_file(&file).is_ok();
-            Mmap::map(&file)
-        }"#,
-    )
-    .expect("parse `&&` short-circuit fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::and_short_circuit");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "fixture must discover exactly the Mmap::map() construction site"
-    );
-    assert_eq!(sites[0].selector, "Mmap::map()");
-    assert!(
-        !sites[0].dominated_by_guard,
-        "a guard call reachable only through the right operand of `&&` must not be credited: \
-         `false && open_trusted_mmap_file(..)` never evaluates the guard at runtime"
-    );
-}
-
-/// F1 regression: `guard(..).is_ok() || unsafe { Mmap::map(&file) }` runs the
-/// mmap exactly when the guard's `.is_ok()` is `false` -- i.e. exactly when
-/// the guard FAILED. Visiting the raw guard call inside `.is_ok()` must not
-/// be credited: only a form that propagates the guard's success
-/// (`?`/`.expect`/`.unwrap`) may.
-#[test]
-fn walk_expr_does_not_credit_a_guard_call_collapsed_to_bool_via_is_ok_in_or() {
-    let block: Block = syn::parse_str(
-        r#"{
-            reject_if_open_mmap_file_untrusted(&file, path).is_ok() || unsafe { Mmap::map(&file) };
-        }"#,
-    )
-    .expect("parse F1 fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f1_is_ok_or");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "fixture must discover exactly one Mmap::map() site"
-    );
-    assert!(
-        !sites[0].dominated_by_guard,
-        "`guard(..).is_ok() || map(..)` runs the map exactly when the guard FAILED; the guard \
-         call being textually present must not be credited"
-    );
-}
-
-/// F2 regression: `if guard(..).is_err() { unsafe { Mmap::map(&file) }; }`
-/// runs the mmap exactly in the branch where the guard failed. Same root
-/// cause as F1.
-#[test]
-fn walk_expr_does_not_credit_a_guard_call_collapsed_to_bool_via_is_err_in_if() {
-    let block: Block = syn::parse_str(
-        r#"{
-            if reject_if_open_mmap_file_untrusted(&file, path).is_err() {
-                unsafe { Mmap::map(&file) };
-            }
-        }"#,
-    )
-    .expect("parse F2 fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f2_is_err_if");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "fixture must discover exactly one Mmap::map() site"
-    );
-    assert!(
-        !sites[0].dominated_by_guard,
-        "`if guard(..).is_err() {{ map(..) }}` runs the map exactly when the guard FAILED; the \
-         guard call being textually present in the condition must not be credited"
-    );
-}
-
-/// Control for F1/F2: the real idiom this crate's loaders use --
-/// `crate::weights::mmap_trust::guard(..).map_err(..)?;` followed by the
-/// construction -- must still be credited. Proves the fix distinguishes
-/// "propagated via `?`" from "collapsed to bool", rather than simply never
-/// crediting a guard call again.
-#[test]
-fn walk_expr_still_credits_a_guard_call_propagated_via_try_and_map_err() {
-    let block: Block = syn::parse_str(
-        r#"{
-            crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted(&file, path)
-                .map_err(Into::into)?;
-            unsafe { Mmap::map(&file) }
-        }"#,
-    )
-    .expect("parse guard-then-map control fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::guard_then_map_control");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "fixture must discover exactly one Mmap::map() site"
-    );
-    assert!(
-        sites[0].dominated_by_guard,
-        "`guard(..).map_err(..)?;` propagates the guard's success via `?` and must still be \
-         credited to the construction call that follows"
-    );
-}
-
-/// Control for F1/F2, `.expect`/`.unwrap` form: `guard(..).expect(msg);`
-/// panics on failure, so continuation past it guarantees success -- the
-/// pattern this crate's own `mmap_trust.rs` tests use (bare, since they are
-/// scanned with `in_guard_definition_module: true`).
-#[test]
-fn walk_expr_still_credits_a_guard_call_propagated_via_expect() {
-    let block: Block = syn::parse_str(
-        r#"{
-            let (file, meta) = open_trusted_mmap_file(&path).expect("fixture");
-            unsafe { MmapOptions::new().map(&file) }
-        }"#,
-    )
-    .expect("parse expect() control fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = WalkCtx {
-        in_guard_definition_module: true,
-        ..empty_ctx("fixture::guard_expect_control")
-    };
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "fixture must discover exactly one MmapOptions::new().map() site"
-    );
-    assert!(
-        sites[0].dominated_by_guard,
-        "`guard(..).expect(..)` panics on failure, so it must still be credited to the \
-         construction call that follows"
-    );
-}
-
-/// F3 regression: `MmapOptions::new()` bound to a local before `.map(..)` is
-/// called on it must still be discovered as a construction site -- and,
-/// being unguarded here, flagged as a violation.
-#[test]
-fn walk_expr_discovers_mmap_options_map_call_through_a_local_binding() {
-    let block: Block = syn::parse_str(
-        r#"{
-            let options = MmapOptions::new();
-            unsafe { options.map(&file) };
-        }"#,
-    )
-    .expect("parse F3 fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f3_bound_options");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "a `MmapOptions::new()` bound to a local before `.map(..)` must still be discovered as \
-         a construction site, not silently vanish"
-    );
-    assert_eq!(sites[0].selector, "MmapOptions::new().map()");
-    assert!(
-        !sites[0].dominated_by_guard,
-        "the fixture has no guard call at all; the site must be reported unguarded"
-    );
-}
-
-/// F5 regression: a locally shadowed function sharing the guard's bare name,
-/// defined and called unqualified inside a module that is NOT
-/// `weights::mmap_trust`, must not satisfy the guard-call requirement --
-/// only [`GUARD_DEFINITION_MODULE`]'s own bare calls may.
-#[test]
-fn walk_expr_does_not_credit_a_locally_shadowed_guard_function() {
-    let block: Block = syn::parse_str(
-        r#"{
-            fn reject_if_open_mmap_file_untrusted(
-                _file: &std::fs::File,
-                _path: &std::path::Path,
-            ) -> Result<(), String> {
-                Ok(())
-            }
-            reject_if_open_mmap_file_untrusted(&file, path)?;
-            unsafe { Mmap::map(&file) }
-        }"#,
-    )
-    .expect("parse F5 shadow fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    // `in_guard_definition_module: false` -- this fixture models a call site
-    // OUTSIDE `weights/mmap_trust.rs`, where a bare call cannot be trusted.
-    let ctx = empty_ctx("fixture::f5_bare_shadow");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "fixture must discover exactly one Mmap::map() site"
-    );
-    assert!(
-        !sites[0].dominated_by_guard,
-        "a bare call to a locally shadowed function sharing the guard's name, outside the \
-         guard's own defining module, must not be credited"
-    );
-}
-
-/// F5 regression, qualified-path form: a decoy function reached through a
-/// path whose LAST segment matches a guard name but whose full path is not
-/// `weights::mmap_trust::..` must not satisfy the guard-call requirement.
-#[test]
-fn walk_expr_does_not_credit_a_wrongly_qualified_same_named_function() {
-    let block: Block = syn::parse_str(
-        r#"{
-            mod decoy {
-                pub(crate) fn reject_if_open_mmap_file_untrusted(
-                    _file: &std::fs::File,
-                    _path: &std::path::Path,
-                ) -> Result<(), String> {
-                    Ok(())
-                }
-            }
-            decoy::reject_if_open_mmap_file_untrusted(&file, path)?;
-            unsafe { Mmap::map(&file) }
-        }"#,
-    )
-    .expect("parse F5 qualified-decoy fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f5_qualified_decoy");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "fixture must discover exactly one Mmap::map() site"
-    );
-    assert!(
-        !sites[0].dominated_by_guard,
-        "`decoy::reject_if_open_mmap_file_untrusted` shares only the guard's last path segment; \
-         it must not be credited"
-    );
-}
-
-/// Control for F5: the crate-qualified path this crate's real callers use
-/// must still be credited.
-#[test]
-fn walk_expr_still_credits_the_crate_qualified_guard_path() {
-    let block: Block = syn::parse_str(
-        r#"{
-            crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted(&file, path)
-                .map_err(Into::into)?;
-            unsafe { Mmap::map(&file) }
-        }"#,
-    )
-    .expect("parse crate-qualified control fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f5_qualified_control");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "fixture must discover exactly one Mmap::map() site"
-    );
-    assert!(
-        sites[0].dominated_by_guard,
-        "`crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted(..)` is the real \
-         crate-qualified guard path and must be credited"
-    );
-}
-
-/// F4 regression: an unguarded construction reachable only through
-/// `Expr::RawAddr` (`&raw const`/`&raw mut`) must still be discovered.
-#[test]
-fn walk_expr_recurses_into_raw_addr_operand() {
-    let block: Block = syn::parse_str(
-        r#"{
-            let _p = &raw const unsafe { Mmap::map(&file) };
-        }"#,
-    )
-    .expect("parse RawAddr fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f4_raw_addr");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "an Mmap::map() call reachable only through the operand of `&raw const` must still be \
-         discovered"
-    );
-    assert!(!sites[0].dominated_by_guard);
-}
-
-/// F4 regression: an unguarded construction reachable only through
-/// `Expr::TryBlock` (`try { .. }`) must still be discovered.
-#[test]
-fn walk_expr_recurses_into_try_block() {
-    let block: Block = syn::parse_str(
-        r#"{
-            let _r = try {
-                unsafe { Mmap::map(&file) }?
-            };
-        }"#,
-    )
-    .expect("parse TryBlock fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f4_try_block");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "an Mmap::map() call reachable only through a `try {{ .. }}` block must still be \
-         discovered"
-    );
-    assert!(!sites[0].dominated_by_guard);
-}
-
-/// F4 regression: an unguarded construction reachable only through
-/// `Expr::Yield` must still be discovered.
-#[test]
-fn walk_expr_recurses_into_yield_operand() {
-    let block: Block = syn::parse_str(
-        r#"{
-            yield unsafe { Mmap::map(&file) };
-        }"#,
-    )
-    .expect("parse Yield fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f4_yield");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "an Mmap::map() call reachable only through the operand of `yield` must still be \
-         discovered"
-    );
-    assert!(!sites[0].dominated_by_guard);
-}
-
-/// F4 regression: an unguarded construction inside an `async { .. }` block
-/// must still be discovered (independently scoped, per `walk_expr`'s doc
-/// comment -- it runs later, not inline -- but must not vanish outright).
-#[test]
-fn walk_expr_recurses_into_async_block() {
-    let block: Block = syn::parse_str(
-        r#"{
-            let _fut = async {
-                unsafe { Mmap::map(&file) }
-            };
-        }"#,
-    )
-    .expect("parse Async fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f4_async");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "an Mmap::map() call reachable only through an `async {{ .. }}` block must still be \
-         discovered"
-    );
-    assert!(!sites[0].dominated_by_guard);
-}
-
-/// F4 regression: an unguarded construction inside a `const { .. }` block
-/// (expression position) must still be discovered.
-#[test]
-fn walk_expr_recurses_into_const_block() {
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f4_const");
-    let expr: Expr = syn::parse_str("const { unsafe { Mmap::map(&file) } }")
-        .expect("parse Const expression fixture");
-    walk_expr(&expr, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "an Mmap::map() call reachable only through a `const {{ .. }}` block must still be \
-         discovered"
-    );
-    assert!(!sites[0].dominated_by_guard);
-}
-
-/// F4 regression: a macro invocation in expression position, in a function
-/// that also has a real construction site, must be recorded as opaque --
-/// the combination [`every_mmap_construction_site_is_guarded_or_explicitly_exempted`]
-/// treats as a violation, since the macro's expansion could be hiding
-/// another site or a guard call this walk cannot see.
-#[test]
-fn walk_expr_records_an_opaque_macro_invocation_alongside_a_real_site() {
-    let block: Block = syn::parse_str(
-        r#"{
-            some_hiding_macro!();
-            unsafe { Mmap::map(&file) };
-        }"#,
-    )
-    .expect("parse Macro fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f4_macro");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "the real construction site must still be discovered"
-    );
-    assert_eq!(
-        opaque.len(),
-        1,
-        "the macro invocation must be recorded as opaque now that the function also has a \
-         discovered construction site"
-    );
-    assert!(opaque[0].contains("some_hiding_macro"));
-}
-
-/// Companion to the fixture above: a macro invocation is recorded as opaque
-/// even when the function has NO construction site of its own -- the
-/// decision about whether that matters belongs to the caller (see
-/// `every_mmap_construction_site_is_guarded_or_explicitly_exempted`'s doc
-/// comment: a function with no site is not flagged even though `opaque`
-/// here is non-empty).
-#[test]
-fn walk_block_records_an_opaque_macro_statement() {
-    let block: Block = syn::parse_str(
-        r#"{
-            some_hiding_macro!();
-        }"#,
-    )
-    .expect("parse Stmt::Macro fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f4_stmt_macro");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert!(sites.is_empty());
-    assert_eq!(opaque.len(), 1);
-    assert!(opaque[0].contains("some_hiding_macro"));
-}
-
-/// Control for the two fixtures above: a macro invocation inside a
-/// closure/`async`/`const` (deferred scope) must NOT be recorded as opaque,
-/// since ordinary, harmless idioms like `.map_err(|e| format!(".."))` --
-/// used throughout this crate's real guarded loaders -- are exactly this
-/// shape, and would otherwise make every one of them unable to pass.
-#[test]
-fn walk_expr_does_not_record_a_macro_inside_a_deferred_closure_as_opaque() {
-    let block: Block = syn::parse_str(
-        r#"{
-            crate::weights::mmap_trust::reject_if_open_mmap_file_untrusted(&file, path)
-                .map_err(|e| format!("failed: {e}"))?;
-            unsafe { Mmap::map(&file) }
-        }"#,
-    )
-    .expect("parse deferred-macro control fixture");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f4_deferred_macro_control");
-    walk_block(&block, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(sites.len(), 1);
-    assert!(sites[0].dominated_by_guard);
-    assert!(
-        opaque.is_empty(),
-        "a macro invocation inside a closure passed to `.map_err(..)` must not be recorded as \
-         opaque -- it is deferred, not part of this function's own synchronous path"
-    );
-}
-
-/// F4 regression: a nested `fn` item, invisible to `collect_functions`
-/// before this fix, must be discovered as its own inventory entry.
-#[test]
-fn collect_functions_discovers_a_nested_fn_item() {
-    let file: syn::File = syn::parse_str(
-        r#"
-        fn outer(file: &std::fs::File) {
-            fn inner(file: &std::fs::File) {
-                unsafe { Mmap::map(file) };
-            }
-            inner(file);
-        }
-        "#,
-    )
-    .expect("parse nested-fn fixture");
-    let mut functions = Vec::new();
-    let mut path_stack = Vec::new();
-    collect_functions(&file.items, &mut path_stack, &mut functions);
-    let inner = functions
-        .iter()
-        .find(|(path, _)| path == "outer::inner")
-        .expect("nested `fn inner` must be discovered as its own entry (`outer::inner`)");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f4_nested_fn::outer::inner");
-    walk_block(inner.1, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "the nested fn's own Mmap::map() call must be discovered"
-    );
-    assert!(!sites[0].dominated_by_guard);
-}
-
-/// F4 regression: a trait default method body, invisible to
-/// `collect_functions` before this fix (only `Item::Fn`/`Item::Impl` were
-/// handled), must be discovered as its own inventory entry.
-#[test]
-fn collect_functions_discovers_a_trait_default_method() {
-    let file: syn::File = syn::parse_str(
-        r#"
-        trait Loader {
-            fn load(&self, file: &std::fs::File) {
-                unsafe { Mmap::map(file) };
-            }
-        }
-        "#,
-    )
-    .expect("parse trait-default-method fixture");
-    let mut functions = Vec::new();
-    let mut path_stack = Vec::new();
-    collect_functions(&file.items, &mut path_stack, &mut functions);
-    let load = functions
-        .iter()
-        .find(|(path, _)| path == "Loader::load")
-        .expect("trait default method must be discovered as its own entry (`Loader::load`)");
-    let mut sites = Vec::new();
-    let mut opaque = Vec::new();
-    let ctx = empty_ctx("fixture::f4_trait_default::Loader::load");
-    walk_block(load.1, false, &ctx, &mut sites, &mut opaque);
-    assert_eq!(
-        sites.len(),
-        1,
-        "the trait default method's own Mmap::map() call must be discovered"
-    );
-    assert!(!sites[0].dominated_by_guard);
-}
-
-#[test]
-fn every_mmap_construction_site_is_guarded_or_explicitly_exempted() {
+fn only_the_mmap_trust_boundary_names_a_construction_api() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let src_root = manifest_dir.join("src");
 
-    let mut discovered: BTreeSet<String> = BTreeSet::new();
+    let mut boundary_hits = 0usize;
     let mut violations: Vec<String> = Vec::new();
 
     for path in rust_sources_under(&src_root) {
@@ -1358,99 +175,81 @@ fn every_mmap_construction_site_is_guarded_or_explicitly_exempted() {
             .into_owned();
         let source = std::fs::read_to_string(&path)
             .unwrap_or_else(|reason| panic!("could not read {relative}: {reason}"));
-        let syntax = syn::parse_file(&source).unwrap_or_else(|reason| {
-            panic!("{relative}: Rust syntax could not be parsed: {reason}")
-        });
+        let hits = construction_token_hits(&source);
 
-        let in_guard_definition_module = relative == GUARD_DEFINITION_MODULE;
+        if relative == TRUST_BOUNDARY_FILE {
+            boundary_hits += hits.len();
+            continue;
+        }
 
-        let mut functions = Vec::new();
-        let mut path_stack = Vec::new();
-        collect_functions(&syntax.items, &mut path_stack, &mut functions);
-
-        for (function_path, body) in functions {
-            let location = format!("{relative}::{function_path}");
-            let ctx = WalkCtx {
-                location: &location,
-                in_guard_definition_module,
-                in_deferred_scope: false,
-                bound_mmap_options: BTreeSet::new(),
-            };
-            let mut sites = Vec::new();
-            let mut opaque = Vec::new();
-            walk_block(body, false, &ctx, &mut sites, &mut opaque);
-            if sites.is_empty() {
-                // Nothing here for an opaque form to hide from this
-                // contract's perspective -- see the module doc comment.
-                continue;
-            }
-
-            // An opaque form (macro/Verbatim) anywhere in a function that
-            // DOES construct an mmap can't be certified: it might expand to
-            // hide another construction, or a guard call this walk would
-            // otherwise have credited.
-            for opaque_form in &opaque {
-                violations.push(opaque_form.clone());
-            }
-
-            let mut ordinals: BTreeMap<&str, usize> = BTreeMap::new();
-            for site in &sites {
-                let ordinal = ordinals.entry(site.selector).or_insert(0);
-                *ordinal += 1;
-                let selector = site.selector;
-                let key = format!("{relative}::{function_path}::{selector}#{ordinal}");
-                discovered.insert(key.clone());
-
-                if !site.dominated_by_guard
-                    && !MMAP_CONSTRUCTION_EXEMPTIONS
-                        .iter()
-                        .any(|exemption| exemption.site == key)
-                {
-                    violations.push(key);
-                }
-            }
+        for (line_no, token) in hits {
+            violations.push(format!(
+                "{relative}:{line_no}: names `{token}`, a mmap construction API, outside \
+                 {TRUST_BOUNDARY_FILE} -- every checkpoint mmap must be constructed inside that \
+                 module (via map_and_verify_trusted / map_after_untrusted_open) so the \
+                 trust-boundary guard cannot be skipped or misordered at the call site"
+            ));
         }
     }
 
     assert!(
         violations.is_empty(),
-        "mmap construction site(s) with neither a trust-boundary guard call earlier in the \
-         same function on a path that necessarily reaches the site, nor a reviewed \
-         MmapConstructionExemption -- or a function with a construction site that also \
-         contains an opaque form this walk cannot certify:\n{}",
+        "mmap construction API named outside the trust boundary:\n{}",
         violations.join("\n")
     );
 
-    let expected: BTreeSet<String> = EXPECTED_MMAP_CONSTRUCTION_SITES
-        .iter()
-        .map(|site| (*site).to_string())
-        .collect();
-    assert_eq!(
-        discovered, expected,
-        "mmap construction-site inventory changed; classify every added or removed site \
-         explicitly -- guard it with open_trusted_mmap_file / \
-         reject_if_open_mmap_file_untrusted, or add a reviewed MmapConstructionExemption \
-         naming why not, then update EXPECTED_MMAP_CONSTRUCTION_SITES"
+    assert!(
+        boundary_hits > 0,
+        "must-MATCH arm: the scan found zero `Mmap::map`/`MmapOptions` occurrences even inside \
+         {TRUST_BOUNDARY_FILE} itself, which does construct mappings -- this means the scan (root, \
+         extension filter, or token list) is broken, not that the crate is clean. A scan that \
+         matches nothing exits the same way as a scan that never ran"
     );
 }
 
-/// Every exemption entry must actually correspond to a discovered
-/// construction site: a stale entry (the site was fixed, renamed, or
-/// deleted) would silently stop meaning anything.
+/// Control for [`CONSTRUCTION_TOKENS`]: proves the policy is "construction is
+/// banned outside the boundary", not "the word `Mmap` is banned outside the
+/// boundary" -- a struct field storing an already-built `memmap2::Mmap`
+/// (`forward/moe_expert_cache.rs::ExpertByteTable::mmap`,
+/// `forward/metal_qwen35.rs`'s `Q3WeightBuf`/`Q4WeightBuf`) must not be
+/// flagged. Synthetic fixture, not a real file, so this test's own use of
+/// the word `Mmap` in a code sample does not depend on -- or drift with --
+/// any real source file's exact contents.
 #[test]
-fn every_exemption_matches_a_currently_expected_site() {
-    let expected: BTreeSet<&str> = EXPECTED_MMAP_CONSTRUCTION_SITES.iter().copied().collect();
-    for exemption in MMAP_CONSTRUCTION_EXEMPTIONS {
-        assert!(
-            expected.contains(exemption.site),
-            "exemption `{}` does not match any site in EXPECTED_MMAP_CONSTRUCTION_SITES -- \
-             it is stale and should be removed",
-            exemption.site
-        );
-        assert!(
-            !exemption.reason.is_empty(),
-            "exemption `{}` must state a reason",
-            exemption.site
-        );
-    }
+fn naming_the_mmap_type_without_constructing_one_stays_legal() {
+    let fixture = "\
+struct ExpertByteTable {
+    mmap: memmap2::Mmap,
+    payload_offset: u64,
+}
+
+fn take_mmap(_m: Option<memmap2::Mmap>) {}
+";
+    assert!(
+        construction_token_hits(fixture).is_empty(),
+        "storing or passing an already-constructed `memmap2::Mmap` must not be flagged -- only \
+         `Mmap::map`/`MmapOptions`, the construction APIs, are banned outside the boundary"
+    );
+}
+
+/// Control for the scan mechanics themselves: a file that does name a
+/// construction token must be caught by [`construction_token_hits`]
+/// directly, independent of the filesystem walk / boundary-file
+/// carve-out logic [`only_the_mmap_trust_boundary_names_a_construction_api`]
+/// layers on top. Isolates "the token scan works at all" from "the
+/// boundary-file exemption is wired correctly".
+#[test]
+fn construction_token_hits_finds_both_tokens_and_reports_correct_line_numbers() {
+    let fixture = "\
+let file = std::fs::File::open(path)?;
+let mmap = unsafe { memmap2::Mmap::map(&file) }?;
+let opts = memmap2::MmapOptions::new();
+";
+    let hits = construction_token_hits(fixture);
+    assert_eq!(
+        hits,
+        vec![(2, "Mmap::map"), (3, "MmapOptions")],
+        "must find exactly the two construction-token lines, at their correct 1-indexed line \
+         numbers, and nothing on the unrelated File::open line"
+    );
 }

--- a/crates/inference/tests/mmap_trust_boundary_contract.rs
+++ b/crates/inference/tests/mmap_trust_boundary_contract.rs
@@ -72,16 +72,27 @@
 //!   announces itself. Not defended against here; recorded as a residual
 //!   for the same reason as the macro case above.
 //! - **Ordering of the guard relative to the map** is no longer something
-//!   this *test* checks at all -- it is enforced by `mmap_trust.rs`'s own
-//!   function bodies (`map_and_verify_trusted`, `map_after_untrusted_open`
-//!   each call the guard, unconditionally, as the first statement, before
-//!   the `unsafe { Mmap::map(..) }` that follows). That is a stronger
-//!   guarantee than the walker's dominance analysis ever gave -- a single
-//!   straight-line function has no branches for a guard-only-on-one-arm bug
-//!   to hide in -- but it now lives as an invariant of that module's source,
-//!   not as something an external instrument re-derives on every run. A
-//!   regression there would have to be caught by `mmap_trust.rs`'s own unit
-//!   tests or code review, not by this file.
+//!   this *test* checks at all -- it is enforced two different ways inside
+//!   `mmap_trust.rs`, one per construction function. `map_after_untrusted_open`
+//!   still calls its guard (`reject_if_open_mmap_file_untrusted`),
+//!   unconditionally, as its first statement, before the
+//!   `unsafe { Mmap::map(..) }` that follows -- a single straight-line
+//!   function with no branches for a guard-only-on-one-arm bug to hide in.
+//!   `map_and_verify_trusted` (#1369 round 6) enforces the same property a
+//!   level up instead: it no longer takes a bare `&File` at all, only a
+//!   `&TrustedMmapFile`, whose fields are private to `mmap_trust.rs` and
+//!   whose only constructor, `open_trusted_mmap_file`, runs the mode/uid/ACL
+//!   and parent-directory checks before it can produce one. There is
+//!   therefore no `TrustedMmapFile` value, and so no call to
+//!   `map_and_verify_trusted`, that has not been through that gate -- the
+//!   ordering is a property of the type graph, not of statement order
+//!   inside one function body. Either shape is a stronger guarantee than the
+//!   walker's dominance analysis ever gave, but it now lives as an invariant
+//!   of that module's source, not as something an external instrument
+//!   re-derives on every run. A regression there would have to be caught by
+//!   `mmap_trust.rs`'s own unit tests (`open_trusted_mmap_file_rejects_a_writable_parent_directory`
+//!   and its siblings all fail if the guard calls inside
+//!   `open_trusted_mmap_file` are removed) or code review, not by this file.
 //!
 //! # What is intentionally NOT preserved from the walker
 //!

--- a/crates/inference/tests/mmap_trust_boundary_contract.rs
+++ b/crates/inference/tests/mmap_trust_boundary_contract.rs
@@ -24,11 +24,14 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
-use syn::{Block, Expr, ExprCall, ExprMethodCall, ImplItem, Item, Stmt};
+use syn::{BinOp, Block, Expr, ExprCall, ExprMethodCall, ImplItem, Item, Stmt};
 
 /// Free functions this crate's mmap trust boundary exposes. A call to either
-/// one, anywhere in the function enclosing a construction site, counts as
-/// that site being guarded.
+/// one counts as guarding a construction site when [`walk_expr`] determines
+/// it runs on a path that necessarily executes before the site, in the same
+/// enclosing function -- not merely "anywhere in the function" (see
+/// [`walk_expr`]'s doc comment for exactly what "necessarily executes before"
+/// does and does not cover).
 const GUARD_FUNCTION_NAMES: &[&str] = &[
     "open_trusted_mmap_file",
     "reject_if_open_mmap_file_untrusted",
@@ -109,7 +112,8 @@ fn impl_self_type_label(self_ty: &syn::Type) -> String {
 
 /// Every free function and `impl` method in a parsed file, named by its
 /// enclosing `mod`/`impl` path (matching `EXPECTED_MMAP_CONSTRUCTION_SITES`'
-/// key format) and paired with its body for the two finder visitors below.
+/// key format) and paired with its body for [`walk_block`]/[`walk_expr`]
+/// below.
 fn collect_functions<'a>(
     items: &'a [Item],
     path: &mut Vec<String>,
@@ -212,9 +216,21 @@ struct SiteObservation {
 ///
 /// What DOES count as "necessarily executes before" and so threads the flag
 /// straight through: sequential statements in the same block, `unsafe { .. }`
-/// and bare `{ .. }` blocks, `?`, casts, references, field/index access, and
+/// and bare `{ .. }` blocks, `?`, casts, references, field/index access,
 /// method-call/call receivers and arguments (in left-to-right evaluation
-/// order), and binary/assignment operands.
+/// order), assignment operands, and the operands of every binary operator
+/// that Rust evaluates unconditionally (arithmetic, comparison, bitwise, ...).
+///
+/// **`&&`/`||` are handled as a branch boundary, not threaded through.** Like
+/// `if`/`else`, Rust may skip the right operand entirely (`true || x` never
+/// runs `x`; `false && x` never runs `x`), so a guard call inside the right
+/// operand of `&&`/`||` is never credited to the binary expression's own
+/// outgoing state, and so never reaches sites after it -- only whatever
+/// `guarded` state the left operand (which always runs) produced does. The
+/// right operand is still walked so a construction site inside it is
+/// discovered and, symmetrically, still sees the left operand's guard state
+/// as input, since the left operand necessarily runs first whenever the
+/// right one runs at all.
 fn walk_expr(expr: &Expr, guarded_in: bool, sites: &mut Vec<SiteObservation>) -> bool {
     match expr {
         Expr::Block(block) => walk_block(&block.block, guarded_in, sites),
@@ -307,7 +323,18 @@ fn walk_expr(expr: &Expr, guarded_in: bool, sites: &mut Vec<SiteObservation>) ->
         }
         Expr::Binary(binary) => {
             let guarded = walk_expr(&binary.left, guarded_in, sites);
-            walk_expr(&binary.right, guarded, sites)
+            match binary.op {
+                BinOp::And(_) | BinOp::Or(_) => {
+                    // `&&`/`||` short-circuit: the right operand may never run.
+                    // Walk it so a construction site inside is still discovered,
+                    // but a guard call inside it must not be credited to sites
+                    // that follow the whole expression -- only `guarded` (the
+                    // state after the left operand, which always runs) does.
+                    walk_expr(&binary.right, guarded, sites);
+                    guarded
+                }
+                _ => walk_expr(&binary.right, guarded, sites),
+            }
         }
         Expr::Assign(assign) => {
             let guarded = walk_expr(&assign.left, guarded_in, sites);
@@ -384,6 +411,65 @@ fn walk_block(block: &Block, guarded_in: bool, sites: &mut Vec<SiteObservation>)
         };
     }
     guarded
+}
+
+/// Regression fixture for the `||` short-circuit hole: `true || guard(..)`
+/// never evaluates the guard at runtime, so it must not be credited to the
+/// `Mmap::map()` call that follows. Parses a synthetic [`Block`] directly and
+/// drives [`walk_block`] on it, rather than routing through the `src/` scan
+/// and [`EXPECTED_MMAP_CONSTRUCTION_SITES`] inventory used by the tests
+/// below -- this file has no existing indirection for exercising a shape
+/// without a real construction site in `src/`, and adding a `src/`-only
+/// fixture would touch production source for a case that has nothing to do
+/// with a real loader.
+#[test]
+fn walk_expr_does_not_credit_a_guard_call_inside_an_or_short_circuit() {
+    let block: Block = syn::parse_str(
+        r#"{
+            true || open_trusted_mmap_file(&file).is_ok();
+            Mmap::map(&file)
+        }"#,
+    )
+    .expect("parse `||` short-circuit fixture");
+    let mut sites = Vec::new();
+    walk_block(&block, false, &mut sites);
+    assert_eq!(
+        sites.len(),
+        1,
+        "fixture must discover exactly the Mmap::map() construction site"
+    );
+    assert_eq!(sites[0].selector, "Mmap::map()");
+    assert!(
+        !sites[0].dominated_by_guard,
+        "a guard call reachable only through the right operand of `||` must not be credited: \
+         `true || open_trusted_mmap_file(..)` never evaluates the guard at runtime"
+    );
+}
+
+/// Mirror of the `||` fixture above for `&&`: `false && guard(..)` never
+/// evaluates the guard at runtime either.
+#[test]
+fn walk_expr_does_not_credit_a_guard_call_inside_an_and_short_circuit() {
+    let block: Block = syn::parse_str(
+        r#"{
+            false && open_trusted_mmap_file(&file).is_ok();
+            Mmap::map(&file)
+        }"#,
+    )
+    .expect("parse `&&` short-circuit fixture");
+    let mut sites = Vec::new();
+    walk_block(&block, false, &mut sites);
+    assert_eq!(
+        sites.len(),
+        1,
+        "fixture must discover exactly the Mmap::map() construction site"
+    );
+    assert_eq!(sites[0].selector, "Mmap::map()");
+    assert!(
+        !sites[0].dominated_by_guard,
+        "a guard call reachable only through the right operand of `&&` must not be credited: \
+         `false && open_trusted_mmap_file(..)` never evaluates the guard at runtime"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #1368.

The mmap trust boundary was wired into the Q4 loader only. `grep -rn "MmapOptions::new()\|Mmap::map("` over `crates/inference/src` finds six constructions: four production sites plus two fixtures inside `mmap_trust`'s own tests. One of the four routed through `open_trusted_mmap_file`; three opened the file directly and mapped it with no ownership, mode or ACL check.

## Why this is two chokepoints rather than one

`open_trusted_mmap_file` opens the path itself with `O_NOFOLLOW`, which rejects a symlink at the final path component. Two of the three unguarded sites must follow one. A HuggingFace hub-cache checkpoint stores the tensor file as a symlink into the blob store (`snapshots/<rev>/model.safetensors -> ../../blobs/<sha>`), and the symlink is the final component, so routing `SafetensorsFile::open` and `open_manifest_entry_once` through `open_trusted_mmap_file` would have made every hub-cache checkpoint unloadable. That path is covered by an existing test, `sharded_loader_follows_hub_cache_snapshot_layout`, which stays green here.

So this adds `reject_if_open_mmap_file_untrusted(file, path)`, which runs the same mode, uid and ACL checks plus the parent-directory check against a `File` the caller has already opened — by which point the symlink is resolved — without the open-time `O_NOFOLLOW`/`O_NONBLOCK` guards. `open_trusted_mmap_file`'s open-time behaviour is unchanged: it still opens with `O_NOFOLLOW` and `O_NONBLOCK` and still applies the same regular-file, mode, uid and ACL checks, in the same order.

**Corrected.** An earlier revision of this section said its "signature and behaviour are unchanged". The behaviour half is accurate; the signature half is not. Its return type changes from `Result<(File, std::fs::Metadata), String>` to `Result<TrustedMmapFile, String>`, in both the unix and the non-unix definition, so that the opened descriptor and its metadata travel together to the mapping call instead of being passed as a loose pair. It is a crate-private function, so this is not a public API change, but the sentence as written was wrong about the diff it was describing.

Placement:

| Site | Guard |
|---|---|
| `weights/q4_weights.rs` `open_and_mmap_q4_file` | unchanged, already guarded: `open_trusted_mmap_file` then `map_and_verify_trusted` |
| `weights/f32_weights.rs` `SafetensorsFile::open` | opens, then delegates to `from_open_file` |
| `weights/f32_weights.rs` `SafetensorsFile::from_open_file` | `map_after_untrusted_open` (this is the site that performs the `Mmap::map`) |
| `weights/f32_weights.rs` `open_manifest_entry_once` | `reject_if_open_mmap_file_untrusted` — it returns a `File` and never maps; its consumer maps through `from_open_file` |
| `quant/quarot/io.rs` `Shard::open` | `map_after_untrusted_open` |
| `forward/metal_qwen35.rs` `mmap_q3_weight` | `open_trusted_mmap_file` (Q3 is this project's own format, never a hub-cache symlink target, so it matches its Q4 sibling exactly) |

An earlier revision of this section placed `reject_if_open_mmap_file_untrusted` at
`SafetensorsFile::open` and `Shard::open`, and said of `from_open_file` that it "deliberately does
not carry the call". Both statements described a design that no longer matches this head, and the
second is now the opposite of the truth: `from_open_file` is precisely where the guarded mapping
happens. The table above is the placement at this head.

## The mapping call is no longer reachable unguarded

Two changes make that a structural property rather than a convention every future caller has to
remember.

First, the trusted handle no longer surrenders the file it guarded. `TrustedMmapFile`'s entire
surface is `len()`, `impl Read` and `impl Seek`; there is no accessor returning the underlying
`File`. A caller therefore cannot take a guarded handle, extract the descriptor, and map it itself,
which was the one path by which the guard could be satisfied and then bypassed.

Second, the two mapping producers are now symmetric about the post-map recheck. Previously only the
`open_trusted_mmap_file` flavour rechecked identity after mapping. `map_after_untrusted_open` now
snapshots metadata *before* running the guard, maps, and then calls `verify_mmap_target_unchanged`
against that snapshot, so a truncate-or-replace landed in the guard-to-map window is caught on this
path too. The window was real and is now covered on both flavours rather than one.

## Contract test

`crates/inference/tests/mmap_trust_boundary_contract.rs` parses every file under `crates/inference/src` with `syn`, finds each mmap construction, and keys it by enclosing module/function path plus an ordinal rather than by line or column, following the convention already used by `metal_measurement_lock_contract.rs`. A site fails unless its enclosing function also reaches a trust-boundary check or carries a reviewed exemption. The discovered inventory is additionally asserted against an expected set, so adding, removing or renaming any mmap site anywhere in the crate fails the test until it is consciously updated. A second test rejects an exemption that no longer matches a live site.

## Verification

```
cargo test -p lattice-inference --features metal-gpu --test mmap_trust_boundary_contract
  test result: ok. 2 passed; 0 failed
cargo test -p lattice-inference --lib --features metal-gpu mmap
  test result: ok. 31 passed; 0 failed
cargo clippy --workspace --all-targets -- -D warnings   # clean
```

Mutation arm, run at this head with the prediction stated before the run: reverting `mmap_q3_weight` to a plain `File::open` must redden `every_mmap_construction_site_is_guarded_or_explicitly_exempted` and nothing else. Observed exactly that — the failure names `src/forward/metal_qwen35.rs::inner::mmap_q3_weight::MmapOptions::new().map()#1`, and `every_exemption_matches_a_currently_expected_site` stayed green. Restored, re-ran, both green.

Each newly guarded site also gained an integration-level regression test that constructs a group- or other-writable checkpoint and asserts the loader rejects it, rather than relying on the underlying predicate's own unit tests.

## bench-compare disposition

No A/B was run; the argument is structural, and it does not claim safety.

Population searched: all 24 `[[bench]]` targets declared in `crates/inference/Cargo.toml`, partitioned by `required-features` (18 with none, one under `f16`, two under `bench-internals`, three under `metal-gpu`+`f16`) — not just the two targets `bench-compare` runs by default. Sweeping all 24 sources for identifiers that reach the changed loaders finds five that do, including `lm_head_bench`, which carries no required feature and so builds in a plain `cargo bench`. The sweep's positive control (`grep -l "Device::system_default" crates/inference/benches/*.rs`, 2 hits) confirms it finds real matches.

So a reachable target exists and this change is measurable in principle. It was not measured here. The added work is one `stat()` and, on macOS, one `acl_get_fd_np()` per model load — before the first token in every one of the five reaching benches, not per tensor and not per step — so an effect on decode or prefill timing is not expected. That is reasoning from the shape of the change, not evidence. If it is wrong, the error runs toward an unmeasured one-time model-load cost rather than a decode-loop regression. Stating the residual risk is the point: an unmeasured change is unmeasured, not safe.


