### PR TITLE
fix(serve): count the forced </think> delimiter in the decode length invariant

### DIFF
--- a/crates/inference/src/bin/lattice/serve.rs
+++ b/crates/inference/src/bin/lattice/serve.rs
@@ -808,18 +808,22 @@ pub(super) fn finish_reason_for(
 /// Decode-side token allowance for the post-generation length invariant
 /// (#1334).
 ///
-/// Mirrors the decode term of admission's shared full-window formula
-/// (`crates/inference/src/serve/contract.rs::validate_context_window_with_budget`):
-/// `prompt + max_tokens + reasoning_budget + 1 <= max_context`. Admission's
-/// `+1` reserves the prompt/generation delimiter and has no counterpart
-/// here -- this only bounds tokens the engine actually generated, so the
-/// invariant is `generated_tokens > max_tokens + reasoning_budget`, not
-/// `> max_tokens + reasoning_budget + 1`. Using the same
-/// `max_tokens.saturating_add(reasoning_budget)` term as admission's
-/// `decode_budget` keeps the two checks from drifting apart the way the
-/// post-generation check drifted from admission before #1334.
+/// Mirrors `decode_cap` (`crates/inference/src/model/qwen35_config.rs`),
+/// which this must stay in agreement with: when a positive
+/// `reasoning_budget` is active and the model does not close its own
+/// thinking block, the engine force-emits a `</think>` delimiter as an
+/// extra generated token (`force_close_think` / `DecodePolicy::
+/// apply_override`), so a completion that legitimately used the full
+/// reasoning and answer allowance is `reasoning_budget + max_tokens + 1`
+/// tokens long, not `reasoning_budget + max_tokens`. The invariant is
+/// `generated_tokens > reasoning_budget + max_tokens + 1` for a positive
+/// budget, and unchanged at `generated_tokens > max_tokens` when the
+/// budget is absent or zero (no forced delimiter can occur).
 fn decode_token_budget(max_tokens: usize, reasoning_budget: Option<usize>) -> usize {
-    max_tokens.saturating_add(reasoning_budget.unwrap_or(0))
+    match reasoning_budget {
+        Some(rb) if rb > 0 => rb.saturating_add(max_tokens).saturating_add(1),
+        _ => max_tokens,
+    }
 }
 
 /// Resolve a token id back to its OpenAI `logprobs` text/bytes representation (#585).
@@ -4461,9 +4465,12 @@ mod tests {
 
         #[tokio::test]
         async fn non_streaming_exact_acceptance_positive_budget() {
+            // The +1 is the forced </think> delimiter (#1372): a positive
+            // reasoning_budget allows rb + max_tokens + 1 generated tokens,
+            // not rb + max_tokens.
             assert_non_streaming(
                 Some(REASONING_BUDGET),
-                MAX_TOKENS + REASONING_BUDGET,
+                MAX_TOKENS + REASONING_BUDGET + 1,
                 true,
                 "non-streaming, positive reasoning_budget, exact budget",
             )
@@ -4474,7 +4481,7 @@ mod tests {
         async fn non_streaming_one_past_rejection_positive_budget() {
             assert_non_streaming(
                 Some(REASONING_BUDGET),
-                MAX_TOKENS + REASONING_BUDGET + 1,
+                MAX_TOKENS + REASONING_BUDGET + 2,
                 false,
                 "non-streaming, positive reasoning_budget, one past budget",
             )
@@ -4563,9 +4570,12 @@ mod tests {
 
         #[tokio::test]
         async fn streaming_exact_acceptance_positive_budget() {
+            // The +1 is the forced </think> delimiter (#1372): a positive
+            // reasoning_budget allows rb + max_tokens + 1 generated tokens,
+            // not rb + max_tokens.
             assert_streaming(
                 Some(REASONING_BUDGET),
-                MAX_TOKENS + REASONING_BUDGET,
+                MAX_TOKENS + REASONING_BUDGET + 1,
                 true,
                 "streaming, positive reasoning_budget, exact budget",
             )
@@ -4576,7 +4586,7 @@ mod tests {
         async fn streaming_one_past_rejection_positive_budget() {
             assert_streaming(
                 Some(REASONING_BUDGET),
-                MAX_TOKENS + REASONING_BUDGET + 1,
+                MAX_TOKENS + REASONING_BUDGET + 2,
                 false,
                 "streaming, positive reasoning_budget, one past budget",
             )

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -10615,7 +10615,8 @@ mod inner {
             }
 
             // Autoregressive decode with streaming.
-            // cap = rb + max_new_tokens when budgeting; max_new_tokens otherwise (parity-safe).
+            // cap = rb + max_new_tokens + 1 when budgeting (the +1 is the forced
+            // </think> delimiter); max_new_tokens otherwise (parity-safe).
             let cap = policy.cap();
             for _ in 1..cap {
                 // Initial-token grammar completion (recorded above) terminates

--- a/crates/inference/src/model/qwen35/generation.rs
+++ b/crates/inference/src/model/qwen35/generation.rs
@@ -810,7 +810,8 @@ impl Qwen35Model {
             let mut stopped_by_caller = false;
             let mut stop_reason = StopReason::Length;
             // Decode loop (mirrors decode_loop free function exactly).
-            // cap = rb + max_new_tokens when budgeting; max_new_tokens otherwise (parity-safe).
+            // cap = rb + max_new_tokens + 1 when budgeting (the +1 is the forced
+            // </think> delimiter); max_new_tokens otherwise (parity-safe).
             let cap = policy.cap();
             for _ in 1..cap {
                 // Checked before any per-step work, independent of whether this
@@ -1022,7 +1023,8 @@ impl Qwen35Model {
             let mut confirmed_stop_string_match = false;
             let mut stop_reason = StopReason::Length;
             // Decode loop for the string-stop path.
-            // cap = rb + max_new_tokens when budgeting; max_new_tokens otherwise (parity-safe).
+            // cap = rb + max_new_tokens + 1 when budgeting (the +1 is the forced
+            // </think> delimiter); max_new_tokens otherwise (parity-safe).
             let cap = policy.cap();
             for _ in 1..cap {
                 if should_cancel() {


### PR DESCRIPTION
Closes #1372

When a request carries a positive `reasoning_budget` and the model does not close its own thinking block, the engine force-emits a `</think>` delimiter as an extra generated token. The unified `lattice serve` post-generation length invariant did not count that token, so a completion the decoder was designed to produce came back as HTTP 500 on the non-streaming path and as a stream error event on the streaming path.

## The disagreement

`decode_cap` deliberately allows `reasoning_budget + max_new_tokens + 1`, and its doc comment explains that the `+1` is the forced delimiter. `decode_token_budget` allowed only `max_tokens + reasoning_budget`, and its doc comment argued that admission's `+1` reserves a prompt/generation delimiter and "has no counterpart here". There is a counterpart, and it is the token the decoder generates. That sentence is the root cause rather than a side effect of it, so it is rewritten to name the delimiter and to name `decode_cap` as the function this must agree with.

The delimiter reaches `generated_tokens` through the ordinary path: `force_close_think` fires at `generated_so_far >= budget`, `DecodePolicy::apply_override` substitutes the close token for that step's sampled token, the step runs the normal push, and `capture_reasoning_end` starts the answer window after it so a full `max_new_tokens` still follows.

## What changed

- `decode_token_budget` now matches `decode_cap`'s shape: `+1` only for `Some(rb)` where `rb > 0`. `None` and `Some(0)` stay at `max_tokens`, so the no-budget path is unchanged.
- Its doc comment is rewritten around the delimiter.
- Three decode-loop comments that described the cap as `rb + max_new_tokens` now include the delimiter slot. The population is exactly three, confirmed by grepping the comment text before and after; the already-correct occurrences were left alone.

## Verification

Both consumers are separate call sites and both are covered. The existing invariant harness drives the real router through an injected generate closure that reports a caller-chosen `generated_tokens`:

| Path | generated tokens | expected |
|---|---|---|
| non-streaming | `rb + max_tokens + 1` | accepted |
| non-streaming | `rb + max_tokens + 2` | rejected |
| streaming | `rb + max_tokens + 1` | accepted, `finish_reason: "stop"` |
| streaming | `rb + max_tokens + 2` | rejected, error event |
| both, unset budget | `max_tokens` / `+1` | unchanged |

The two moved accept arms are proven load-bearing by mutation: reverting `decode_token_budget` to the old formula while leaving the new boundaries in place reddens exactly those two and nothing else, with the failure message `generated_tokens=15 max_tokens=10 reasoning_budget=Some(4)`. The prediction was written before the run and matched arm by arm. Restored by inverse edit.

Gates: `completion_length_invariant_1334` 8 passed / 0 failed, `serve::` 100 passed / 0 failed, `cargo check` and `cargo clippy -D warnings` clean under `f16,metal-gpu`, `cargo fmt --check` clean.

## bench-compare disposition

Structural reachability waiver, and it holds by reachability rather than by compilation.

`decode_token_budget` is a private function in `crates/inference/src/bin/lattice/serve.rs`, which belongs to the `lattice` binary target, not to the library. Benches link the library; no bench target can call a binary's private item.

The population was searched rather than sampled: all 31 declared bench targets across the workspace, with every source under `crates/*/benches/` grepped for the symbol. No match. The search instrument was validated on the same trees first — 24 bench sources reference `lattice_inference`, so a non-match is a real absence rather than a broken query.

The two other files touched are library files, and their diff contains zero non-comment changed lines, so they cannot move any measurement.

Residual risk: this change is not covered by any bench, so a regression in it would not be caught by bench evidence. The compensating coverage is the boundary test above on both consumers, with the mutation arm showing it fails when the arithmetic is wrong.

