### PR TITLE
feat(vision): Metal-dispatching pooled image embedding entry point

### DIFF
--- a/crates/embed/src/vision.rs
+++ b/crates/embed/src/vision.rs
@@ -33,7 +33,7 @@ use lattice_inference::vision::checkpoint::{
     Qwen35VisionWeights, load_qwen35_vision_weights_from_safetensors,
     open_qwen35_single_decoder_safetensors,
 };
-use lattice_inference::vision::embed_image_from_bytes_f16;
+use lattice_inference::vision::{embed_image_from_bytes_f16, embed_image_from_bytes_f16_metal};
 use lattice_inference::weights::f16_weights::{F16ModelWeights, load_f16_weights};
 use std::path::Path;
 
@@ -205,6 +205,38 @@ impl VisionEmbeddingModel {
         pooling: PoolingStrategy,
     ) -> Result<Vec<f32>> {
         embed_image_from_bytes_f16(
+            &self.weights,
+            &self.config,
+            &self.vision_weights,
+            &self.tokenizer,
+            image_bytes,
+            prompt,
+            pooling,
+        )
+        .map_err(map_inference_error)
+    }
+
+    /// Metal-dispatching sibling of [`Self::embed_image`]: runs the ViT
+    /// forward pass on the Metal GPU instead of the CPU (see
+    /// [`lattice_inference::vision::embed_image_from_bytes_f16_metal`]).
+    /// Same scaffold, pooling contract, and error semantics as
+    /// [`Self::embed_image`], with one addition: on a build/platform with no
+    /// Metal support, this returns [`EmbedError::InferenceFailed`] (Metal
+    /// unavailability is a runtime-backend failure, not caller-input
+    /// validation) rather than silently falling back to
+    /// [`Self::embed_image`]'s CPU path — callers that want a fallback must
+    /// call [`Self::embed_image`] themselves.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::embed_image`]'s docs.
+    pub fn embed_image_metal(
+        &self,
+        image_bytes: &[u8],
+        prompt: &str,
+        pooling: PoolingStrategy,
+    ) -> Result<Vec<f32>> {
+        embed_image_from_bytes_f16_metal(
             &self.weights,
             &self.config,
             &self.vision_weights,
@@ -734,6 +766,72 @@ mod tests {
             via_wrapper, via_raw,
             "embed-crate wrapper must return the identical vector to the raw primitive"
         );
+    }
+
+    /// Same wire-through claim as
+    /// `embed_image_matches_raw_inference_primitive`, for the Metal entry
+    /// point: the crate wrapper must add no numerical difference relative to
+    /// calling `embed_image_from_bytes_f16_metal` directly.
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+    #[test]
+    fn embed_image_metal_matches_raw_inference_primitive() {
+        use lattice_inference::vision::embed_image_from_bytes_f16_metal;
+
+        let (cfg, weights, vision_weights) = tiny_vlm_fixture();
+        let tokenizer = tiny_tokenizer();
+        let png = make_test_png(8, 8, 0);
+
+        let model = VisionEmbeddingModel::new(
+            weights.clone(),
+            cfg.clone(),
+            vision_weights.clone(),
+            tokenizer.clone(),
+        );
+        let via_wrapper = model
+            .embed_image_metal(
+                &png,
+                "describe this image",
+                PoolingStrategy::MeanVisualTokens,
+            )
+            .expect("wrapper embed_image_metal succeeds");
+
+        let via_raw = embed_image_from_bytes_f16_metal(
+            &weights,
+            &cfg,
+            &vision_weights,
+            &tokenizer,
+            &png,
+            "describe this image",
+            PoolingStrategy::MeanVisualTokens,
+        )
+        .expect("raw metal primitive succeeds");
+
+        assert_eq!(
+            via_wrapper, via_raw,
+            "embed-crate Metal wrapper must return the identical vector to the raw primitive"
+        );
+    }
+
+    /// Off this cfg gate, the wrapper must surface the CPU/Metal
+    /// distinction the inference crate makes (`InferenceError::
+    /// UnsupportedModel`) as `EmbedError::InferenceFailed`, never silently
+    /// substituting `embed_image`'s CPU output.
+    #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
+    #[test]
+    fn embed_image_metal_fails_closed_without_metal_gpu() {
+        let (cfg, weights, vision_weights) = tiny_vlm_fixture();
+        let tokenizer = tiny_tokenizer();
+        let png = make_test_png(8, 8, 0);
+        let model = VisionEmbeddingModel::new(weights, cfg, vision_weights, tokenizer);
+
+        let err = model
+            .embed_image_metal(
+                &png,
+                "describe this image",
+                PoolingStrategy::MeanVisualTokens,
+            )
+            .expect_err("Metal wrapper must fail without the metal-gpu feature");
+        assert!(matches!(err, EmbedError::InferenceFailed(_)));
     }
 
     #[test]

--- a/crates/inference/src/forward/metal_gemm.rs
+++ b/crates/inference/src/forward/metal_gemm.rs
@@ -156,7 +156,6 @@ mod gpu {
     }
 
     /// Report whether Metal GPU is available and initialized.
-    #[allow(dead_code)] // public API for callers to probe Metal availability before dispatch
     pub fn is_available() -> bool {
         get_metal().is_some()
     }

--- a/crates/inference/src/vision/mod.rs
+++ b/crates/inference/src/vision/mod.rs
@@ -88,7 +88,7 @@ pub mod vit;
 
 pub use config::VisionConfig;
 pub use multimodal::MultimodalInput;
-pub use pooled_embed::embed_image_from_bytes_f16;
+pub use pooled_embed::{embed_image_from_bytes_f16, embed_image_from_bytes_f16_metal};
 
 use merger::{MlpMerger, MlpMergerWeights};
 use preprocess::PreprocessConfig;

--- a/crates/inference/src/vision/pooled_embed.rs
+++ b/crates/inference/src/vision/pooled_embed.rs
@@ -19,13 +19,15 @@
 //! unvalidated — see [`crate::forward::cpu_f16::PoolingStrategy`]'s doc
 //! comment.
 
+use super::VisionError;
 use super::checkpoint::Qwen35VisionWeights;
 use super::multimodal::Qwen35VisionRequest;
 use super::qwen35_merger::qwen35_merger_forward;
-use super::qwen35_vit::{preprocess_qwen35_image, qwen35_vit_forward};
+use super::qwen35_vit::{GridThw, preprocess_qwen35_image, qwen35_vit_forward};
+use super::qwen35_vit_metal::qwen35_vit_forward_metal;
 use crate::error::InferenceError;
 use crate::forward::cpu_f16::{PoolingStrategy, embed_image_f16};
-use crate::model::qwen35_config::Qwen35Config;
+use crate::model::qwen35_config::{Qwen35Config, VisionModelConfig};
 use crate::tokenizer::bpe::BpeTokenizer;
 use crate::tokenizer::common::Tokenizer;
 use crate::weights::f16_weights::F16ModelWeights;
@@ -52,6 +54,93 @@ pub fn embed_image_from_bytes_f16(
     prompt: &str,
     pooling: PoolingStrategy,
 ) -> Result<Vec<f32>, InferenceError> {
+    let (vision_cfg, image_token_id, vision_start, vision_end) = require_vision_ids(cfg)?;
+
+    let (pixel_values, grid) = preprocess_qwen35_image(image_bytes, vision_cfg)
+        .map_err(|e| InferenceError::InvalidInput(format!("image preprocessing failed: {e}")))?;
+    let pre_merger = qwen35_vit_forward(vision_weights, vision_cfg, &pixel_values, grid)
+        .map_err(|e| InferenceError::InvalidInput(format!("ViT forward failed: {e}")))?;
+
+    pool_from_pre_merger_hidden_states(
+        weights,
+        cfg,
+        vision_weights,
+        vision_cfg,
+        tokenizer,
+        grid,
+        pre_merger,
+        image_token_id,
+        vision_start,
+        vision_end,
+        prompt,
+        pooling,
+    )
+}
+
+/// Metal-dispatching sibling of [`embed_image_from_bytes_f16`]: runs the ViT
+/// forward pass on the Metal GPU ([`qwen35_vit_forward_metal`]) instead of
+/// the CPU, mirroring the serving path's CPU/Metal split
+/// (`crate::serve::metal_worker::build_vision_request` dispatches
+/// `qwen35_vit_forward_metal_with_cancel` then the CPU
+/// `qwen35_merger_forward`). The merger and the decoder-side pooling both
+/// stay CPU here too — only the ViT block loop moves to the GPU.
+///
+/// # Errors
+///
+/// Returns [`InferenceError::UnsupportedModel`] when Metal is unavailable
+/// (non-macOS build, or the crate's `metal-gpu` feature is off) — this entry
+/// never falls back to the CPU ViT forward silently; a caller that wants a
+/// fallback must catch this variant itself and call
+/// [`embed_image_from_bytes_f16`]. See [`embed_image_from_bytes_f16`]'s docs
+/// for the remaining error conditions (missing vision config, undecodable or
+/// misaligned image, invalid assembled request), which are identical here.
+pub fn embed_image_from_bytes_f16_metal(
+    weights: &F16ModelWeights,
+    cfg: &Qwen35Config,
+    vision_weights: &Qwen35VisionWeights,
+    tokenizer: &BpeTokenizer,
+    image_bytes: &[u8],
+    prompt: &str,
+    pooling: PoolingStrategy,
+) -> Result<Vec<f32>, InferenceError> {
+    let (vision_cfg, image_token_id, vision_start, vision_end) = require_vision_ids(cfg)?;
+
+    let (pixel_values, grid) = preprocess_qwen35_image(image_bytes, vision_cfg)
+        .map_err(|e| InferenceError::InvalidInput(format!("image preprocessing failed: {e}")))?;
+    let pre_merger = qwen35_vit_forward_metal(vision_weights, vision_cfg, &pixel_values, grid)
+        .map_err(|e| match e {
+            // `qwen35_vit_forward_metal` returns exactly this variant when
+            // Metal is unavailable at build time (see its non-`metal-gpu`
+            // stub) — map it to a distinct `InferenceError` so a caller can
+            // tell "no Metal on this build" apart from a bad request and
+            // choose to retry via `embed_image_from_bytes_f16` instead.
+            VisionError::InvalidConfig(msg) => {
+                InferenceError::UnsupportedModel(format!("Metal ViT forward unavailable: {msg}"))
+            }
+            other => InferenceError::InvalidInput(format!("Metal ViT forward failed: {other}")),
+        })?;
+
+    pool_from_pre_merger_hidden_states(
+        weights,
+        cfg,
+        vision_weights,
+        vision_cfg,
+        tokenizer,
+        grid,
+        pre_merger,
+        image_token_id,
+        vision_start,
+        vision_end,
+        prompt,
+        pooling,
+    )
+}
+
+/// Shared `cfg.vision_config`/token-id extraction for both
+/// [`embed_image_from_bytes_f16`] and [`embed_image_from_bytes_f16_metal`].
+fn require_vision_ids(
+    cfg: &Qwen35Config,
+) -> Result<(&VisionModelConfig, u32, u32, u32), InferenceError> {
     let vision_cfg = cfg.vision_config.as_ref().ok_or_else(|| {
         InferenceError::InvalidInput(
             "checkpoint has no vision_config; embed_image_from_bytes_f16 requires a \
@@ -68,11 +157,27 @@ pub fn embed_image_from_bytes_f16(
     let vision_end = cfg.vision_end_token_id.ok_or_else(|| {
         InferenceError::InvalidInput("checkpoint has no vision_end_token_id".into())
     })?;
+    Ok((vision_cfg, image_token_id, vision_start, vision_end))
+}
 
-    let (pixel_values, grid) = preprocess_qwen35_image(image_bytes, vision_cfg)
-        .map_err(|e| InferenceError::InvalidInput(format!("image preprocessing failed: {e}")))?;
-    let pre_merger = qwen35_vit_forward(vision_weights, vision_cfg, &pixel_values, grid)
-        .map_err(|e| InferenceError::InvalidInput(format!("ViT forward failed: {e}")))?;
+/// Shared merger + decoder-prompt-scaffold + pooled-decoder-prefill tail,
+/// common to the CPU and Metal ViT entry points above — the only thing that
+/// differs between them is which forward produced `pre_merger`.
+#[allow(clippy::too_many_arguments)]
+fn pool_from_pre_merger_hidden_states(
+    weights: &F16ModelWeights,
+    cfg: &Qwen35Config,
+    vision_weights: &Qwen35VisionWeights,
+    vision_cfg: &VisionModelConfig,
+    tokenizer: &BpeTokenizer,
+    grid: GridThw,
+    pre_merger: Vec<f32>,
+    image_token_id: u32,
+    vision_start: u32,
+    vision_end: u32,
+    prompt: &str,
+    pooling: PoolingStrategy,
+) -> Result<Vec<f32>, InferenceError> {
     let post_merger = qwen35_merger_forward(&vision_weights.merger, vision_cfg, &pre_merger)
         .map_err(|e| InferenceError::InvalidInput(format!("merger forward failed: {e}")))?;
 
@@ -425,5 +530,92 @@ mod tests {
         )
         .expect_err("a misaligned image must be rejected, not panic");
         assert!(matches!(err, InferenceError::InvalidInput(_)));
+    }
+
+    /// Metal/CPU pooled-output parity for the tiny synthetic fixture (same
+    /// weights, same image, same prompt scaffold). This checks the wiring
+    /// added in this change (merger + prompt-scaffold + decoder pooling
+    /// reused identically by both entry points) rather than ViT-level
+    /// numerics — the ViT forward itself is already gated at cosine > 0.999
+    /// against the CPU reference in
+    /// `qwen35_vit_metal.rs`'s own `metal_forward_matches_cpu_reference_small_shapes`
+    /// test, which uses this same tiny geometry and therefore also exercises
+    /// the CPU-fallback branch (shapes here are far below the Metal
+    /// dispatch threshold), so this asserts the same tight
+    /// `metal_forward_matches_cpu_reference_small_shapes`-style tolerance
+    /// (`< 1e-4` max-abs-diff) rather than the looser real-geometry cosine
+    /// gate.
+    ///
+    /// Mutation-sensitivity: swapping the `vision_start`/`vision_end`
+    /// arguments in `embed_image_from_bytes_f16_metal`'s call to
+    /// `pool_from_pre_merger_hidden_states` (this file) reorders the
+    /// assembled `input_ids` scaffold on the Metal path only, changing which
+    /// decoder positions get pooled — the CPU path's output would stay
+    /// fixed, so `max_abs_diff` would jump well past `1e-4` and this test
+    /// would fail.
+    #[cfg(all(target_os = "macos", feature = "metal-gpu"))]
+    #[test]
+    fn embed_image_from_bytes_metal_matches_cpu_reference() {
+        let (cfg, weights, vision_weights) = tiny_vlm_fixture();
+        let tokenizer = tiny_tokenizer();
+        let png = make_test_png(8, 8, 0);
+
+        let cpu = embed_image_from_bytes_f16(
+            &weights,
+            &cfg,
+            &vision_weights,
+            &tokenizer,
+            &png,
+            "describe this image",
+            PoolingStrategy::MeanVisualTokens,
+        )
+        .expect("cpu embed succeeds");
+        let metal = embed_image_from_bytes_f16_metal(
+            &weights,
+            &cfg,
+            &vision_weights,
+            &tokenizer,
+            &png,
+            "describe this image",
+            PoolingStrategy::MeanVisualTokens,
+        )
+        .expect("metal embed succeeds");
+
+        assert_eq!(cpu.len(), metal.len());
+        let max_abs_diff = cpu
+            .iter()
+            .zip(metal.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f32, f32::max);
+        assert!(
+            max_abs_diff < 1e-4,
+            "cpu vs metal pooled embedding diverged: max_abs_diff={max_abs_diff}"
+        );
+    }
+
+    /// Off this cfg gate (no macOS, or `metal-gpu` off), the Metal entry
+    /// must fail closed with a distinct error rather than silently running
+    /// the CPU ViT forward.
+    #[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
+    #[test]
+    fn embed_image_from_bytes_metal_fails_closed_without_metal_gpu() {
+        let (cfg, weights, vision_weights) = tiny_vlm_fixture();
+        let tokenizer = tiny_tokenizer();
+        let png = make_test_png(8, 8, 0);
+
+        let err = embed_image_from_bytes_f16_metal(
+            &weights,
+            &cfg,
+            &vision_weights,
+            &tokenizer,
+            &png,
+            "describe this image",
+            PoolingStrategy::MeanVisualTokens,
+        )
+        .expect_err("Metal entry must fail without the metal-gpu feature, not silently run CPU");
+        assert!(
+            matches!(err, InferenceError::UnsupportedModel(_)),
+            "expected a distinct UnsupportedModel error, got {err:?}"
+        );
     }
 }

--- a/crates/inference/src/vision/pooled_embed.rs
+++ b/crates/inference/src/vision/pooled_embed.rs
@@ -19,11 +19,13 @@
 //! unvalidated — see [`crate::forward::cpu_f16::PoolingStrategy`]'s doc
 //! comment.
 
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 use super::VisionError;
 use super::checkpoint::Qwen35VisionWeights;
 use super::multimodal::Qwen35VisionRequest;
 use super::qwen35_merger::qwen35_merger_forward;
 use super::qwen35_vit::{GridThw, preprocess_qwen35_image, qwen35_vit_forward};
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 use super::qwen35_vit_metal::qwen35_vit_forward_metal;
 use crate::error::InferenceError;
 use crate::forward::cpu_f16::{PoolingStrategy, embed_image_f16};
@@ -32,6 +34,9 @@ use crate::tokenizer::bpe::BpeTokenizer;
 use crate::tokenizer::common::Tokenizer;
 use crate::weights::f16_weights::F16ModelWeights;
 
+/// **Unstable**: the pooled-embedding prompt scaffold and pooling contract
+/// may evolve before 1.0.
+///
 /// Encode `image_bytes` through the real Qwen3.5-0.8B vision pipeline
 /// (preprocess -> ViT -> merger), assemble a minimal vision-prompt scaffold
 /// around `prompt`, run decoder prefill, and return a pooled, L2-normalized
@@ -77,6 +82,9 @@ pub fn embed_image_from_bytes_f16(
     )
 }
 
+/// **Unstable**: the Metal-dispatch surface (this cfg-split shape, and the
+/// runtime-probe fail-closed error) may evolve before 1.0.
+///
 /// Metal-dispatching sibling of [`embed_image_from_bytes_f16`]: runs the ViT
 /// forward pass on the Metal GPU ([`qwen35_vit_forward_metal`]) instead of
 /// the CPU, mirroring the serving path's CPU/Metal split
@@ -85,15 +93,45 @@ pub fn embed_image_from_bytes_f16(
 /// `qwen35_merger_forward`). The merger and the decoder-side pooling both
 /// stay CPU here too — only the ViT block loop moves to the GPU.
 ///
+/// Three distinct "no GPU" regimes exist, and this function's contract only
+/// covers the first two — the third is not a failure at all:
+///
+/// 1. **Build-level unavailable** (non-macOS, or this crate's `metal-gpu`
+///    feature is off): the sibling definition of this function below (same
+///    name, opposite `cfg` gate) fails closed with
+///    [`InferenceError::UnsupportedModel`] before any work — Metal code
+///    simply is not compiled into that build.
+/// 2. **Runtime device unavailable** (macOS + `metal-gpu` compiled in, but no
+///    Metal device could be initialized on this machine, e.g. no GPU or
+///    `MTLCreateSystemDefaultDevice` returned null): this function probes
+///    [`crate::forward::metal_gemm::is_available`] up front and fails closed
+///    with the same [`InferenceError::UnsupportedModel`] before touching the
+///    ViT weights or doing any preprocessing.
+/// 3. **Per-GEMM below `GPU_DISPATCH_THRESHOLD`** (an individual matrix in
+///    the ViT forward is too small to be worth a GPU launch): this is NOT an
+///    availability failure. `crate::forward::metal_gemm::metal_matmul`/
+///    `metal_matmul_bt` silently run the equivalent CPU dot product for that
+///    one GEMM call, by design (a dispatch-threshold optimization internal
+///    to the Metal path, not a fallback this function's caller can observe
+///    or needs to handle) — the ViT forward as a whole still ran via this
+///    Metal entry point, it just used CPU math for its smallest matrices.
+///
 /// # Errors
 ///
-/// Returns [`InferenceError::UnsupportedModel`] when Metal is unavailable
-/// (non-macOS build, or the crate's `metal-gpu` feature is off) — this entry
-/// never falls back to the CPU ViT forward silently; a caller that wants a
-/// fallback must catch this variant itself and call
-/// [`embed_image_from_bytes_f16`]. See [`embed_image_from_bytes_f16`]'s docs
-/// for the remaining error conditions (missing vision config, undecodable or
+/// Returns [`InferenceError::UnsupportedModel`] for either "no GPU" regime
+/// above — this entry never falls back to the CPU ViT forward silently; a
+/// caller that wants a fallback must catch this variant itself and call
+/// [`embed_image_from_bytes_f16`]. Also maps a
+/// [`VisionError::InvalidConfig`] surfaced from the underlying
+/// [`qwen35_vit_forward_metal`] call to the same
+/// [`InferenceError::UnsupportedModel`], as defense in depth — this should
+/// not be reachable once the `is_available` probe above has already passed,
+/// but is kept in case a future change to `qwen35_vit_forward_metal`
+/// reintroduces an availability-shaped failure inside it; it is not itself
+/// the availability guard. See [`embed_image_from_bytes_f16`]'s docs for the
+/// remaining error conditions (missing vision config, undecodable or
 /// misaligned image, invalid assembled request), which are identical here.
+#[cfg(all(target_os = "macos", feature = "metal-gpu"))]
 pub fn embed_image_from_bytes_f16_metal(
     weights: &F16ModelWeights,
     cfg: &Qwen35Config,
@@ -103,17 +141,22 @@ pub fn embed_image_from_bytes_f16_metal(
     prompt: &str,
     pooling: PoolingStrategy,
 ) -> Result<Vec<f32>, InferenceError> {
+    if !crate::forward::metal_gemm::is_available() {
+        return Err(InferenceError::UnsupportedModel(
+            "embed_image_from_bytes_f16_metal: this build supports metal-gpu, but no Metal \
+             device could be initialized on this machine"
+                .into(),
+        ));
+    }
+
     let (vision_cfg, image_token_id, vision_start, vision_end) = require_vision_ids(cfg)?;
 
     let (pixel_values, grid) = preprocess_qwen35_image(image_bytes, vision_cfg)
         .map_err(|e| InferenceError::InvalidInput(format!("image preprocessing failed: {e}")))?;
     let pre_merger = qwen35_vit_forward_metal(vision_weights, vision_cfg, &pixel_values, grid)
         .map_err(|e| match e {
-            // `qwen35_vit_forward_metal` returns exactly this variant when
-            // Metal is unavailable at build time (see its non-`metal-gpu`
-            // stub) — map it to a distinct `InferenceError` so a caller can
-            // tell "no Metal on this build" apart from a bad request and
-            // choose to retry via `embed_image_from_bytes_f16` instead.
+            // Defense in depth, not the availability guard (see doc comment
+            // above) -- the `is_available` probe already ran before this call.
             VisionError::InvalidConfig(msg) => {
                 InferenceError::UnsupportedModel(format!("Metal ViT forward unavailable: {msg}"))
             }
@@ -134,6 +177,25 @@ pub fn embed_image_from_bytes_f16_metal(
         prompt,
         pooling,
     )
+}
+
+/// Build-level-unavailable sibling of the `metal-gpu` macOS definition above
+/// (see its doc comment for the full three-regime contract): this crate was
+/// built without Metal support at all (non-macOS, or the `metal-gpu` feature
+/// is off), so this fails closed immediately, before touching any argument.
+#[cfg(not(all(target_os = "macos", feature = "metal-gpu")))]
+pub fn embed_image_from_bytes_f16_metal(
+    _weights: &F16ModelWeights,
+    _cfg: &Qwen35Config,
+    _vision_weights: &Qwen35VisionWeights,
+    _tokenizer: &BpeTokenizer,
+    _image_bytes: &[u8],
+    _prompt: &str,
+    _pooling: PoolingStrategy,
+) -> Result<Vec<f32>, InferenceError> {
+    Err(InferenceError::UnsupportedModel(
+        "embed_image_from_bytes_f16_metal requires the metal-gpu feature on macOS".into(),
+    ))
 }
 
 /// Shared `cfg.vision_config`/token-id extraction for both
@@ -536,15 +598,21 @@ mod tests {
     /// weights, same image, same prompt scaffold). This checks the wiring
     /// added in this change (merger + prompt-scaffold + decoder pooling
     /// reused identically by both entry points) rather than ViT-level
-    /// numerics — the ViT forward itself is already gated at cosine > 0.999
-    /// against the CPU reference in
-    /// `qwen35_vit_metal.rs`'s own `metal_forward_matches_cpu_reference_small_shapes`
-    /// test, which uses this same tiny geometry and therefore also exercises
-    /// the CPU-fallback branch (shapes here are far below the Metal
-    /// dispatch threshold), so this asserts the same tight
-    /// `metal_forward_matches_cpu_reference_small_shapes`-style tolerance
-    /// (`< 1e-4` max-abs-diff) rather than the looser real-geometry cosine
-    /// gate.
+    /// numerics. Two separate, differently-scoped artifacts already cover the
+    /// ViT forward itself, and neither is this test:
+    /// - `qwen35_vit_metal.rs`'s own `metal_forward_matches_cpu_reference_small_shapes`
+    ///   test uses this *same* tiny geometry (and therefore also exercises the
+    ///   CPU-fallback branch, since these shapes sit far below the Metal
+    ///   dispatch threshold) at a tight `< 1e-4` max-abs-diff tolerance — this
+    ///   test reuses that same tolerance for the same reason (tiny geometry,
+    ///   deterministic fixture, no GPU-rounding slack to budget for).
+    /// - `tests/vision_s3b_vit_metal_gate_test.rs` is the one gated at
+    ///   cosine > 0.999, on the *real* checkpoint geometry (depth 2,
+    ///   hidden 768, 12 heads) against the committed real-image golden
+    ///   fixture, where every GEMM clears the dispatch threshold and
+    ///   genuinely runs on the GPU — that test, not this one and not
+    ///   `metal_forward_matches_cpu_reference_small_shapes`, is what
+    ///   validates real Metal dispatch.
     ///
     /// Mutation-sensitivity: swapping the `vision_start`/`vision_end`
     /// arguments in `embed_image_from_bytes_f16_metal`'s call to


### PR DESCRIPTION
Adds a Metal-dispatching sibling of the pooled image-embedding entry point.

`embed_image_from_bytes_f16_metal` runs the ViT forward on the Metal GPU
(`qwen35_vit_forward_metal`) and keeps the merger and decoder-side pooling on
CPU, mirroring the split the serving path already uses. The existing CPU entry
point is unchanged in behavior and signature; shared config/token-id extraction
and the post-ViT pooling tail are factored into private helpers used by both.

When Metal is unavailable (non-macOS build or the `metal-gpu` feature is off)
the new entry fails closed with `InferenceError::UnsupportedModel` rather than
silently falling back to the CPU ViT — callers that want a fallback catch that
variant and call the CPU entry explicitly. `lattice-embed` gains a matching
`VisionEmbeddingModel::embed_image_metal` wrapper.

Tests: a Metal-vs-CPU pooled-output parity test on the module's existing
synthetic-weight fixtures (max-abs-diff < 1e-4), plus fail-closed tests for
builds without `metal-gpu`, in both crates.


## bench-compare disposition

A/B on an Apple Silicon test machine at this head, release build with `metal-gpu`, real
Qwen3.5-0.8B vision checkpoint, the committed `tests/fixtures/vision/golden_image.png`,
`MeanVisualTokens` pooling, 9 interleaved rounds (cpu / metal / cpu per round, so the
two CPU arms double as an in-run A/A control on byte-identical code):

| arm | median end-to-end |
|---|---|
| `embed_image` (CPU ViT) | 41418.7 ms / 41324.8 ms (two interleaved arms) |
| `embed_image_metal` (Metal ViT) | 31943.5 ms (**-22.8%** vs mean CPU) |

A/A drift between the two CPU arms: 0.2%. Output parity at real geometry: cosine
1.000000000, max abs diff 4.34e-7 (dim 1024). End-to-end time includes the unchanged
CPU decoder prefill common to both arms, so the ViT-only speedup is larger than the
end-to-end figure; the number above is the caller-visible one. Single image/prompt —
the ratio varies with image grid size. The pre-existing CPU entry point is
call-graph-identical after the refactor (verified against the pre-change source) and
its two arms' 0.2% A/A bounds any regression there.
