### PR TITLE
chore(deny): acknowledge RUSTSEC-2024-0436 (paste, unmaintained) with rationale

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -59,3 +59,11 @@ version = 2
 # runs continue-on-error (informational), so a fresh upstream disclosure cannot
 # wedge merges while still showing up in the log.
 yanked = "deny"
+ignore = [
+    # RUSTSEC-2024-0436 (paste 1.0.15): unmaintained-only advisory, no
+    # vulnerability. paste is a compile-time proc-macro that ships no runtime
+    # code. Every dependency path is transitive via metal / wgpu-hal /
+    # tokenizers, and no patched upgrade is available. Remove this entry once
+    # those upstreams drop paste.
+    { id = "RUSTSEC-2024-0436", reason = "unmaintained-only advisory (no vulnerability); paste is a compile-time proc-macro that ships no runtime code; all dependency paths are transitive via metal / wgpu-hal / tokenizers with no patched upgrade available; remove this entry when those upstreams drop paste" },
+]


### PR DESCRIPTION
Adds a v2 `[advisories].ignore` entry for RUSTSEC-2024-0436 to deny.toml.

`paste` v1.0.15 is flagged unmaintained (no vulnerability). It is a compile-time proc-macro that ships no runtime code, and every dependency path is transitive via `metal` (0.29/0.31/0.33), `wgpu-hal` (23/24), and `tokenizers` 0.22.2 — none of which currently offer a paste-free upgrade. The ignore entry carries this rationale inline and states the removal condition (drop it when those upstreams drop paste).

Verified locally: `cargo deny check advisories` rc=0 (warning cleared), `cargo deny check licenses bans sources` rc=0 (unchanged). Config-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)