### PR TITLE
docs: add M-RoPE video-axis fix to v0.9.0 release notes

### DIFF
--- a/docs/releases/v0.9.0.md
+++ b/docs/releases/v0.9.0.md
@@ -83,6 +83,10 @@ at all.
 - **Serving**: three vision error-taxonomy distinctions that had collapsed together are
   restored, and a vision-weight load failure is now retryable instead of wedging the model
   in a failed state.
+- **Vision (M-RoPE)**: video temporal/spatial position-lane assignment in Qwen3.5's M-RoPE
+  now matches the reference implementation's lane computation instead of only accepting a
+  narrower cyclic split; the image position path is unchanged. Covered by the vision and
+  mrope unit-test suites; no benchmark group exercises this path.
 - **Checkpoint loading**: all checkpoint mmap sites now route through the trust boundary
   consistently.
 - **Quantization**: `quantize_quarot` now records whether its PPL-gate promotion actually ran,


### PR DESCRIPTION
The v0.9.0 release notes were written before the M-RoPE video-axis fix merged; the release range now includes it. Adds one bullet to the Fixes section describing the video position-indexing alignment with the reference implementation, with a note that the change is covered by the vision/mrope unit-test suites and no benchmark group exercises this path.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)