### PR TITLE
feat(embed): load unindexed single-file vision checkpoints

### DIFF
--- a/crates/embed/src/vision.rs
+++ b/crates/embed/src/vision.rs
@@ -9,26 +9,78 @@
 //! here — only checkpoint loading (mirroring the directory-loading pattern
 //! `service::native` uses for the BERT/Qwen text models) and error mapping.
 //!
-//! [`VisionEmbeddingModel::from_directory`] supports only checkpoints that
-//! carry a `model.safetensors.index.json` (or `quantize_index.json`)
-//! manifest naming exactly one decoder shard (matches the Qwen3.5-0.8B
-//! checkpoint shape) — the vision-tensor loader requires that manifest and
-//! runs before decoder-shard resolution, so a directory with only a plain
-//! `model.safetensors` and no manifest is rejected. Callers with pre-loaded
-//! components, or a multi-shard checkpoint, can assemble their own weights
-//! and call [`VisionEmbeddingModel::new`] directly.
+//! [`VisionEmbeddingModel::from_directory`] accepts either a
+//! `model.safetensors.index.json` naming exactly one decoder shard (the
+//! Qwen3.5-0.8B layout), or an unindexed directory containing exactly one
+//! safetensors file named `model.safetensors`. The indexed path is
+//! authoritative when both are present. The unindexed path parses the
+//! safetensors header and validates the exact `model.visual.*` inventory
+//! before tensor payloads are materialized. Decoder and visual tensors are
+//! materialized from the same mmap-backed open file, so a path replacement
+//! during loading cannot mix two checkpoint versions. For an indexed
+//! one-shard layout, the authoritative `weight_map` must exactly match that
+//! opened shard's header inventory. `quantize_index.json` is rejected: this
+//! loader constructs an f16 decoder and cannot bind a quantized visual file
+//! set coherently. Callers with pre-loaded components, or a multi-shard
+//! decoder checkpoint, can assemble their own weights and call
+//! [`VisionEmbeddingModel::new`] directly.
 
 use crate::error::{EmbedError, Result};
 use lattice_inference::InferenceError;
 use lattice_inference::model::qwen35_config::Qwen35Config;
 use lattice_inference::tokenizer::bpe::BpeTokenizer;
-use lattice_inference::vision::checkpoint::{Qwen35VisionWeights, load_qwen35_vision_weights};
+use lattice_inference::vision::checkpoint::{
+    Qwen35VisionWeights, load_qwen35_vision_weights_from_safetensors,
+    open_qwen35_single_decoder_safetensors,
+};
 use lattice_inference::vision::embed_image_from_bytes_f16;
-use lattice_inference::weights::SafetensorsFile;
 use lattice_inference::weights::f16_weights::{F16ModelWeights, load_f16_weights};
 use std::path::Path;
 
 pub use lattice_inference::forward::cpu_f16::PoolingStrategy;
+
+#[cfg(test)]
+thread_local! {
+    static AFTER_VISUAL_LOAD_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        std::cell::RefCell::new(None);
+}
+
+#[cfg(test)]
+fn run_after_visual_load_hook() {
+    let hook = AFTER_VISUAL_LOAD_HOOK.with(|slot| slot.borrow_mut().take());
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
+#[cfg(test)]
+fn with_after_visual_load_hook<T>(hook: impl FnOnce() + 'static, action: impl FnOnce() -> T) -> T {
+    struct ClearHookOnDrop;
+    impl Drop for ClearHookOnDrop {
+        fn drop(&mut self) {
+            AFTER_VISUAL_LOAD_HOOK.with(|slot| {
+                slot.borrow_mut().take();
+            });
+        }
+    }
+
+    AFTER_VISUAL_LOAD_HOOK.with(|slot| {
+        let previous = slot.borrow_mut().replace(Box::new(hook));
+        assert!(
+            previous.is_none(),
+            "visual-load test hook already installed"
+        );
+    });
+    let _clear_on_drop = ClearHookOnDrop;
+    let result = action();
+    AFTER_VISUAL_LOAD_HOOK.with(|slot| {
+        assert!(
+            slot.borrow().is_none(),
+            "VisionEmbeddingModel::from_directory did not traverse the visual-load test hook"
+        );
+    });
+    result
+}
 
 /// A loaded Qwen3.5 vision-language checkpoint, ready to pool image (and
 /// image+text) embeddings.
@@ -64,21 +116,41 @@ impl VisionEmbeddingModel {
 
     /// Load a Qwen3.5 vision-language checkpoint directory: `config.json`,
     /// `tokenizer.json`, the `model.visual.*` vision-encoder tensors, and a
-    /// single-shard decoder checkpoint. The directory must carry a
-    /// `model.safetensors.index.json` (or `quantize_index.json`) manifest
-    /// naming exactly one decoder shard file — the vision-tensor loader
-    /// requires one of those manifests and runs before decoder-shard
-    /// resolution, so a plain `model.safetensors` alone (with no manifest)
-    /// is not sufficient. The canonical Qwen3.5-0.8B HF layout (a one-shard
-    /// index) satisfies this.
+    /// single-shard f16 decoder checkpoint. An existing
+    /// `model.safetensors.index.json` is authoritative. Without an index, the
+    /// directory must contain exactly one `*.safetensors` file, named
+    /// `model.safetensors`; its header must carry the exact `model.visual.*`
+    /// inventory implied by `vision_config`. A `quantize_index.json` is
+    /// rejected because this constructor has no quantized decoder loader. The
+    /// chosen safetensors file is opened once and that same reader supplies
+    /// both visual and decoder tensors.
     ///
     /// # Errors
     ///
     /// Returns [`EmbedError::ModelInitialization`] if `config.json` is
-    /// missing or invalid, if the checkpoint has no `vision_config`, if
-    /// neither manifest is present, if the decoder weights are sharded
-    /// across more than one file, or if any component tensor fails to load.
+    /// missing or invalid, if the checkpoint has no `vision_config`, if a
+    /// quantized checkpoint is present, if the unindexed safetensors layout is
+    /// missing or ambiguous, if the decoder weights are sharded across more
+    /// than one file, or if any component tensor fails to load.
     pub fn from_directory(dir: &Path) -> Result<Self> {
+        let quantized_index = dir.join("quantize_index.json");
+        match std::fs::symlink_metadata(&quantized_index) {
+            Ok(_) => {
+                return Err(EmbedError::ModelInitialization(format!(
+                    "{} is present, but quantized checkpoints are not supported by \
+                     VisionEmbeddingModel::from_directory's f16 decoder loader",
+                    quantized_index.display()
+                )));
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(EmbedError::ModelInitialization(format!(
+                    "failed to inspect {}: {err}",
+                    quantized_index.display()
+                )));
+            }
+        }
+
         let config = Qwen35Config::from_model_dir(dir)
             .map_err(|e| EmbedError::ModelInitialization(format!("config.json: {e}")))?;
         let vision_cfg = config.vision_config.clone().ok_or_else(|| {
@@ -88,20 +160,24 @@ impl VisionEmbeddingModel {
             ))
         })?;
 
-        let vision_weights = load_qwen35_vision_weights(dir, &vision_cfg)
-            .map_err(|e| EmbedError::ModelInitialization(format!("vision weights: {e}")))?;
-
-        let shard_path = resolve_single_shard(dir)?;
-        let sf = SafetensorsFile::open(&shard_path).map_err(|e| {
-            EmbedError::ModelInitialization(format!("opening {}: {e}", shard_path.display()))
-        })?;
-        let weights = load_f16_weights(&sf, &config)
-            .map_err(|e| EmbedError::ModelInitialization(format!("decoder weights: {e}")))?;
-
+        // Tokenizer parsing is independent of tensor payloads, so reject a
+        // missing or malformed tokenizer before materializing multi-GB model
+        // weights. The checkpoint itself is still opened only once below so
+        // visual and decoder tensors stay bound to one file descriptor.
         let tokenizer_path = dir.join("tokenizer.json");
         let tokenizer = BpeTokenizer::from_tokenizer_json(&tokenizer_path).map_err(|e| {
             EmbedError::ModelInitialization(format!("{}: {e}", tokenizer_path.display()))
         })?;
+
+        let (mut sf, shard_path) = open_qwen35_single_decoder_safetensors(dir)
+            .map_err(|e| EmbedError::ModelInitialization(format!("decoder checkpoint: {e}")))?;
+        let vision_weights =
+            load_qwen35_vision_weights_from_safetensors(&mut sf, &shard_path, &vision_cfg)
+                .map_err(|e| EmbedError::ModelInitialization(format!("vision weights: {e}")))?;
+        #[cfg(test)]
+        run_after_visual_load_hook();
+        let weights = load_f16_weights(&sf, &config)
+            .map_err(|e| EmbedError::ModelInitialization(format!("decoder weights: {e}")))?;
 
         Ok(Self::new(weights, config, vision_weights, tokenizer))
     }
@@ -177,51 +253,13 @@ fn map_inference_error(e: InferenceError) -> EmbedError {
     }
 }
 
