### PR TITLE
fix(inference): enable zune-jpeg log feature so semver-checks builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,6 +1667,7 @@ dependencies = [
  "tracing",
  "ureq 2.12.1",
  "wgpu 24.0.5",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -4102,6 +4103,9 @@ name = "zune-core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "zune-jpeg"

--- a/crates/inference/Cargo.toml
+++ b/crates/inference/Cargo.toml
@@ -100,6 +100,15 @@ pollster = { version = "0.4", optional = true }
 bytemuck = { version = "1", features = ["derive"], optional = true }
 ort = { version = "2.0.0-rc.12", optional = true }
 tokenizers = { version = "0.22", optional = true, default-features = false, features = ["progressbar", "onig"] }
+# Not called directly: forces `image`'s transitive `zune-jpeg` to build with
+# its `log` feature (which pulls in `zune-core/log`) via Cargo feature
+# unification. Without it, `zune-jpeg 0.5.15` fails to compile against
+# `zune-core 0.5.2` -- a `warn!` call with no trailing semicolon is the last
+# statement of an `else` block, and with `log` off the macro expands to
+# nothing, leaving the block with no tail expression. Our lockfile pins
+# `zune-core 0.5.1` (unaffected), but `cargo-semver-checks` resolves fresh
+# and ignores the lockfile, so it hits 0.5.2 and fails.
+zune-jpeg = { version = "0.5", features = ["log"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 lattice-fann = { version = "0.9.0", path = "../fann", optional = true }
 


### PR DESCRIPTION
Fixes #1378.

`cargo-semver-checks` fails on this workspace with a compile error inside a third-party crate, which fails the aggregate `ci-gate` check and so blocks merges.

## Mechanism

`zune-jpeg 0.5.15` does not compile against `zune-core 0.5.2`. At `src/mcu_prog.rs:463` a `warn!` call with no trailing semicolon is the last statement of an `else` block. `zune-jpeg`'s `warn!` expands to nothing when its `log` feature is off, which leaves that block with no tail expression:

```
error: macro expansion ends with an incomplete expression: expected expression
   --> zune-jpeg-0.5.15/src/mcu_prog.rs:463:17
    |
463 |                 warn!("RST marker was not found, where expected, image may be garbled")
    |                 ^^^ expected expression
```

Ordinary builds never see this, because `Cargo.lock` pins `zune-core 0.5.1`, which is unaffected. `cargo-semver-checks` builds a scratch rustdoc project that resolves fresh and ignores the workspace lockfile, so it lands on `zune-core 0.5.2` and hits the error. That is why the failure appeared without any change to this repository, and why it reproduces against an empty diff.

## Fix

`lattice-inference` pulls `zune-jpeg` in transitively through `image`'s `jpeg` feature. `image` requests no features from it, and `log` is not in `zune-jpeg`'s default set, so the feature is off unless something in the graph turns it on.

This declares `zune-jpeg` as a direct dependency with `log` enabled:

```toml
zune-jpeg = { version = "0.5", features = ["log"] }
```

Cargo's feature unification then builds `zune-jpeg` with `log` on regardless of which `zune-core` resolves, and that arm compiles under both 0.5.1 and 0.5.2. The dependency is not called from our source; the comment above the line says so and says why it is there.

The alternative of constraining `zune-core` to `=0.5.1` was considered and rejected: it freezes the workspace around the incompatibility instead of removing the exposure, and it would have to be undone later.

## Verification

The failing arm was reproduced first and then shown to pass, rather than assumed:

- **Before**, in an isolated crate depending on `zune-jpeg =0.5.15` with `zune-core` forced to 0.5.2: the `mcu_prog.rs:463` error above.
- **Positive control**, same crate and same `zune-core 0.5.2`, with `features = ["log"]`: compiles clean.
- **After**, against a copy of this branch with `Cargo.lock` deleted and `zune-core` resolved fresh to 0.5.2 — the same conditions `cargo-semver-checks` creates: `cargo check -p lattice-inference --locked` finishes clean.

`cargo tree -p lattice-inference -e features -i zune-jpeg` attributes `zune-jpeg feature "log"` directly to `lattice-inference`, and shows it activating `zune-core feature "log"`, so the feature is genuinely on rather than merely requested.

`cargo check --workspace`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and the doc lint are all clean on the default feature set with the checked-in lockfile.

## Scope and side effects

Two files, additive only: one dependency line plus its explanatory comment in `crates/inference/Cargo.toml`, and the corresponding two edges in `Cargo.lock`. No source file changes and no public API surface change.

`log` was already in the dependency tree before this change, so no crate is added — only a feature activation. One behavioural note worth stating: with `log` enabled, `zune-jpeg`'s decoder warnings now emit through the `log` facade instead of being discarded at compile time. For a malformed JPEG that previously decoded silently, a warning record can now appear.

## bench-compare disposition

Structural waiver, no A/B table. The population is stated because enumerating by
declaration kind is how a reachable measurement gets missed.

**Population searched:** every measurement-capable artifact in `crates/inference`, not only
the declared bench targets — 24 `[[bench]]` targets, 12 `[[bin]]` targets (7 of whose sources
are named `bench_*` or `profile_*`), and 27 examples.

**Result:** zero bench sources and zero examples reference `jpeg`, `Jpeg`, `JPEG`, or
`image::`. The positive control is that 21 of the 24 bench sources match `criterion` in the
same pass, so the search reached those files and the zero is a real absence rather than a
search that never opened them. (`fn main` is the wrong control for a Criterion bench, since
`criterion_main!` generates it rather than the source containing it.)

Two `[[bin]]` sources do match: `src/bin/lattice/serve.rs` and `src/bin/lattice_serve.rs`.
Both matches are `image::RgbImage::new(32, 32)` and `image::ImageFormat::Png` inside test
fixtures. They encode PNG. Neither decodes JPEG, and neither is a measurement artifact.

**Why that settles it:** this change alters exactly one thing at runtime — whether
`zune-jpeg`'s `warn!` calls expand to real `log` calls instead of to nothing. That code runs
only inside the JPEG decoder, on the warning paths. No declared bench, bin, or example
executes JPEG decoding, so no existing measurement can observe this change.

**Residual risk, stated rather than waived away:** with `log` enabled, a JPEG whose decode
emits warnings now performs real logging work per warning where it previously performed
none. For a well-formed JPEG no warning fires and the cost is zero. For a malformed or
truncated JPEG decoded in a hot loop the cost is not zero and is unmeasured here, because
nothing in the repository measures that path. Unmeasured is not the same as unchanged.