-/// Resolve the single safetensors shard `load_f16_weights` needs. By the time
-/// this runs, [`load_qwen35_vision_weights`] has already required a
-/// `model.safetensors.index.json` or `quantize_index.json` manifest to exist
-/// in `model_dir` (see module docs) — so a convenience `model.safetensors`
-/// file (often a symlink some local checkouts add alongside the manifest) is
-/// checked first as a cheap shortcut when present, then falls back to
-/// resolving the shard named by the index. This mirrors
-/// `Qwen35Model::from_safetensors`'s plain-then-index precedence, but
-/// resolves the concrete shard path a single-`SafetensorsFile` loader needs
-/// (multi-shard checkpoints are out of scope here — see module docs).
-fn resolve_single_shard(model_dir: &Path) -> Result<std::path::PathBuf> {
-    let plain = model_dir.join("model.safetensors");
-    if plain.exists() {
-        return Ok(plain);
-    }
-    let index = lattice_inference::weights::parse_index(model_dir).map_err(|e| {
-        EmbedError::ModelInitialization(format!(
-            "no model.safetensors in {} and no valid model.safetensors.index.json: {e}",
-            model_dir.display()
-        ))
-    })?;
-    let mut shards: Vec<&str> = index.weight_map.values().map(String::as_str).collect();
-    shards.sort_unstable();
-    shards.dedup();
-    match shards.as_slice() {
-        [one] => Ok(model_dir.join(one)),
-        [] => Err(EmbedError::ModelInitialization(format!(
-            "empty weight_map in {}",
-            model_dir.join("model.safetensors.index.json").display()
-        ))),
-        _ => Err(EmbedError::ModelInitialization(format!(
-            "checkpoint at {} is sharded across {} files; VisionEmbeddingModel::from_directory \
-             only supports single-shard checkpoints -- use VisionEmbeddingModel::new with \
-             manually loaded components instead",
-            model_dir.display(),
-            shards.len()
-        ))),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use lattice_inference::model::qwen35_config::{LayerType, RopeParams, VisionModelConfig};
-    use lattice_inference::vision::checkpoint::{VisualBlockWeights, VisualMergerWeights};
+    use lattice_inference::vision::checkpoint::{
+        VisualBlockWeights, VisualMergerWeights, resolve_qwen35_single_decoder_safetensors,
+    };
     use lattice_inference::weights::f16_weights::{
         F16AttentionWeights, F16CommonLayerWeights, F16FeedForwardWeights,
         F16FullAttentionLayerWeights, f32_to_f16_slice,
@@ -435,6 +473,228 @@ mod tests {
         BpeTokenizer::from_vocab_and_merges(vocab_map, vec![]).expect("tokenizer constructs")
     }
 
+    fn tiny_vlm_checkpoint_shapes() -> Vec<(String, Vec<usize>)> {
+        let hidden = 8usize;
+        let mut shapes = vec![
+            (
+                "model.language_model.embed_tokens.weight".to_string(),
+                vec![16, hidden],
+            ),
+            ("model.language_model.norm.weight".to_string(), vec![hidden]),
+            (
+                "model.language_model.layers.0.input_layernorm.weight".to_string(),
+                vec![hidden],
+            ),
+            (
+                "model.language_model.layers.0.post_attention_layernorm.weight".to_string(),
+                vec![hidden],
+            ),
+            (
+                "model.language_model.layers.0.mlp.gate_proj.weight".to_string(),
+                vec![4, hidden],
+            ),
+            (
+                "model.language_model.layers.0.mlp.up_proj.weight".to_string(),
+                vec![4, hidden],
+            ),
+            (
+                "model.language_model.layers.0.mlp.down_proj.weight".to_string(),
+                vec![hidden, 4],
+            ),
+            (
+                "model.language_model.layers.0.self_attn.q_proj.weight".to_string(),
+                vec![16, hidden],
+            ),
+            (
+                "model.language_model.layers.0.self_attn.k_proj.weight".to_string(),
+                vec![hidden, hidden],
+            ),
+            (
+                "model.language_model.layers.0.self_attn.v_proj.weight".to_string(),
+                vec![hidden, hidden],
+            ),
+            (
+                "model.language_model.layers.0.self_attn.o_proj.weight".to_string(),
+                vec![hidden, hidden],
+            ),
+            (
+                "model.language_model.layers.0.self_attn.q_norm.weight".to_string(),
+                vec![hidden],
+            ),
+            (
+                "model.language_model.layers.0.self_attn.k_norm.weight".to_string(),
+                vec![hidden],
+            ),
+            (
+                "model.visual.patch_embed.proj.weight".to_string(),
+                vec![hidden, 3, 1, 2, 2],
+            ),
+            (
+                "model.visual.patch_embed.proj.bias".to_string(),
+                vec![hidden],
+            ),
+            (
+                "model.visual.pos_embed.weight".to_string(),
+                vec![16, hidden],
+            ),
+            (
+                "model.visual.merger.linear_fc1.weight".to_string(),
+                vec![32, 32],
+            ),
+            ("model.visual.merger.linear_fc1.bias".to_string(), vec![32]),
+            (
+                "model.visual.merger.linear_fc2.weight".to_string(),
+                vec![hidden, 32],
+            ),
+            (
+                "model.visual.merger.linear_fc2.bias".to_string(),
+                vec![hidden],
+            ),
+            ("model.visual.merger.norm.weight".to_string(), vec![hidden]),
+            ("model.visual.merger.norm.bias".to_string(), vec![hidden]),
+        ];
+        for (suffix, shape) in [
+            ("attn.qkv.weight", vec![24, hidden]),
+            ("attn.qkv.bias", vec![24]),
+            ("attn.proj.weight", vec![hidden, hidden]),
+            ("attn.proj.bias", vec![hidden]),
+            ("mlp.linear_fc1.weight", vec![32, hidden]),
+            ("mlp.linear_fc1.bias", vec![32]),
+            ("mlp.linear_fc2.weight", vec![hidden, 32]),
+            ("mlp.linear_fc2.bias", vec![hidden]),
+            ("norm1.weight", vec![hidden]),
+            ("norm1.bias", vec![hidden]),
+            ("norm2.weight", vec![hidden]),
+            ("norm2.bias", vec![hidden]),
+        ] {
+            shapes.push((format!("model.visual.blocks.0.{suffix}"), shape));
+        }
+        shapes
+    }
+
+    fn write_f32_safetensors(path: &Path, shapes: &[(String, Vec<usize>)]) {
+        write_f32_safetensors_with_offset(path, shapes, 0.0);
+    }
+
+    fn write_f32_safetensors_with_offset(
+        path: &Path,
+        shapes: &[(String, Vec<usize>)],
+        offset: f32,
+    ) {
+        let mut header_parts = Vec::with_capacity(shapes.len());
+        let mut data = Vec::new();
+        for (i, (name, shape)) in shapes.iter().enumerate() {
+            let start = data.len();
+            let numel: usize = shape.iter().product();
+            for _ in 0..numel {
+                data.extend_from_slice(&(offset + (i + 1) as f32 / 100.0).to_le_bytes());
+            }
+            let end = data.len();
+            let shape = shape
+                .iter()
+                .map(usize::to_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            header_parts.push(format!(
+                r#""{name}":{{"dtype":"F32","shape":[{shape}],"data_offsets":[{start},{end}]}}"#
+            ));
+        }
+        let header = format!("{{{}}}", header_parts.join(","));
+        let mut bytes = Vec::with_capacity(8 + header.len() + data.len());
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&data);
+        std::fs::write(path, bytes).expect("write safetensors fixture");
+    }
+
+    fn write_tiny_tokenizer_json(dir: &Path) {
+        let tokenizer = r#"{
+            "model": {
+                "type": "BPE",
+                "vocab": {
+                    "a": 0, "b": 1, "c": 2, "d": 3,
+                    "e": 4, "f": 5, "g": 6, "h": 7,
+                    "i": 8, "j": 9, "k": 10, "l": 11,
+                    "m": 12, "n": 13, "o": 14, "p": 15
+                },
+                "merges": []
+            }
+        }"#;
+        std::fs::write(dir.join("tokenizer.json"), tokenizer).expect("write tokenizer.json");
+    }
+
+    fn write_tiny_vlm_checkpoint(dir: &Path, indexed: bool) {
+        let config = r#"{
+            "text_config": {
+                "hidden_size": 8,
+                "num_hidden_layers": 1,
+                "vocab_size": 16,
+                "intermediate_size": 4,
+                "rms_norm_eps": 0.000001,
+                "num_attention_heads": 1,
+                "num_key_value_heads": 1,
+                "head_dim": 8,
+                "rope_theta": 10000000.0,
+                "partial_rotary_factor": 1.0,
+                "rope_parameters": {
+                    "rope_theta": 10000000.0,
+                    "partial_rotary_factor": 1.0,
+                    "mrope_section": [2, 1, 1],
+                    "mrope_interleaved": true
+                },
+                "linear_num_key_heads": 2,
+                "linear_num_value_heads": 2,
+                "linear_key_head_dim": 32,
+                "linear_value_head_dim": 32,
+                "linear_conv_kernel_dim": 4,
+                "tie_word_embeddings": true,
+                "full_attention_interval": 1,
+                "layer_types": ["full_attention"],
+                "layer_mask": [true],
+                "eos_token_id": 15,
+                "max_position_embeddings": 512
+            },
+            "vision_config": {
+                "depth": 1,
+                "hidden_size": 8,
+                "num_heads": 2,
+                "patch_size": 2,
+                "spatial_merge_size": 2,
+                "out_hidden_size": 8,
+                "temporal_patch_size": 1,
+                "num_position_embeddings": 16,
+                "in_channels": 3,
+                "deepstack_visual_indexes": []
+            },
+            "image_token_id": 9,
+            "vision_start_token_id": 10,
+            "vision_end_token_id": 11,
+            "tie_word_embeddings": true
+        }"#;
+        std::fs::write(dir.join("config.json"), config).expect("write config.json");
+        write_tiny_tokenizer_json(dir);
+
+        let shapes = tiny_vlm_checkpoint_shapes();
+        let shard_name = if indexed {
+            "model-00001-of-00001.safetensors"
+        } else {
+            "model.safetensors"
+        };
+        write_f32_safetensors(&dir.join(shard_name), &shapes);
+        if indexed {
+            let weight_map = shapes
+                .iter()
+                .map(|(name, _)| format!(r#""{name}":"{shard_name}""#))
+                .collect::<Vec<_>>()
+                .join(",");
+            std::fs::write(
+                dir.join("model.safetensors.index.json"),
+                format!(r#"{{"weight_map":{{{weight_map}}}}}"#),
+            )
+            .expect("write one-shard index");
+        }
+    }
+
     /// The embed-crate wrapper must return the exact same vector as calling
     /// the raw inference-crate primitive directly: wiring adds no numerical
     /// difference. This is the core claim of this module (a wire-through,
@@ -610,42 +870,197 @@ mod tests {
         )
         .expect("write index");
 
-        let err = resolve_single_shard(tmp.path()).expect_err("multi-shard must be rejected");
+        let err = resolve_qwen35_single_decoder_safetensors(tmp.path())
+            .expect_err("multi-shard must be rejected");
         let msg = err.to_string();
         assert!(msg.contains("sharded across 2 files"), "got: {msg}");
     }
 
     #[test]
-    fn resolve_single_shard_rejects_missing_manifest() {
+    fn resolve_single_shard_rejects_missing_checkpoint() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let err = resolve_single_shard(tmp.path()).expect_err("missing manifest must be rejected");
-        assert!(matches!(err, EmbedError::ModelInitialization(_)));
+        let err = resolve_qwen35_single_decoder_safetensors(tmp.path())
+            .expect_err("missing checkpoint must be rejected");
+        assert!(matches!(err, InferenceError::ModelNotFound(_)));
     }
 
-    /// `from_directory`'s documented contract requires an index/quantize
-    /// manifest (the vision-tensor loader runs before decoder-shard
-    /// resolution and has no plain-file fallback). A directory with a valid
-    /// config.json (including `vision_config`) but no manifest at all must
-    /// fail with an actionable, named error -- not merely `expect_err` on
-    /// some opaque error -- pinning the real (manifest-required) behavior
-    /// rather than the previously-documented (plain-file-sufficient) one.
     #[test]
-    fn from_directory_without_manifest_reports_actionable_error() {
+    fn from_directory_without_checkpoint_reports_actionable_error() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let config_json = include_str!(concat!(
             env!("CARGO_MANIFEST_DIR"),
             "/../inference/tests/fixtures/qwen35_0_8b_config.json"
         ));
         std::fs::write(tmp.path().join("config.json"), config_json).expect("write config.json");
+        write_tiny_tokenizer_json(tmp.path());
 
         let Err(err) = VisionEmbeddingModel::from_directory(tmp.path()) else {
-            panic!("a directory with no index/quantize manifest must be rejected")
+            panic!("a directory with no checkpoint must be rejected")
         };
         assert!(matches!(err, EmbedError::ModelInitialization(_)));
         let msg = err.to_string();
         assert!(
-            msg.contains("model.safetensors.index.json") && msg.contains("quantize_index.json"),
-            "error must name the missing manifest(s), got: {msg}"
+            msg.contains("model.safetensors") && msg.contains("model.safetensors.index.json"),
+            "error must name the supported checkpoint layouts, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn from_directory_rejects_missing_tokenizer_before_checkpoint_materialization() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_tiny_vlm_checkpoint(tmp.path(), false);
+        std::fs::remove_file(tmp.path().join("tokenizer.json")).expect("remove tokenizer fixture");
+        std::fs::write(tmp.path().join("model.safetensors"), u64::MAX.to_le_bytes())
+            .expect("replace checkpoint with a corrupt header");
+
+        let Err(err) = VisionEmbeddingModel::from_directory(tmp.path()) else {
+            panic!("a checkpoint without tokenizer.json must be rejected")
+        };
+        assert!(matches!(err, EmbedError::ModelInitialization(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("tokenizer.json"), "got: {msg}");
+        assert!(
+            !msg.contains("vision weights") && !msg.contains("decoder weights"),
+            "tokenizer admission must fail before tensor materialization, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn from_directory_rejects_quantized_checkpoint_before_tensor_loading() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("quantize_index.json"), b"not valid json")
+            .expect("write quantized checkpoint sentinel");
+
+        let Err(err) = VisionEmbeddingModel::from_directory(tmp.path()) else {
+            panic!("the f16 pooled decoder loader must reject quantized checkpoints")
+        };
+        assert!(matches!(err, EmbedError::ModelInitialization(_)));
+        let msg = err.to_string();
+        assert!(msg.contains("quantize_index.json"), "got: {msg}");
+        assert!(msg.contains("not supported"), "got: {msg}");
+        assert!(
+            !msg.contains("config.json"),
+            "the unsupported file-set must fail before unrelated component loading, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn from_directory_loads_single_model_safetensors_without_index() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_tiny_vlm_checkpoint(tmp.path(), false);
+
+        let model = VisionEmbeddingModel::from_directory(tmp.path())
+            .expect("single-file VLM checkpoint must load without a synthetic index");
+        assert_eq!(model.dimensions(), 8);
+    }
+
+    #[test]
+    fn single_file_and_one_shard_index_produce_identical_image_embeddings() {
+        let single = tempfile::tempdir().expect("single tempdir");
+        let indexed = tempfile::tempdir().expect("indexed tempdir");
+        write_tiny_vlm_checkpoint(single.path(), false);
+        write_tiny_vlm_checkpoint(indexed.path(), true);
+
+        let single_model = VisionEmbeddingModel::from_directory(single.path())
+            .expect("single-file VLM checkpoint loads");
+        let indexed_model = VisionEmbeddingModel::from_directory(indexed.path())
+            .expect("equivalent one-shard indexed VLM checkpoint loads");
+        let image = make_test_png(4, 4, 17);
+        let from_single = single_model
+            .embed_image(&image, "a", PoolingStrategy::MeanVisualTokens)
+            .expect("single-file image embedding succeeds");
+        let from_index = indexed_model
+            .embed_image(&image, "a", PoolingStrategy::MeanVisualTokens)
+            .expect("indexed image embedding succeeds");
+
+        assert_eq!(
+            from_single, from_index,
+            "equivalent single-file and indexed layouts must produce parity embeddings"
+        );
+    }
+
+    #[test]
+    fn from_directory_rejects_index_map_that_contradicts_opened_shard_header() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_tiny_vlm_checkpoint(tmp.path(), true);
+        std::fs::write(
+            tmp.path().join("model.safetensors.index.json"),
+            r#"{"weight_map":{"not.a.real.tensor":"model-00001-of-00001.safetensors"}}"#,
+        )
+        .expect("replace index with contradictory weight_map");
+
+        let Err(err) = VisionEmbeddingModel::from_directory(tmp.path()) else {
+            panic!("an authoritative index that omits the physical tensors must be rejected")
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("weight_map/header inventory mismatch"),
+            "got: {msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn from_directory_binds_visual_and_decoder_weights_across_path_replacement() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_tiny_vlm_checkpoint(tmp.path(), false);
+        let checkpoint_path = tmp.path().join("model.safetensors");
+        let replacement = tmp.path().join("replacement-checkpoint");
+        write_f32_safetensors_with_offset(&replacement, &tiny_vlm_checkpoint_shapes(), 10.0);
+
+        let model = with_after_visual_load_hook(
+            move || {
+                std::fs::rename(&replacement, &checkpoint_path)
+                    .expect("atomically replace checkpoint pathname with checkpoint B");
+            },
+            || {
+                VisionEmbeddingModel::from_directory(tmp.path())
+                    .expect("constructor keeps both components on checkpoint A")
+            },
+        );
+
+        assert_eq!(
+            model.vision_weights.patch_embed_weight[0], 0.14,
+            "visual weights must remain bound to checkpoint A"
+        );
+        let mut expected_embed = [0u16];
+        f32_to_f16_slice(&[0.01], &mut expected_embed);
+        assert_eq!(
+            model.weights.embed_tokens[0], expected_embed[0],
+            "decoder weights must remain bound to checkpoint A"
+        );
+    }
+
+    #[test]
+    fn resolve_single_shard_prefers_existing_index_over_plain_file() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("model.safetensors"), b"plain")
+            .expect("write convenience file");
+        std::fs::write(
+            tmp.path().join("model.safetensors.index.json"),
+            r#"{"weight_map":{"tensor":"indexed.safetensors"}}"#,
+        )
+        .expect("write index");
+
+        let resolved = resolve_qwen35_single_decoder_safetensors(tmp.path())
+            .expect("single-shard index resolves");
+        assert_eq!(resolved, tmp.path().join("indexed.safetensors"));
+    }
+
+    #[test]
+    fn resolve_single_shard_rejects_index_entry_escaping_model_directory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            tmp.path().join("model.safetensors.index.json"),
+            r#"{"weight_map":{"tensor":"../outside.safetensors"}}"#,
+        )
+        .expect("write index");
+
+        let err = resolve_qwen35_single_decoder_safetensors(tmp.path())
+            .expect_err("an index entry must not escape the checkpoint directory");
+        assert!(
+            err.to_string().contains("escapes the model directory"),
+            "got: {err}"
         );
     }
 }

--- a/crates/embed/tests/vision_single_file_real_model.rs
+++ b/crates/embed/tests/vision_single_file_real_model.rs
@@ -1,0 +1,94 @@
+//! Manual real-model gate for the unindexed visual-checkpoint loader (#1381).
+//!
+//! This test is ignored because it maps and loads a multi-gigabyte Qwen3.5
+//! checkpoint and runs two full CPU image embeddings. Run it explicitly:
+//!
+//! ```text
+//! LATTICE_VISION_EMBED_MODEL_DIR=/path/to/qwen3.5-2b \
+//! cargo test --release -p lattice-embed \
+//!   --test vision_single_file_real_model -- --ignored --nocapture
+//! ```
+
+use lattice_embed::vision::{PoolingStrategy, VisionEmbeddingModel};
+use std::path::{Path, PathBuf};
+
+fn require_model_dir() -> PathBuf {
+    let value = std::env::var("LATTICE_VISION_EMBED_MODEL_DIR")
+        .expect("set LATTICE_VISION_EMBED_MODEL_DIR to an unindexed Qwen3.5 vision checkpoint");
+    let path = PathBuf::from(value);
+    assert!(
+        path.is_dir(),
+        "LATTICE_VISION_EMBED_MODEL_DIR={} is not a directory",
+        path.display()
+    );
+    path
+}
+
+fn assert_single_file_layout(model_dir: &Path) {
+    assert!(
+        model_dir.join("model.safetensors").is_file(),
+        "real-model gate requires model.safetensors"
+    );
+    assert!(
+        !model_dir.join("model.safetensors.index.json").exists(),
+        "real-model gate must exercise the unindexed path"
+    );
+    assert!(
+        !model_dir.join("quantize_index.json").exists(),
+        "real-model gate must exercise the f16/bf16 safetensors path"
+    );
+    let candidates = std::fs::read_dir(model_dir)
+        .expect("inspect model directory")
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().is_some_and(|ext| ext == "safetensors"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        candidates.len(),
+        1,
+        "real-model gate requires exactly one unindexed safetensors candidate"
+    );
+}
+
+fn golden_image() -> Vec<u8> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("tests")
+        .join("fixtures")
+        .join("vision")
+        .join("golden_image.png");
+    std::fs::read(&path)
+        .unwrap_or_else(|err| panic!("failed to read golden image {}: {err}", path.display()))
+}
+
+#[test]
+#[ignore = "requires a multi-gigabyte Qwen3.5 vision checkpoint; set LATTICE_VISION_EMBED_MODEL_DIR"]
+fn qwen35_single_file_embedding_is_normalized_and_deterministic() {
+    let model_dir = require_model_dir();
+    assert_single_file_layout(&model_dir);
+
+    let model = VisionEmbeddingModel::from_directory(&model_dir)
+        .expect("an unindexed single-file Qwen3.5 vision checkpoint must load");
+    assert_eq!(
+        model.dimensions(),
+        2048,
+        "Qwen3.5-2B embedding dimension drifted"
+    );
+
+    let image = golden_image();
+    let first = model
+        .embed_image(&image, "", PoolingStrategy::MeanVisualTokens)
+        .expect("first real image embedding succeeds");
+    let second = model
+        .embed_image(&image, "", PoolingStrategy::MeanVisualTokens)
+        .expect("second real image embedding succeeds");
+
+    assert_eq!(first.len(), model.dimensions());
+    assert!(first.iter().all(|value| value.is_finite()));
+    let norm = first.iter().map(|value| value * value).sum::<f32>().sqrt();
+    assert!((norm - 1.0).abs() < 1.0e-4, "embedding norm={norm}");
+    assert_eq!(
+        first, second,
+        "identical image requests must produce deterministic embeddings"
+    );
+}

--- a/crates/inference/src/vision/checkpoint.rs
+++ b/crates/inference/src/vision/checkpoint.rs
@@ -14,12 +14,15 @@
 //! wire them into any forward pass.
 
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::InferenceError;
 use crate::model::qwen35_config::VisionModelConfig;
 use crate::quant::q4_manifest;
-use crate::weights::f32_weights::{ShardedSafetensors, TensorSource, open_manifest_entry_once};
+use crate::weights::f32_weights::{
+    SafetensorsFile, ShardedSafetensors, TensorSource, contained_shard_path,
+    open_manifest_entry_once, parse_index,
+};
 use crate::weights::q4_weights::{
     F16LoadError, dequantize_q4_to_f32, load_f16_tensor_from_open_file,
     load_f16_tensor_from_open_file_expecting, load_q4_from_open_file,
@@ -109,24 +112,64 @@ impl Qwen35VisionWeights {
     }
 }
 
-/// Load the real `model.visual.*` tensors from a model directory, in either the fp16
-/// sharded-safetensors form (`model.safetensors.index.json`) or the per-tensor q4 form
-/// (`quantize_index.json`) — whichever manifest is present. Both forms are supported
-/// because the on-disk q4 checkpoint (verified by inspection) already retains all 153
-/// visual tensors alongside the text decoder's, using the same per-tensor `.q4`/`.f16`
-/// convention; no fp16-fallback plumbing is needed for the q4 case.
+/// Load the real `model.visual.*` tensors from a model directory. Manifest-backed
+/// checkpoints retain their existing precedence: `quantize_index.json`, then
+/// `model.safetensors.index.json`. When neither manifest exists, exactly one regular
+/// `*.safetensors` file must be present and it must be named `model.safetensors`.
+/// Its header is parsed and its exact visual tensor inventory is validated before any
+/// tensor payload is materialized.
 ///
 /// # Errors
 ///
-/// Returns [`InferenceError::ModelNotFound`] if neither manifest is present, and
-/// [`InferenceError::MissingTensor`] / [`InferenceError::ShapeMismatch`] if any of the
-/// expected tensors (derived from `vision_cfg`) is absent or the wrong size.
+/// Returns [`InferenceError::ModelNotFound`] if no supported checkpoint is present,
+/// [`InferenceError::InvalidSafetensors`] when an unindexed layout is ambiguous or its
+/// header is corrupt, and [`InferenceError::MissingTensor`] /
+/// [`InferenceError::ShapeMismatch`] if an expected tensor (derived from `vision_cfg`)
+/// is absent or has the wrong shape.
 pub fn load_qwen35_vision_weights(
     model_dir: &Path,
     vision_cfg: &VisionModelConfig,
 ) -> Result<Qwen35VisionWeights, InferenceError> {
     let mut never_cancel = || false;
     match load_qwen35_vision_weights_with_cancel(model_dir, vision_cfg, &mut never_cancel)? {
+        Some(weights) => Ok(weights),
+        None => Err(InferenceError::Inference(
+            "non-cancellable vision weight load was cancelled".to_string(),
+        )),
+    }
+}
+
+/// **Unstable**: the reader-based checkpoint-loading surface may evolve before 1.0.
+///
+/// Load Qwen3.5 `model.visual.*` tensors from an already-open safetensors
+/// reader. This is the descriptor-binding entry point for callers that also
+/// load decoder tensors from the same [`SafetensorsFile`]: both components
+/// then come from one mmap-backed open file even if the directory entry is
+/// replaced while a multi-gigabyte checkpoint is loading.
+///
+/// The reader may also contain decoder tensors, but its `model.visual.*`
+/// inventory must exactly match `vision_cfg`. `checkpoint_path` is used only
+/// for attributable error messages; it does not reopen the file.
+///
+/// # Errors
+///
+/// Returns [`InferenceError::InvalidSafetensors`] for a corrupt header,
+/// [`InferenceError::MissingTensor`] or [`InferenceError::ShapeMismatch`] for
+/// an incompatible visual inventory, and an inference error when a tensor
+/// cannot be materialized safely.
+pub fn load_qwen35_vision_weights_from_safetensors(
+    reader: &mut SafetensorsFile,
+    checkpoint_path: &Path,
+    vision_cfg: &VisionModelConfig,
+) -> Result<Qwen35VisionWeights, InferenceError> {
+    vision_cfg.validate()?;
+    let mut never_cancel = || false;
+    match load_from_safetensors_reader_with_cancel(
+        reader,
+        checkpoint_path,
+        vision_cfg,
+        &mut never_cancel,
+    )? {
         Some(weights) => Ok(weights),
         None => Err(InferenceError::Inference(
             "non-cancellable vision weight load was cancelled".to_string(),
@@ -146,16 +189,12 @@ pub(crate) fn load_qwen35_vision_weights_with_cancel(
     // boundary re-validates rather than trusting that every caller went through
     // `Qwen35Config::from_config_json_str`'s parse-time check.
     vision_cfg.validate()?;
-    if model_dir.join("quantize_index.json").exists() {
+    if checkpoint_entry_present(&model_dir.join("quantize_index.json"))? {
         load_from_q4_dir_with_cancel(model_dir, vision_cfg, should_cancel)
-    } else if model_dir.join("model.safetensors.index.json").exists() {
+    } else if checkpoint_entry_present(&model_dir.join("model.safetensors.index.json"))? {
         load_from_fp16_dir_with_cancel(model_dir, vision_cfg, should_cancel)
     } else {
-        Err(InferenceError::ModelNotFound(format!(
-            "no model.safetensors.index.json or quantize_index.json in {} -- cannot load \
-             model.visual.* vision tensors from this directory",
-            model_dir.display()
-        )))
+        load_from_single_file_with_cancel(model_dir, vision_cfg, should_cancel)
     }
 }
 
@@ -163,14 +202,16 @@ pub(crate) fn load_qwen35_vision_weights_with_cancel(
 ///
 /// This is the serving capability preflight: every expected `model.visual.*`
 /// name must occur exactly once and every referenced shard/file must be
-/// openable before HTTP request normalization advertises vision support.
+/// openable before HTTP request normalization advertises vision support. For
+/// an unindexed `model.safetensors`, the bounded safetensors header is parsed
+/// and every expected tensor shape is checked without decoding tensor values.
 pub fn validate_qwen35_vision_weight_inventory(
     model_dir: &Path,
     vision_cfg: &VisionModelConfig,
 ) -> Result<(), InferenceError> {
     vision_cfg.validate()?;
     let expected: HashSet<String> = tensor_names(vision_cfg).into_iter().collect();
-    if model_dir.join("quantize_index.json").exists() {
+    if checkpoint_entry_present(&model_dir.join("quantize_index.json"))? {
         let manifest = q4_manifest::load_manifest(model_dir)
             .map_err(|err| {
                 InferenceError::InvalidSafetensors(format!(
@@ -213,7 +254,7 @@ pub fn validate_qwen35_vision_weight_inventory(
     }
 
     let index_path = model_dir.join("model.safetensors.index.json");
-    if index_path.exists() {
+    if checkpoint_entry_present(&index_path)? {
         let reader = ShardedSafetensors::open_index(&index_path)?;
         let actual: HashSet<String> = reader
             .index()
@@ -242,11 +283,249 @@ pub fn validate_qwen35_vision_weight_inventory(
         return Ok(());
     }
 
-    Err(InferenceError::ModelNotFound(format!(
-        "no model.safetensors.index.json or quantize_index.json in {} -- cannot validate \
-         model.visual.* vision tensors",
-        model_dir.display()
+    let single_path = resolve_qwen35_single_decoder_safetensors(model_dir)?;
+    let reader = SafetensorsFile::open(&single_path)?;
+    validate_single_file_inventory(&reader, &single_path, vision_cfg)
+}
+
+/// **Unstable**: checkpoint-layout resolution may evolve before 1.0.
+///
+/// Resolve the one safetensors file required by the pooled vision-embedding
+/// decoder loader. An existing `model.safetensors.index.json` is authoritative,
+/// even when a convenience `model.safetensors` also exists; its `weight_map`
+/// must name exactly one contained shard. Without an index, the directory must
+/// contain exactly one `*.safetensors` candidate whose resolved metadata is a
+/// file, and that candidate must be named `model.safetensors`. Symlinks are
+/// followed consistently with the checkpoint mmap trust policy.
+///
+/// This is the shared file-set policy used by `lattice-embed`'s
+/// `VisionEmbeddingModel`: decoder and visual tensors cannot independently
+/// select the plain and indexed layouts when both sentinels are present. The
+/// embed constructor opens the returned path once and loads both components
+/// through that reader; this resolver itself performs structural discovery
+/// and does not compute a checkpoint content digest.
+///
+/// # Errors
+///
+/// Returns [`InferenceError::ModelNotFound`] when no supported single-file
+/// decoder checkpoint exists, or [`InferenceError::InvalidSafetensors`] when
+/// an index escapes the model directory or an unindexed layout is ambiguous.
+pub fn resolve_qwen35_single_decoder_safetensors(
+    model_dir: &Path,
+) -> Result<PathBuf, InferenceError> {
+    Ok(resolve_qwen35_single_checkpoint_file_set(model_dir)?.path)
+}
+
+/// **Unstable**: checkpoint-layout opening may evolve before 1.0.
+///
+/// Resolve and open the one safetensors file required by the pooled
+/// vision-embedding decoder loader. The returned [`SafetensorsFile`] is the
+/// only open of the selected checkpoint needed to materialize both visual and
+/// decoder tensors. For an indexed layout, the authoritative `weight_map`
+/// must exactly match the opened shard's header inventory; a sparse, stale, or
+/// otherwise contradictory index fails before any tensor payload is decoded.
+///
+/// # Errors
+///
+/// Returns the same layout errors as
+/// [`resolve_qwen35_single_decoder_safetensors`], an invalid-safetensors error
+/// when an indexed `weight_map` and shard header disagree, or an open/header
+/// error from [`SafetensorsFile`].
+pub fn open_qwen35_single_decoder_safetensors(
+    model_dir: &Path,
+) -> Result<(SafetensorsFile, PathBuf), InferenceError> {
+    let resolved = resolve_qwen35_single_checkpoint_file_set(model_dir)?;
+    let reader = SafetensorsFile::open(&resolved.path)?;
+    if let Some(indexed_weight_map) = &resolved.indexed_weight_map {
+        validate_indexed_single_shard_inventory(&reader, &resolved.path, indexed_weight_map)?;
+    }
+    Ok((reader, resolved.path))
+}
+
+struct ResolvedQwen35SingleCheckpoint {
+    path: PathBuf,
+    indexed_weight_map: Option<HashMap<String, String>>,
+}
+
+fn resolve_qwen35_single_checkpoint_file_set(
+    model_dir: &Path,
+) -> Result<ResolvedQwen35SingleCheckpoint, InferenceError> {
+    let index_path = model_dir.join("model.safetensors.index.json");
+    if checkpoint_entry_present(&index_path)? {
+        let index = parse_index(model_dir)?;
+        let mut shards: Vec<String> = index.weight_map.values().cloned().collect();
+        shards.sort_unstable();
+        shards.dedup();
+        return match shards.as_slice() {
+            [one] => Ok(ResolvedQwen35SingleCheckpoint {
+                path: contained_shard_path(model_dir, one)?,
+                indexed_weight_map: Some(index.weight_map),
+            }),
+            [] => Err(InferenceError::InvalidSafetensors(format!(
+                "empty weight_map in {}",
+                index_path.display()
+            ))),
+            _ => Err(InferenceError::InvalidSafetensors(format!(
+                "checkpoint at {} is sharded across {} files; pooled vision embedding requires \
+                 one decoder safetensors shard",
+                model_dir.display(),
+                shards.len()
+            ))),
+        };
+    }
+
+    Ok(ResolvedQwen35SingleCheckpoint {
+        path: resolve_unindexed_safetensors(model_dir)?,
+        indexed_weight_map: None,
+    })
+}
+
+fn validate_indexed_single_shard_inventory(
+    reader: &SafetensorsFile,
+    checkpoint_path: &Path,
+    indexed_weight_map: &HashMap<String, String>,
+) -> Result<(), InferenceError> {
+    let declared: HashSet<&str> = indexed_weight_map.keys().map(String::as_str).collect();
+    let actual: HashSet<&str> = reader.tensor_names().into_iter().collect();
+    if declared == actual {
+        return Ok(());
+    }
+
+    let mut missing_from_shard: Vec<&str> = declared.difference(&actual).copied().collect();
+    missing_from_shard.sort_unstable();
+    let mut missing_from_index: Vec<&str> = actual.difference(&declared).copied().collect();
+    missing_from_index.sort_unstable();
+    Err(InferenceError::InvalidSafetensors(format!(
+        "authoritative model.safetensors.index.json weight_map/header inventory mismatch for {}: \
+         weight_map declares {} tensor(s), shard header contains {}; missing_from_shard={:?}, \
+         missing_from_index={:?}",
+        checkpoint_path.display(),
+        declared.len(),
+        actual.len(),
+        missing_from_shard.into_iter().take(5).collect::<Vec<_>>(),
+        missing_from_index.into_iter().take(5).collect::<Vec<_>>()
     )))
+}
+
+fn checkpoint_entry_present(path: &Path) -> Result<bool, InferenceError> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(InferenceError::InvalidSafetensors(format!(
+            "failed to inspect checkpoint sentinel {}: {err}",
+            path.display()
+        ))),
+    }
+}
+
+fn resolve_unindexed_safetensors(model_dir: &Path) -> Result<PathBuf, InferenceError> {
+    let entries = std::fs::read_dir(model_dir).map_err(|err| {
+        InferenceError::InvalidSafetensors(format!(
+            "failed to inspect unindexed checkpoint directory {}: {err}",
+            model_dir.display()
+        ))
+    })?;
+    let mut candidates = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|err| {
+            InferenceError::InvalidSafetensors(format!(
+                "failed to inspect an entry in unindexed checkpoint directory {}: {err}",
+                model_dir.display()
+            ))
+        })?;
+        let path = entry.path();
+        if path.extension() != Some(std::ffi::OsStr::new("safetensors")) {
+            continue;
+        }
+        let metadata = path.metadata().map_err(|err| {
+            InferenceError::InvalidSafetensors(format!(
+                "failed to inspect safetensors candidate {}: {err}",
+                path.display()
+            ))
+        })?;
+        if metadata.is_file() {
+            candidates.push(path);
+        }
+    }
+    candidates.sort();
+
+    match candidates.as_slice() {
+        [only] if only.file_name() == Some(std::ffi::OsStr::new("model.safetensors")) => {
+            Ok(only.clone())
+        }
+        [] => Err(InferenceError::ModelNotFound(format!(
+            "no model.safetensors.index.json or model.safetensors in {}",
+            model_dir.display()
+        ))),
+        [only] => Err(InferenceError::ModelNotFound(format!(
+            "unindexed checkpoint in {} contains {}, but the sole safetensors file must be named \
+             model.safetensors",
+            model_dir.display(),
+            only.display()
+        ))),
+        _ => Err(InferenceError::InvalidSafetensors(format!(
+            "ambiguous unindexed checkpoint in {}: found {} safetensors files; provide exactly \
+             one model.safetensors or a model.safetensors.index.json",
+            model_dir.display(),
+            candidates.len()
+        ))),
+    }
+}
+
+fn validate_single_file_inventory(
+    reader: &SafetensorsFile,
+    checkpoint_path: &Path,
+    vision_cfg: &VisionModelConfig,
+) -> Result<(), InferenceError> {
+    let expected_names = tensor_names(vision_cfg);
+    let expected: HashSet<&str> = expected_names.iter().map(String::as_str).collect();
+    let actual: HashSet<String> = reader
+        .tensor_names()
+        .into_iter()
+        .filter(|name| name.starts_with("model.visual."))
+        .map(str::to_string)
+        .collect();
+    if actual.len() != expected.len() || actual.iter().any(|name| !expected.contains(name.as_str()))
+    {
+        let mut missing: Vec<&str> = expected
+            .iter()
+            .copied()
+            .filter(|name| !actual.contains(*name))
+            .collect();
+        missing.sort_unstable();
+        let mut unexpected: Vec<&str> = actual
+            .iter()
+            .map(String::as_str)
+            .filter(|name| !expected.contains(name))
+            .collect();
+        unexpected.sort_unstable();
+        return Err(InferenceError::Inference(format!(
+            "vision checkpoint inventory mismatch in {}: found {} unique model.visual.* \
+             tensor(s), expected {} for depth {}; missing={:?}, unexpected={:?}",
+            checkpoint_path.display(),
+            actual.len(),
+            expected.len(),
+            vision_cfg.depth,
+            missing.into_iter().take(5).collect::<Vec<_>>(),
+            unexpected.into_iter().take(5).collect::<Vec<_>>()
+        )));
+    }
+
+    for name in &expected_names {
+        if let Some(expected_shape) = expected_visual_tensor_shape(name, vision_cfg) {
+            let actual_shape = reader
+                .tensor_shape(name)
+                .ok_or_else(|| InferenceError::MissingTensor(name.clone()))?;
+            if actual_shape != expected_shape {
+                return Err(InferenceError::ShapeMismatch {
+                    name: name.clone(),
+                    expected: expected_shape,
+                    actual: actual_shape.to_vec(),
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 /// The 153 real tensor names for a `depth`-block checkpoint (used to drive the fp16
@@ -368,6 +647,46 @@ fn load_from_fp16_dir_with_cancel(
 
     let Some(tensors) =
         fetch_expected_tensors_with_cancel(&mut reader, expected_names, vision_cfg, should_cancel)?
+    else {
+        return Ok(None);
+    };
+    if should_cancel() {
+        return Ok(None);
+    }
+    assemble(tensors, vision_cfg).map(Some)
+}
+
+fn load_from_single_file_with_cancel(
+    model_dir: &Path,
+    vision_cfg: &VisionModelConfig,
+    should_cancel: &mut dyn FnMut() -> bool,
+) -> Result<Option<Qwen35VisionWeights>, InferenceError> {
+    if should_cancel() {
+        return Ok(None);
+    }
+    let checkpoint_path = resolve_qwen35_single_decoder_safetensors(model_dir)?;
+    let mut reader = SafetensorsFile::open(&checkpoint_path)?;
+    load_from_safetensors_reader_with_cancel(
+        &mut reader,
+        &checkpoint_path,
+        vision_cfg,
+        should_cancel,
+    )
+}
+
+fn load_from_safetensors_reader_with_cancel(
+    reader: &mut SafetensorsFile,
+    checkpoint_path: &Path,
+    vision_cfg: &VisionModelConfig,
+    should_cancel: &mut dyn FnMut() -> bool,
+) -> Result<Option<Qwen35VisionWeights>, InferenceError> {
+    validate_single_file_inventory(reader, checkpoint_path, vision_cfg)?;
+    if should_cancel() {
+        return Ok(None);
+    }
+    let expected_names = tensor_names(vision_cfg);
+    let Some(tensors) =
+        fetch_expected_tensors_with_cancel(reader, expected_names, vision_cfg, should_cancel)?
     else {
         return Ok(None);
     };
@@ -1147,6 +1466,258 @@ mod tests {
         bytes.extend_from_slice(header.as_bytes());
         bytes.extend_from_slice(&data);
         std::fs::write(path, &bytes).expect("test setup: write shard");
+    }
+
+    fn tiny_f32_tensors(value: f32) -> Vec<(String, Vec<usize>, Vec<f32>)> {
+        tiny_expected_shapes()
+            .into_iter()
+            .map(|(name, shape)| {
+                let numel: usize = shape.iter().product();
+                (name, shape, vec![value; numel])
+            })
+            .collect()
+    }
+
+    fn assert_vision_weights_eq(actual: &Qwen35VisionWeights, expected: &Qwen35VisionWeights) {
+        assert_eq!(actual.patch_embed_weight, expected.patch_embed_weight);
+        assert_eq!(
+            actual.patch_embed_weight_shape,
+            expected.patch_embed_weight_shape
+        );
+        assert_eq!(actual.patch_embed_bias, expected.patch_embed_bias);
+        assert_eq!(actual.pos_embed, expected.pos_embed);
+        assert_eq!(actual.blocks.len(), expected.blocks.len());
+        for (actual, expected) in actual.blocks.iter().zip(&expected.blocks) {
+            assert_eq!(actual.qkv_weight, expected.qkv_weight);
+            assert_eq!(actual.qkv_bias, expected.qkv_bias);
+            assert_eq!(actual.proj_weight, expected.proj_weight);
+            assert_eq!(actual.proj_bias, expected.proj_bias);
+            assert_eq!(actual.fc1_weight, expected.fc1_weight);
+            assert_eq!(actual.fc1_bias, expected.fc1_bias);
+            assert_eq!(actual.fc2_weight, expected.fc2_weight);
+            assert_eq!(actual.fc2_bias, expected.fc2_bias);
+            assert_eq!(actual.norm1_weight, expected.norm1_weight);
+            assert_eq!(actual.norm1_bias, expected.norm1_bias);
+            assert_eq!(actual.norm2_weight, expected.norm2_weight);
+            assert_eq!(actual.norm2_bias, expected.norm2_bias);
+        }
+        assert_eq!(actual.merger.fc1_weight, expected.merger.fc1_weight);
+        assert_eq!(actual.merger.fc1_bias, expected.merger.fc1_bias);
+        assert_eq!(actual.merger.fc2_weight, expected.merger.fc2_weight);
+        assert_eq!(actual.merger.fc2_bias, expected.merger.fc2_bias);
+        assert_eq!(actual.merger.norm_weight, expected.merger.norm_weight);
+        assert_eq!(actual.merger.norm_bias, expected.merger.norm_bias);
+    }
+
+    #[test]
+    fn single_file_checkpoint_loads_without_an_index() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tiny_vision_cfg();
+        let tensors = tiny_f32_tensors(0.5);
+        write_multi_f32_tensor_shard(&tmp.path().join("model.safetensors"), &tensors);
+
+        let weights = load_qwen35_vision_weights(tmp.path(), &cfg)
+            .expect("a valid single model.safetensors must not require a synthetic index");
+        assert_eq!(weights.tensor_count(), tensors.len());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unindexed_model_safetensors_symlink_to_file_is_a_valid_candidate() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("checkpoint-blob"), b"fixture")
+            .expect("test setup: write symlink target");
+        symlink("checkpoint-blob", tmp.path().join("model.safetensors"))
+            .expect("test setup: create model.safetensors symlink");
+
+        let resolved = resolve_qwen35_single_decoder_safetensors(tmp.path())
+            .expect("a safetensors symlink resolving to a file is a supported candidate");
+        assert_eq!(resolved, tmp.path().join("model.safetensors"));
+    }
+
+    #[test]
+    fn single_file_inventory_preflight_accepts_valid_header() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tiny_vision_cfg();
+        let tensors = tiny_f32_tensors(0.5);
+        write_multi_f32_tensor_shard(&tmp.path().join("model.safetensors"), &tensors);
+
+        validate_qwen35_vision_weight_inventory(tmp.path(), &cfg)
+            .expect("single-file structural preflight must accept the exact visual inventory");
+    }
+
+    #[test]
+    fn single_file_checkpoint_rejects_ambiguous_unindexed_candidates() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tiny_vision_cfg();
+        let tensors = tiny_f32_tensors(0.5);
+        write_multi_f32_tensor_shard(&tmp.path().join("model.safetensors"), &tensors);
+        std::fs::write(tmp.path().join("leftover.safetensors"), b"not a checkpoint")
+            .expect("test setup: write second candidate");
+
+        let err = load_qwen35_vision_weights(tmp.path(), &cfg)
+            .expect_err("multiple unindexed safetensors files must be ambiguous");
+        let msg = err.to_string();
+        assert!(msg.contains("ambiguous unindexed checkpoint"), "got: {msg}");
+        assert!(msg.contains("2 safetensors files"), "got: {msg}");
+    }
+
+    #[test]
+    fn single_file_inventory_preflight_rejects_missing_visual_tensor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tiny_vision_cfg();
+        let omitted = "model.visual.merger.norm.bias";
+        let tensors: Vec<(String, Vec<usize>, Vec<f32>)> = tiny_expected_shapes()
+            .into_iter()
+            .filter(|(name, _)| name != omitted)
+            .map(|(name, shape)| {
+                let numel: usize = shape.iter().product();
+                (name, shape, vec![0.5f32; numel])
+            })
+            .collect();
+        write_multi_f32_tensor_shard(&tmp.path().join("model.safetensors"), &tensors);
+
+        let err = validate_qwen35_vision_weight_inventory(tmp.path(), &cfg)
+            .expect_err("an incomplete visual inventory must fail structural preflight");
+        assert!(err.to_string().contains("inventory mismatch"), "got: {err}");
+    }
+
+    #[test]
+    fn single_file_checkpoint_rejects_corrupt_header() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tiny_vision_cfg();
+        std::fs::write(tmp.path().join("model.safetensors"), u64::MAX.to_le_bytes())
+            .expect("test setup: write corrupt checkpoint");
+
+        let err = load_qwen35_vision_weights(tmp.path(), &cfg)
+            .expect_err("a corrupt safetensors header must fail before tensor loading");
+        assert!(
+            matches!(err, InferenceError::InvalidSafetensors(_)),
+            "got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn indexed_checkpoint_path_remains_preferred_over_plain_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tiny_vision_cfg();
+        let tensors = tiny_f32_tensors(0.5);
+        write_multi_f32_tensor_shard(&tmp.path().join("model.safetensors"), &tensors);
+        std::fs::write(
+            tmp.path().join("model.safetensors.index.json"),
+            b"not valid json",
+        )
+        .expect("test setup: write invalid index");
+
+        load_qwen35_vision_weights(tmp.path(), &cfg)
+            .expect_err("an existing index must not silently fall back to model.safetensors");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_index_sentinel_does_not_fall_back_to_plain_file() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tiny_vision_cfg();
+        let tensors = tiny_f32_tensors(0.5);
+        write_multi_f32_tensor_shard(&tmp.path().join("model.safetensors"), &tensors);
+        symlink(
+            "missing-index-target.json",
+            tmp.path().join("model.safetensors.index.json"),
+        )
+        .expect("test setup: create dangling index sentinel");
+
+        resolve_qwen35_single_decoder_safetensors(tmp.path())
+            .expect_err("a dangling authoritative index must not resolve the plain file");
+        load_qwen35_vision_weights(tmp.path(), &cfg)
+            .expect_err("a dangling authoritative index must not load the plain file");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_quantize_sentinel_does_not_fall_back_to_plain_file() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tiny_vision_cfg();
+        let tensors = tiny_f32_tensors(0.5);
+        write_multi_f32_tensor_shard(&tmp.path().join("model.safetensors"), &tensors);
+        symlink(
+            "missing-quantize-target.json",
+            tmp.path().join("quantize_index.json"),
+        )
+        .expect("test setup: create dangling quantized sentinel");
+
+        load_qwen35_vision_weights(tmp.path(), &cfg)
+            .expect_err("a dangling authoritative quantized manifest must not load the plain file");
+    }
+
+    #[test]
+    fn indexed_layout_binds_visual_and_decoder_resolution_to_the_same_shard() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = tiny_vision_cfg();
+        let shapes = tiny_expected_shapes();
+        let plain_tensors = tiny_f32_tensors(0.1);
+        write_multi_f32_tensor_shard(&tmp.path().join("model.safetensors"), &plain_tensors);
+
+        let shard_name = "model-00001-of-00001.safetensors";
+        let indexed_tensors = tiny_f32_tensors(0.9);
+        write_multi_f32_tensor_shard(&tmp.path().join(shard_name), &indexed_tensors);
+        let weight_map = shapes
+            .iter()
+            .map(|(name, _)| format!(r#""{name}":"{shard_name}""#))
+            .collect::<Vec<_>>()
+            .join(",");
+        std::fs::write(
+            tmp.path().join("model.safetensors.index.json"),
+            format!(r#"{{"weight_map":{{{weight_map}}}}}"#),
+        )
+        .expect("test setup: write index");
+
+        let resolved = resolve_qwen35_single_decoder_safetensors(tmp.path())
+            .expect("one-shard index resolves");
+        assert_eq!(resolved, tmp.path().join(shard_name));
+        let weights =
+            load_qwen35_vision_weights(tmp.path(), &cfg).expect("indexed visual checkpoint loads");
+        assert_eq!(weights.patch_embed_weight[0], 0.9f32);
+    }
+
+    #[test]
+    fn single_file_and_one_shard_index_load_identical_vision_weights() {
+        let single = tempfile::tempdir().unwrap();
+        let indexed = tempfile::tempdir().unwrap();
+        let cfg = tiny_vision_cfg();
+        let tensors: Vec<(String, Vec<usize>, Vec<f32>)> = tiny_expected_shapes()
+            .into_iter()
+            .enumerate()
+            .map(|(i, (name, shape))| {
+                let numel: usize = shape.iter().product();
+                (name, shape, vec![i as f32 / 100.0; numel])
+            })
+            .collect();
+        write_multi_f32_tensor_shard(&single.path().join("model.safetensors"), &tensors);
+
+        let shard_name = "model-00001-of-00001.safetensors";
+        write_multi_f32_tensor_shard(&indexed.path().join(shard_name), &tensors);
+        let weight_map = tensors
+            .iter()
+            .map(|(name, _, _)| format!(r#""{name}":"{shard_name}""#))
+            .collect::<Vec<_>>()
+            .join(",");
+        std::fs::write(
+            indexed.path().join("model.safetensors.index.json"),
+            format!(r#"{{"weight_map":{{{weight_map}}}}}"#),
+        )
+        .expect("test setup: write index");
+
+        let from_single =
+            load_qwen35_vision_weights(single.path(), &cfg).expect("single-file checkpoint loads");
+        let from_index = load_qwen35_vision_weights(indexed.path(), &cfg)
+            .expect("one-shard indexed checkpoint loads");
+        assert_vision_weights_eq(&from_single, &from_index);
     }
 
     fn assert_fc2_shape_mismatch(result: Result<Qwen35VisionWeights, InferenceError>) {

--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -5,7 +5,7 @@ use crate::weights::safetensors_layout::{
 };
 use memmap2::Mmap;
 use serde_json::Value;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -1799,10 +1799,10 @@ impl ShardedSafetensors {
 
 fn parse_safetensors_header(json: &str) -> Result<HashMap<String, TensorMeta>, InferenceError> {
     let mut parser = JsonParser::new(json);
-    parser.skip_ws();
     parser.expect(b'{')?;
 
     let mut tensors = HashMap::new();
+    let mut seen_keys = HashSet::new();
 
     loop {
         parser.skip_ws();
@@ -1820,12 +1820,22 @@ fn parse_safetensors_header(json: &str) -> Result<HashMap<String, TensorMeta>, I
         }
 
         let key = parser.parse_string()?;
+        if !seen_keys.insert(key.clone()) {
+            let kind = if key == "__metadata__" {
+                "metadata member"
+            } else {
+                "tensor name"
+            };
+            return Err(InferenceError::InvalidSafetensors(format!(
+                "duplicate {kind} in safetensors header: {key}"
+            )));
+        }
         parser.skip_ws();
         parser.expect(b':')?;
         parser.skip_ws();
 
         if key == "__metadata__" {
-            parser.skip_value()?;
+            parser.parse_metadata()?;
         } else {
             let meta = parser.parse_tensor_meta(&key)?;
             tensors.insert(key, meta);
@@ -1835,6 +1845,12 @@ fn parse_safetensors_header(json: &str) -> Result<HashMap<String, TensorMeta>, I
         match parser.peek() {
             Some(b',') => {
                 parser.bump();
+                parser.skip_ws();
+                if matches!(parser.peek(), Some(b'}')) {
+                    return Err(InferenceError::InvalidSafetensors(
+                        "trailing comma in safetensors header object".into(),
+                    ));
+                }
             }
             Some(b'}') => {
                 parser.bump();
@@ -1851,6 +1867,15 @@ fn parse_safetensors_header(json: &str) -> Result<HashMap<String, TensorMeta>, I
                 ));
             }
         }
+    }
+
+    while matches!(parser.peek(), Some(b' ')) {
+        parser.bump();
+    }
+    if let Some(other) = parser.peek() {
+        return Err(InferenceError::InvalidSafetensors(format!(
+            "non-space byte {other} after top-level safetensors header object"
+        )));
     }
 
     Ok(tensors)
@@ -1906,77 +1931,51 @@ impl<'a> JsonParser<'a> {
     }
 
     fn parse_string(&mut self) -> Result<String, InferenceError> {
+        let start = self.pos;
         self.expect(b'"')?;
-        let mut out = String::new();
+        let mut escaped = false;
         loop {
             let byte = self.bump().ok_or_else(|| {
                 InferenceError::InvalidSafetensors("unterminated string in header".into())
             })?;
-            match byte {
-                b'"' => break,
-                b'\\' => {
-                    let esc = self.bump().ok_or_else(|| {
-                        InferenceError::InvalidSafetensors(
-                            "unterminated escape sequence in header".into(),
-                        )
-                    })?;
-                    match esc {
-                        b'"' => out.push('"'),
-                        b'\\' => out.push('\\'),
-                        b'/' => out.push('/'),
-                        b'b' => out.push('\u{0008}'),
-                        b'f' => out.push('\u{000C}'),
-                        b'n' => out.push('\n'),
-                        b'r' => out.push('\r'),
-                        b't' => out.push('\t'),
-                        b'u' => {
-                            let hex = self.take_n(4)?;
-                            let hex_str = std::str::from_utf8(hex).map_err(|e| {
-                                InferenceError::InvalidSafetensors(format!(
-                                    "invalid unicode escape in header: {e}"
-                                ))
-                            })?;
-                            let value = u16::from_str_radix(hex_str, 16).map_err(|e| {
-                                InferenceError::InvalidSafetensors(format!(
-                                    "invalid unicode escape value {hex_str}: {e}"
-                                ))
-                            })?;
-                            let ch = char::from_u32(value as u32).ok_or_else(|| {
-                                InferenceError::InvalidSafetensors(format!(
-                                    "invalid unicode scalar value {value}"
-                                ))
-                            })?;
-                            out.push(ch);
-                        }
-                        other => {
-                            return Err(InferenceError::InvalidSafetensors(format!(
-                                "unsupported escape sequence \\{}",
-                                other as char
-                            )));
-                        }
-                    }
-                }
-                other => out.push(other as char),
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                break;
             }
         }
-        Ok(out)
-    }
-
-    fn take_n(&mut self, n: usize) -> Result<&'a [u8], InferenceError> {
-        if self.pos + n > self.bytes.len() {
-            return Err(InferenceError::InvalidSafetensors(
-                "unexpected end of input while reading header".into(),
-            ));
-        }
-        let slice = &self.bytes[self.pos..self.pos + n];
-        self.pos += n;
-        Ok(slice)
+        let raw = std::str::from_utf8(&self.bytes[start..self.pos]).map_err(|err| {
+            InferenceError::InvalidSafetensors(format!(
+                "safetensors header string is not valid UTF-8: {err}"
+            ))
+        })?;
+        serde_json::from_str(raw).map_err(|err| {
+            InferenceError::InvalidSafetensors(format!(
+                "invalid JSON string in safetensors header: {err}"
+            ))
+        })
     }
 
     fn parse_usize(&mut self) -> Result<usize, InferenceError> {
         let start = self.pos;
-        while matches!(self.peek(), Some(b'0'..=b'9')) {
-            self.pos += 1;
+        match self.peek() {
+            Some(b'0') => {
+                self.pos += 1;
+                if matches!(self.peek(), Some(b'0'..=b'9')) {
+                    return Err(InferenceError::InvalidSafetensors(format!(
+                        "leading zero in unsigned integer at byte {start}"
+                    )));
+                }
+            }
+            Some(b'1'..=b'9') => {
+                self.pos += 1;
+                while matches!(self.peek(), Some(b'0'..=b'9')) {
+                    self.pos += 1;
+                }
+            }
+            _ => {}
         }
         if start == self.pos {
             return Err(InferenceError::InvalidSafetensors(format!(
@@ -2028,6 +2027,57 @@ impl<'a> JsonParser<'a> {
         Ok(values)
     }
 
+    /// Parse the optional safetensors `__metadata__` member. The wire format
+    /// requires a JSON object whose keys and values are strings; arbitrary
+    /// nested JSON is not a valid metadata payload.
+    fn parse_metadata(&mut self) -> Result<(), InferenceError> {
+        self.expect(b'{')?;
+        self.skip_ws();
+        let mut seen_keys = HashSet::new();
+        if matches!(self.peek(), Some(b'}')) {
+            self.bump();
+            return Ok(());
+        }
+        loop {
+            self.skip_ws();
+            let key = self.parse_string()?;
+            if !seen_keys.insert(key.clone()) {
+                return Err(InferenceError::InvalidSafetensors(format!(
+                    "duplicate __metadata__ key in safetensors header: {key}"
+                )));
+            }
+            self.skip_ws();
+            self.expect(b':')?;
+            self.skip_ws();
+            self.parse_string().map_err(|_| {
+                InferenceError::InvalidSafetensors(format!(
+                    "safetensors __metadata__ value for {key:?} must be a string"
+                ))
+            })?;
+            self.skip_ws();
+            match self.peek() {
+                Some(b',') => {
+                    self.bump();
+                }
+                Some(b'}') => {
+                    self.bump();
+                    break;
+                }
+                Some(other) => {
+                    return Err(InferenceError::InvalidSafetensors(format!(
+                        "expected ',' or '}}' in safetensors __metadata__, found byte {other}"
+                    )));
+                }
+                None => {
+                    return Err(InferenceError::InvalidSafetensors(
+                        "unexpected end of safetensors __metadata__ object".into(),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn skip_value(&mut self) -> Result<(), InferenceError> {
         self.skip_ws();
         match self.peek() {
@@ -2049,9 +2099,15 @@ impl<'a> JsonParser<'a> {
                     self.depth -= 1;
                     return Ok(());
                 }
+                let mut seen_keys = HashSet::new();
                 loop {
                     self.skip_ws();
-                    self.parse_string()?;
+                    let key = self.parse_string()?;
+                    if !seen_keys.insert(key.clone()) {
+                        return Err(InferenceError::InvalidSafetensors(format!(
+                            "duplicate key in safetensors header object: {key}"
+                        )));
+                    }
                     self.skip_ws();
                     self.expect(b':')?;
                     self.skip_ws();
@@ -2124,10 +2180,7 @@ impl<'a> JsonParser<'a> {
             Some(b't') => self.skip_literal(b"true"),
             Some(b'f') => self.skip_literal(b"false"),
             Some(b'n') => self.skip_literal(b"null"),
-            Some(b'-' | b'0'..=b'9') => {
-                self.skip_number();
-                Ok(())
-            }
+            Some(b'-' | b'0'..=b'9') => self.skip_number(),
             Some(other) => Err(InferenceError::InvalidSafetensors(format!(
                 "unsupported JSON value starting with byte {other}"
             ))),
@@ -2150,13 +2203,68 @@ impl<'a> JsonParser<'a> {
         Ok(())
     }
 
-    fn skip_number(&mut self) {
-        while matches!(
-            self.peek(),
-            Some(b'0'..=b'9' | b'-' | b'+' | b'.' | b'e' | b'E')
-        ) {
+    /// Consume one RFC 8259 JSON number. This is used only for unknown
+    /// extension values, but accepting a loose run of number-like bytes here
+    /// would make the entire safetensors header non-JSON while still passing
+    /// structural preflight.
+    fn skip_number(&mut self) -> Result<(), InferenceError> {
+        let start = self.pos;
+        if matches!(self.peek(), Some(b'-')) {
             self.pos += 1;
         }
+
+        match self.peek() {
+            Some(b'0') => {
+                self.pos += 1;
+                if matches!(self.peek(), Some(b'0'..=b'9')) {
+                    return Err(InferenceError::InvalidSafetensors(format!(
+                        "leading zero in JSON number at byte {start}"
+                    )));
+                }
+            }
+            Some(b'1'..=b'9') => {
+                self.pos += 1;
+                while matches!(self.peek(), Some(b'0'..=b'9')) {
+                    self.pos += 1;
+                }
+            }
+            _ => {
+                return Err(InferenceError::InvalidSafetensors(format!(
+                    "invalid JSON number at byte {start}: expected an integer digit"
+                )));
+            }
+        }
+
+        if matches!(self.peek(), Some(b'.')) {
+            self.pos += 1;
+            let fraction_start = self.pos;
+            while matches!(self.peek(), Some(b'0'..=b'9')) {
+                self.pos += 1;
+            }
+            if self.pos == fraction_start {
+                return Err(InferenceError::InvalidSafetensors(format!(
+                    "invalid JSON number at byte {start}: fraction has no digits"
+                )));
+            }
+        }
+
+        if matches!(self.peek(), Some(b'e' | b'E')) {
+            self.pos += 1;
+            if matches!(self.peek(), Some(b'+' | b'-')) {
+                self.pos += 1;
+            }
+            let exponent_start = self.pos;
+            while matches!(self.peek(), Some(b'0'..=b'9')) {
+                self.pos += 1;
+            }
+            if self.pos == exponent_start {
+                return Err(InferenceError::InvalidSafetensors(format!(
+                    "invalid JSON number at byte {start}: exponent has no digits"
+                )));
+            }
+        }
+
+        Ok(())
     }
 
     /// Parse one tensor's header entry. `tensor_name` is the key this entry
@@ -2176,6 +2284,7 @@ impl<'a> JsonParser<'a> {
         let mut dtype_str: Option<String> = None;
         let mut shape = None;
         let mut data_offsets = None;
+        let mut seen_keys = HashSet::new();
 
         if matches!(self.peek(), Some(b'}')) {
             self.bump();
@@ -2183,6 +2292,11 @@ impl<'a> JsonParser<'a> {
             loop {
                 self.skip_ws();
                 let key = self.parse_string()?;
+                if !seen_keys.insert(key.clone()) {
+                    return Err(InferenceError::InvalidSafetensors(format!(
+                        "duplicate member in tensor {tensor_name} header object: {key}"
+                    )));
+                }
                 self.skip_ws();
                 self.expect(b':')?;
                 self.skip_ws();
@@ -2474,6 +2588,192 @@ mod tests {
         assert_eq!(mat_data, &[3.0, 4.0, 5.0, 6.0]);
     }
 
+    #[test]
+    fn duplicate_tensor_name_in_safetensors_header_is_rejected() {
+        let header = r#"{"tensor":{"dtype":"F32","shape":[1],"data_offsets":[0,4]},"tensor":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}"#;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&1.0f32.to_le_bytes());
+
+        let err = SafetensorsFile::from_bytes(bytes)
+            .expect_err("duplicate tensor names must not collapse into the header map");
+        assert!(
+            err.to_string().contains("duplicate tensor name"),
+            "error must identify the duplicate header member: {err}"
+        );
+    }
+
+    #[test]
+    fn duplicate_tensor_object_members_are_rejected() {
+        let duplicate_members = [
+            r#""dtype":"F32","dtype":"F32","shape":[1],"data_offsets":[0,4]"#,
+            r#""dtype":"F32","shape":[1],"shape":[1],"data_offsets":[0,4]"#,
+            r#""dtype":"F32","shape":[1],"data_offsets":[0,4],"data_offsets":[0,4]"#,
+            r#""dtype":"F32","shape":[1],"data_offsets":[0,4],"extra":1,"extra":2"#,
+            r#""dtype":"F32","shape":[1],"data_offsets":[0,4],"extra":{"nested":1,"nested":2}"#,
+        ];
+
+        for members in duplicate_members {
+            let header = format!(r#"{{"tensor":{{{members}}}}}"#);
+            let mut bytes = Vec::new();
+            bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+            bytes.extend_from_slice(header.as_bytes());
+            bytes.extend_from_slice(&1.0f32.to_le_bytes());
+
+            let err = SafetensorsFile::from_bytes(bytes)
+                .expect_err("duplicate keys anywhere in a tensor object must be rejected");
+            assert!(
+                err.to_string().contains("duplicate"),
+                "error must identify the duplicate object member: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn metadata_must_be_a_unique_string_map() {
+        let invalid_headers = [
+            r#"{"__metadata__":{"source":"a","source":"b"},"tensor":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}"#,
+            r#"{"__metadata__":{"source":1},"tensor":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}"#,
+            r#"{"__metadata__":[],"tensor":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}"#,
+            r#"{"__metadata__":{},"__metadata__":{},"tensor":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}"#,
+        ];
+
+        for header in invalid_headers {
+            let mut bytes = Vec::new();
+            bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+            bytes.extend_from_slice(header.as_bytes());
+            bytes.extend_from_slice(&1.0f32.to_le_bytes());
+            SafetensorsFile::from_bytes(bytes)
+                .expect_err("safetensors metadata must be one unique string-to-string map");
+        }
+    }
+
+    #[test]
+    fn utf8_strings_decode_canonically_before_duplicate_checks() {
+        let header = r#"{"__metadata__":{"作者":"café 🚀"},"t\u00e9nsor\ud83d\ude80":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}"#;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&1.0f32.to_le_bytes());
+        let parsed = SafetensorsFile::from_bytes(bytes)
+            .expect("valid UTF-8 and a valid escaped surrogate pair must parse");
+        assert!(
+            parsed.has_tensor("ténsor🚀"),
+            "raw UTF-8 and escaped surrogate pairs must decode to canonical scalar values"
+        );
+
+        let duplicate = r#"{"__metadata__":{"é":"raw","\u00e9":"escaped"},"tensor":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}"#;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(duplicate.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(duplicate.as_bytes());
+        bytes.extend_from_slice(&1.0f32.to_le_bytes());
+        SafetensorsFile::from_bytes(bytes)
+            .expect_err("raw and escaped forms of the same metadata key are duplicates");
+    }
+
+    #[test]
+    fn malformed_json_numbers_are_rejected() {
+        let invalid_members = [
+            r#""extra":-"#,
+            r#""extra":1+2"#,
+            r#""extra":01"#,
+            r#""extra":-01"#,
+            r#""extra":1."#,
+            r#""extra":1e"#,
+            r#""extra":1e+"#,
+            r#""shape":[01]"#,
+            r#""data_offsets":[00,4]"#,
+        ];
+
+        for invalid in invalid_members {
+            let members = match invalid.split_once(':').map(|(key, _)| key) {
+                Some(r#""shape""#) => {
+                    format!(r#""dtype":"F32",{invalid},"data_offsets":[0,4]"#)
+                }
+                Some(r#""data_offsets""#) => {
+                    format!(r#""dtype":"F32","shape":[1],{invalid}"#)
+                }
+                _ => format!(r#""dtype":"F32","shape":[1],"data_offsets":[0,4],{invalid}"#),
+            };
+            let header = format!(r#"{{"tensor":{{{members}}}}}"#);
+            let mut bytes = Vec::new();
+            bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+            bytes.extend_from_slice(header.as_bytes());
+            bytes.extend_from_slice(&1.0f32.to_le_bytes());
+
+            assert!(
+                SafetensorsFile::from_bytes(bytes).is_err(),
+                "invalid JSON number must fail closed: {header}"
+            );
+        }
+    }
+
+    #[test]
+    fn valid_json_numbers_in_unknown_values_are_accepted() {
+        let header = r#"{"tensor":{"dtype":"F32","shape":[1],"data_offsets":[0,4],"extra":[0,-1,1.5,1e2,-0.25E+2]}}"#;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&1.0f32.to_le_bytes());
+
+        SafetensorsFile::from_bytes(bytes)
+            .expect("RFC 8259 numbers in an unknown extension value must remain valid");
+    }
+
+    #[test]
+    fn malformed_unicode_surrogates_are_rejected() {
+        for escaped in [r#"\ud83d"#, r#"\ude80"#, r#"\ud83dX"#] {
+            let header = format!(
+                r#"{{"__metadata__":{{"value":"{escaped}"}},"tensor":{{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}}}"#
+            );
+            let mut bytes = Vec::new();
+            bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+            bytes.extend_from_slice(header.as_bytes());
+            bytes.extend_from_slice(&1.0f32.to_le_bytes());
+            SafetensorsFile::from_bytes(bytes)
+                .expect_err("a malformed JSON Unicode surrogate must fail closed");
+        }
+    }
+
+    #[test]
+    fn trailing_comma_in_header_object_is_rejected() {
+        let header = r#"{"tensor":{"dtype":"F32","shape":[1],"data_offsets":[0,4]},}"#;
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&1.0f32.to_le_bytes());
+
+        SafetensorsFile::from_bytes(bytes)
+            .expect_err("the safetensors header must be valid JSON without a trailing comma");
+    }
+
+    #[test]
+    fn non_space_bytes_after_top_level_header_are_rejected() {
+        let tensor = r#"{"tensor":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}"#;
+        let header = format!("{tensor}THIS_IS_NOT_JSON");
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&1.0f32.to_le_bytes());
+
+        SafetensorsFile::from_bytes(bytes)
+            .expect_err("the declared header may contain only space padding after its JSON object");
+    }
+
+    #[test]
+    fn space_padding_after_top_level_header_is_accepted() {
+        let tensor = r#"{"tensor":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}"#;
+        let header = format!("{tensor}   ");
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&1.0f32.to_le_bytes());
+
+        SafetensorsFile::from_bytes(bytes)
+            .expect("ASCII space is valid safetensors header padding");
+    }
+
     // #1368: `SafetensorsFile::open` is a raw-open entry point (used directly
     // by the runtime model loaders, not just via `open_manifest_entry_once`)
     // that must route through the mmap trust boundary the same as every
@@ -2660,10 +2960,11 @@ mod tests {
         // couple hundred bytes -- far under MAX_SAFETENSORS_HEADER_BYTES, so only
         // the depth bound can be what rejects this fixture.
         let depth = MAX_SAFETENSORS_HEADER_DEPTH + 8;
-        let mut header = String::from(r#"{"__metadata__":"#);
+        let mut header =
+            String::from(r#"{"tensor":{"dtype":"F32","shape":[0],"data_offsets":[0,0],"extra":"#);
         header.push_str(&"[".repeat(depth));
         header.push_str(&"]".repeat(depth));
-        header.push('}');
+        header.push_str("}}");
         assert!(header.len() < MAX_SAFETENSORS_HEADER_BYTES);
 
         let mut bytes = Vec::new();

--- a/docs/adr/ADR-003-safetensors-loading.md
+++ b/docs/adr/ADR-003-safetensors-loading.md
@@ -10,14 +10,14 @@
 
 Loading model weights is the dominant startup-latency operation for inference servers. For Qwen3-Embedding-0.6B (28 layers, 1024 hidden size), the checkpoint is distributed across multiple safetensors shards. The design must address:
 
-1. **Parse cost**: The safetensors format uses a JSON header to describe tensor locations within the binary blob. Parsing this header with a full JSON library (serde_json) would pull in a significant dependency chain.
+1. **Parse cost**: The safetensors format uses a JSON header to describe tensor locations within the binary blob. Deserializing that full header into a generic JSON tree would add allocation and obscure duplicate-member checks; the crate already carries `serde_json`, so bounded string-token decoding can still reuse its standards-compliant Unicode handling.
 2. **Copy cost**: F32 weights on a little-endian host can be used in-place from the memory-mapped file if alignment permits. Copying them defeats the point of safetensors.
 3. **Type conversion**: F16 and BF16 tensors cannot be used in-place by the f32 compute kernels. They must be converted and cached.
 4. **Sharding**: Multi-shard checkpoints must be served transparently, opening each shard lazily to avoid holding all file descriptors simultaneously.
 
 Relevant implementation: `src/weights/f32_weights.rs`.
 
-The file contains a hand-written `JsonParser` struct (no serde dependency), `memmap2::Mmap` for the binary data, `TensorMeta` with an `OnceLock<Box<[f32]>>` for lazy conversion cache, and `ShardedSafetensors` for multi-file checkpoints.
+The file contains a hand-written structural `JsonParser` (with `serde_json` used only for one bounded string token at a time), `memmap2::Mmap` for the binary data, `TensorMeta` with an `OnceLock<Box<[f32]>>` for lazy conversion cache, and `ShardedSafetensors` for multi-file checkpoints.
 
 Key code paths:
 
@@ -84,11 +84,48 @@ wins. Repeated access to an aligned zero-copy F32 tensor therefore does not resc
 memory-mapped pages, and a failed validation is cached as its error message (`validate_ingested_tensor`
 only ever returns `InferenceError::InvalidSafetensors`) and never as success.
 
+### Amendment — strict headers and bound single-file visual loads (2026-08-09)
+
+The bounded header parser enforces the SafeTensors framing and JSON contract before any tensor is
+materialized: an eight-byte little-endian header length capped at 4 MiB; a UTF-8 JSON object that
+begins with `{`; unique keys at the top level and in every parsed or skipped object; tensor objects
+with unambiguous `dtype`, `shape`, and `data_offsets`; an optional `__metadata__` string-to-string
+map; canonical JSON-string decoding (so raw and escaped-equivalent Unicode keys compare equal);
+strict RFC 8259 number grammar (including no leading-zero integers); and only ASCII-space padding
+after the one complete top-level object. Trailing commas, non-space trailing bytes, malformed
+surrogate pairs, duplicate names or members, malformed numbers, and arbitrary metadata values
+fail closed. Structural parsing remains hand-written and bounded; the already-present `serde_json`
+dependency is used only to decode one bounded JSON string token canonically, not to deserialize the
+header tree or collapse object members into maps.
+
+For Qwen3.5 vision checkpoints, an entry named `model.safetensors.index.json` is authoritative.
+Presence is checked with `symlink_metadata`, so a malformed, unreadable, or dangling index fails
+rather than falling back. Without an index, discovery accepts exactly one `*.safetensors`
+candidate whose resolved metadata is a file and requires its name to be `model.safetensors`;
+symlinks are followed consistently with the checkpoint mmap trust policy. Zero, multiple, or
+misnamed candidates fail closed. `quantize_index.json` retains precedence in the lower-level
+vision loader, but constructors with only an f16 decoder path reject it explicitly.
+
+`resolve_qwen35_single_decoder_safetensors` exposes this structural policy as an unstable public
+path-preflight surface. `open_qwen35_single_decoder_safetensors` resolves and opens the selected
+file once; for an indexed layout it also requires the authoritative `weight_map` to match the open
+shard's complete tensor-name inventory exactly. `load_qwen35_vision_weights_from_safetensors` is
+the corresponding unstable already-open reader surface. A pooled vision constructor materializes
+both visual and decoder tensors through that one reader. This binds the two components to one open
+file description even if the directory entry is atomically replaced during a multi-gigabyte load,
+and prevents direct-reader loading from bypassing indexed membership. These surfaces do not compute
+a content digest; identity-governing callers remain responsible for optional checkpoint attestation
+after structural preflight.
+
 ---
 
 ## Key Design Choices
 
-1. **Hand-written JSON parser**: The safetensors header is a constrained subset of JSON (no nested objects beyond the header map, no arrays of arbitrary depth). A custom parser avoids the `serde`, `serde_json`, and `serde_derive` dependency chain while being faster to compile and smaller in binary size.
+1. **Hand-written structural JSON parser**: The safetensors header is bounded and structurally
+   constrained. The parser retains explicit duplicate-key, depth, metadata-shape, padding, and
+   extent checks without allocating a generic JSON tree. The already-present `serde_json`
+   dependency decodes only individual bounded string tokens so Unicode and escape equivalence are
+   canonical before duplicate checks.
 2. **`OnceLock` conversion cache**: On first access to an F16/BF16 tensor, `get_or_init` performs the conversion and stores it. Subsequent accesses return the cached `Box<[f32]>` with no synchronization overhead (post-init reads are lock-free).
 3. **Zero-copy F32**: `bytes_to_f32_slice` returns `None` on misalignment and the caller falls back to a copy. In practice, safetensors aligns tensors to 8 bytes, which satisfies f32's 4-byte alignment requirement on all target platforms.
 4. **Eager QKV fusion**: Fusing at load time rather than inference time means the fusion cost is paid once and inference hot paths see a single contiguous weight matrix. The cost is ~30% higher peak memory during the load window (both original and fused forms exist briefly).
@@ -105,7 +142,7 @@ only ever returns `InferenceError::InvalidSafetensors`) and never as success.
 
 | Alternative                               | Pros                                | Cons                                                                                               | Why Not                                                               |
 | ----------------------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `serde_json` for header parsing           | No custom code; handles edge cases  | Adds ~400KB to binary; slower compile; overkill for this constrained format                        | Dependency budget; safetensors header JSON is well-constrained        |
+| Full-tree `serde_json` header parsing     | Less structural parser code         | Default maps collapse duplicate keys; a generic tree allocates more and obscures admission order   | Explicit bounded duplicate/metadata/layout checks stay reviewable     |
 | `candle` weight loading primitives        | Battle-tested; type-safe tensor API | Pulls in the entire `candle` ecosystem; incompatible with the crate's no-ONNX/no-Python constraint | Defeats the purpose of a pure Rust inference engine                   |
 | Copy all weights at load time             | Simpler memory model; no `unsafe`   | 1–4 GB of unnecessary allocations; slower startup; more GC pressure                                | Latency and memory budget                                             |
 | Load shards eagerly                       | Simpler code                        | All shard file descriptors held open simultaneously; larger virtual memory footprint               | Resource usage                                                        |
@@ -118,7 +155,7 @@ only ever returns `InferenceError::InvalidSafetensors`) and never as success.
 **Positive**:
 
 - F32 model startup is near-zero-copy: the OS maps pages on demand.
-- No serde dependency in the inference crate.
+- No generic JSON-tree allocation on the checkpoint header path.
 - F16/BF16 conversion cost is paid at most once per tensor per process lifetime.
 - Finite-value validation cost is paid at most once per successfully accessed tensor.
 - Single-GEMM QKV path reduces per-layer arithmetic from 5 matmuls to 3.

--- a/docs/adr/ADR-069-vision-encoder-qwen35-recalibration.md
+++ b/docs/adr/ADR-069-vision-encoder-qwen35-recalibration.md
@@ -259,3 +259,26 @@ real HTTP image request emits the production multimodal-dispatch marker, that ev
 for the 256-patch golden image actually dispatched to Metal instead of silently taking the CPU
 fallback, and that the request returns generated text, while a text-only control request does not
 emit that marker. The Studio composer portion of S6 remains separate UI work.
+
+## Amendment 3 — Unindexed single-file vision checkpoints (2026-08-09)
+
+Vision capability discovery and pooled-embedding construction also accept the standard
+HuggingFace layout with no weight index when the model directory contains exactly one
+`*.safetensors` candidate whose resolved metadata is a file, named `model.safetensors`. Symlinks
+are followed consistently with the checkpoint mmap trust policy. An existing
+`model.safetensors.index.json` remains authoritative, including malformed or dangling entries;
+the loader never falls back from that sentinel to the plain file. Multiple unindexed candidates
+are ambiguous and fail closed.
+
+The single-file path reuses the bounded `SafetensorsFile` parser and mmap trust boundary from
+ADR-003. Before materializing tensor payloads it validates the complete `model.visual.*` name and
+shape inventory implied by `vision_config`; corrupt JSON, duplicate object keys, invalid metadata,
+unsupported padding, missing tensors, and unexpected visual tensors are rejected. The pooled f16
+embedding constructor resolves and opens the selected safetensors file once, then materializes
+both visual and decoder weights through that same mmap-backed reader so an atomic path replacement
+during a multi-gigabyte load cannot compose components from different checkpoint versions. For an
+indexed one-shard layout, the authoritative `weight_map` must exactly match the opened shard's
+tensor-name inventory; direct-reader materialization cannot bypass indexed membership. Config,
+tokenizer, layout, and bounded header validation all precede tensor-payload materialization.
+`quantize_index.json` remains supported by the lower-level vision loader and serving preflight,
+but is rejected by the pooled f16 constructor because it has no coherent quantized decoder path.


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Summary

- accept the standard unindexed Qwen3.5 layout containing exactly one `model.safetensors`, while preserving `model.safetensors.index.json` as authoritative when present;
- resolve and open the selected checkpoint once, then materialize both visual and decoder tensors through that same mmap-backed reader;
- require a one-shard index's complete `weight_map` to match the opened shard header exactly before reading tensor payloads;
- harden bounded SafeTensors header admission around duplicate keys, metadata shape, Unicode escapes, RFC 8259 numbers, padding, and trailing bytes;
- add direct indexed/unindexed embedding parity, mutation-sensitive constructor binding, admission-order, corrupt/ambiguous layout, and real-model coverage.

Closes #1381.

## Contract and failure behavior

`VisionEmbeddingModel::from_directory` now accepts either:

1. an authoritative `model.safetensors.index.json` naming exactly one contained shard; or
2. no index and exactly one resolved file candidate named `model.safetensors`.

An existing malformed, unreadable, or dangling index never falls back to the plain file. Multiple or misnamed unindexed candidates are rejected. The f16 pooled constructor rejects `quantize_index.json`; the lower-level quantized vision loader remains supported.

For the selected f16 file, config and tokenizer admission happen before multi-gigabyte tensor materialization. The constructor opens the checkpoint once and reuses that reader for both visual and decoder weights, so an atomic pathname replacement during loading cannot mix versions. Lattice deliberately does not assign a content identity here; callers that govern model identity still own checkpoint-digest attestation.

The public resolver/open-reader seams are documented as unstable before 1.0. Accepted ADR-003 records the file-set, strict-header, and one-open contracts; proposed ADR-069 records the corresponding vision-layout amendment.

## Verification

Executed on the final feature code:

- `cargo test -p lattice-inference weights::f32_weights::tests --lib` — 54 passed;
- `cargo test -p lattice-inference vision::checkpoint::tests --lib` — 34 passed;
- `cargo test -p lattice-embed vision::tests --lib` — 17 passed;
- workspace all-target Clippy with `-D warnings` — passed;
- `cargo fmt --check`, documentation lint, and `git diff --check` — passed;
- env-gated Qwen3.5-2B unindexed checkpoint test — 1 passed in 383.31 s, with dimension 2048, finite unit-normalized output, and exact repeat determinism;
- synthetic `VisionEmbeddingModel::from_directory` parity — the same tiny checkpoint in unindexed and equivalent one-shard-indexed layouts produces identical image embeddings;
- mutation-sensitive file binding — the public constructor atomically replaces the pathname after visual loading and verifies both returned visual and decoder weights still came from the original opened file.

The post-main-merge `make ci` gate completed all preceding inference suites (including 2,586 inference tests) before entering the repository's real Gemma-4 sliding-window golden on the local checkpoint. It was explicitly interrupted after this PR opened to free CPU for the dependent Khive build, per user direction. The PR does not represent that unfinished gate as a pass; GitHub checks provide the remaining workspace coverage. `make publish-dry` remains a post-open follow-up.

## bench-compare disposition

The changed header parser is reached by `f16_convert_bench`'s `safetensors_ingress_widen` group. The repository's certified wrapper was attempted, but this managed sandbox cannot execute its mandatory quiet-machine probe:

```text
[quiet] safetensors-ingress-head-certified: before: PROBE FAILED ([Errno 1] Operation not permitted: 'top') - refusing to measure
bench-supervision: machine was not quiet before safetensors-ingress-head-certified; refusing to measure
```

That refusal is reported as a measurement limitation, not converted into a waiver. A supplemental same-machine, lock-serialized base-then-head comparison (not ABBA; no idle, thermal, AC, cooldown, or HID certification) produced:

| Group | Base mean | Head mean | Delta |
|---|---:|---:|---:|
| F16 / 8,388,608 | 20.964087 ms | 19.976610 ms | -4.7103% |
| BF16 / 8,388,608 | 7.248974 ms | 7.205548 ms | -0.5991% |

Median deltas were -2.9633% (F16) and -0.3862% (BF16). These numbers show no regression signal in this run, but they are supplemental evidence only and are not a certified performance claim.

## AI-assisted contribution checklist

- [x] Every PR claim is tied to the current diff or recorded command output.
- [x] Independent review found no remaining P0-P2 issues after the mutation-sensitive fixes.
- [x] No SIMD or numerical-kernel implementation changed.
- [x] No external ML runtime dependency was added.
- [x] Real-model behavior was exercised rather than inferred from synthetic fixtures alone.
