### PR TITLE
fix(npm): keep downloaded platform prebuilds intact through the publish preflight

### DIFF
--- a/npm/lattice-embed-native/__test__/guard-artifacts.spec.mjs
+++ b/npm/lattice-embed-native/__test__/guard-artifacts.spec.mjs
@@ -1,0 +1,108 @@
+// Node test-runner suite for scripts/guard-artifacts.mjs's two exported
+// helpers: platformBinariesPresent (does every platform in
+// optionalDependencies already carry a trustworthy, present .node binary)
+// and npmCommandFor (which npm executable name to spawn on the current
+// platform). Fixtures build a scratch native-package tree under a temp
+// dir; nothing here touches the real npm/ layout or spawns a real build.
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { platformBinariesPresent, npmCommandFor } from '../scripts/guard-artifacts.mjs'
+
+const NAME_PREFIX = '@khive-ai/lattice-embed-'
+
+function makeFixture(files) {
+  const dir = mkdtempSync(join(tmpdir(), 'guard-artifacts-fixture-'))
+  for (const [path, content] of Object.entries(files)) {
+    mkdirSync(dirname(join(dir, path)), { recursive: true })
+    writeFileSync(join(dir, path), content)
+  }
+  return dir
+}
+
+function nativePackageJson(platforms) {
+  const optionalDependencies = {}
+  for (const platform of platforms) optionalDependencies[`${NAME_PREFIX}${platform}`] = '1.0.0'
+  return JSON.stringify({ name: 'test-native-pkg', version: '1.0.0', optionalDependencies }, null, 2)
+}
+
+function platformPackageJson(platform, main) {
+  return JSON.stringify({ name: `${NAME_PREFIX}${platform}`, version: '1.0.0', main }, null, 2)
+}
+
+test('all platforms populated with a valid .node main returns true', () => {
+  const dir = makeFixture({
+    'package.json': nativePackageJson(['darwin-arm64', 'linux-x64-gnu']),
+    'npm/darwin-arm64/package.json': platformPackageJson('darwin-arm64', 'lattice-embed-native.darwin-arm64.node'),
+    'npm/darwin-arm64/lattice-embed-native.darwin-arm64.node': 'fake-binary',
+    'npm/linux-x64-gnu/package.json': platformPackageJson('linux-x64-gnu', 'lattice-embed-native.linux-x64-gnu.node'),
+    'npm/linux-x64-gnu/lattice-embed-native.linux-x64-gnu.node': 'fake-binary',
+  })
+  try {
+    assert.equal(platformBinariesPresent(dir), true)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a platform whose main is missing returns false', () => {
+  const dir = makeFixture({
+    'package.json': nativePackageJson(['darwin-arm64']),
+    // "main" omitted entirely.
+    'npm/darwin-arm64/package.json': JSON.stringify({ name: `${NAME_PREFIX}darwin-arm64`, version: '1.0.0' }),
+  })
+  try {
+    assert.equal(platformBinariesPresent(dir), false)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a platform whose main is empty returns false', () => {
+  const dir = makeFixture({
+    'package.json': nativePackageJson(['darwin-arm64']),
+    'npm/darwin-arm64/package.json': platformPackageJson('darwin-arm64', ''),
+  })
+  try {
+    assert.equal(platformBinariesPresent(dir), false)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a platform whose main is ../evil.js returns false', () => {
+  // The escaped file is created and DOES exist on disk, so a false "true"
+  // here would prove the rejection is a missing-file coincidence rather
+  // than the main-format validation this test targets.
+  const dir = makeFixture({
+    'package.json': nativePackageJson(['darwin-arm64']),
+    'npm/darwin-arm64/package.json': platformPackageJson('darwin-arm64', '../evil.js'),
+    'npm/evil.js': 'arbitrary file escaping the platform directory\n',
+  })
+  try {
+    assert.equal(platformBinariesPresent(dir), false)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('a platform whose main is README.md returns false', () => {
+  const dir = makeFixture({
+    'package.json': nativePackageJson(['darwin-arm64']),
+    'npm/darwin-arm64/package.json': platformPackageJson('darwin-arm64', 'README.md'),
+    'npm/darwin-arm64/README.md': '# not a binary\n',
+  })
+  try {
+    assert.equal(platformBinariesPresent(dir), false)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('npm command resolves to npm.cmd on win32 and npm elsewhere', () => {
+  assert.equal(npmCommandFor('win32'), 'npm.cmd')
+  assert.equal(npmCommandFor('darwin'), 'npm')
+  assert.equal(npmCommandFor('linux'), 'npm')
+})

--- a/npm/lattice-embed-native/package.json
+++ b/npm/lattice-embed-native/package.json
@@ -36,7 +36,7 @@
     "packlist": "npm pack --dry-run --json | node scripts/assert-packlist.mjs",
     "packlist:darwin-arm64": "cd npm/darwin-arm64 && npm pack --dry-run --json | node ../../scripts/assert-platform-packlist.mjs",
     "test:prebuild": "node scripts/assert-prebuild-matrix.mjs",
-    "prepublishOnly": "npm run artifacts && npm test"
+    "prepublishOnly": "node scripts/guard-artifacts.mjs && npm test"
   },
   "napi": {
     "binaryName": "lattice-embed-native",

--- a/npm/lattice-embed-native/scripts/guard-artifacts.mjs
+++ b/npm/lattice-embed-native/scripts/guard-artifacts.mjs
@@ -1,0 +1,44 @@
+// `napi artifacts --output-dir . --npm-dir npm` (the package.json "artifacts"
+// script) reconciles --npm-dir against --output-dir: for every configured
+// target it looks for a freshly built binary under --output-dir, and when
+// one platform's --output-dir binary is absent it deletes that platform's
+// existing --npm-dir binary rather than leaving it alone, then exits nonzero
+// once nothing is left to place. That is correct when npm/<platform>/ is
+// still empty and this step's job is to collect a fresh local build into it,
+// and destructive when every platform binary has already been placed there
+// by another means (e.g. downloaded prebuilt binaries) with no matching
+// fresh build sitting in --output-dir to reconcile against. This guard runs
+// before prepublishOnly's `napi artifacts` invocation and skips it entirely
+// when every platform in optionalDependencies already resolves its exact
+// `main`-named .node file, so a release whose platform packages are already
+// fully populated is not silently emptied out during `npm publish`.
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const nativeDir = dirname(dirname(fileURLToPath(import.meta.url)))
+const pkg = JSON.parse(readFileSync(join(nativeDir, 'package.json'), 'utf8'))
+const platforms = Object.keys(pkg.optionalDependencies || {}).map(name =>
+  name.replace('@khive-ai/lattice-embed-', '')
+)
+
+function platformBinariesPresent() {
+  if (platforms.length === 0) return false
+  for (const platform of platforms) {
+    const platformPkgPath = join(nativeDir, 'npm', platform, 'package.json')
+    if (!existsSync(platformPkgPath)) return false
+    const platformPkg = JSON.parse(readFileSync(platformPkgPath, 'utf8'))
+    const main = platformPkg.main || ''
+    if (!main || !existsSync(join(nativeDir, 'npm', platform, main))) return false
+  }
+  return true
+}
+
+if (platformBinariesPresent()) {
+  console.log(
+    'Platform prebuilds already present for every configured target; skipping `napi artifacts`.'
+  )
+} else {
+  execFileSync('npm', ['run', 'artifacts'], { cwd: nativeDir, stdio: 'inherit' })
+}

--- a/npm/lattice-embed-native/scripts/guard-artifacts.mjs
+++ b/npm/lattice-embed-native/scripts/guard-artifacts.mjs
@@ -15,30 +15,48 @@
 import { execFileSync } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const nativeDir = dirname(dirname(fileURLToPath(import.meta.url)))
-const pkg = JSON.parse(readFileSync(join(nativeDir, 'package.json'), 'utf8'))
-const platforms = Object.keys(pkg.optionalDependencies || {}).map(name =>
-  name.replace('@khive-ai/lattice-embed-', '')
-)
 
-function platformBinariesPresent() {
+// A platform package's "main" is trusted only when it resolves to exactly
+// the .node file the platform directory ships -- not any existing path the
+// field happens to name. Rejects an absent/empty value, a path separator
+// (forward or back), a ".." segment, and any extension other than ".node".
+export function isValidPlatformMain(main) {
+  return Boolean(main) && !main.includes('/') && !main.includes('\\') && !main.includes('..') && main.endsWith('.node')
+}
+
+// npm's own executable is `npm.cmd` on Windows; spawning the bare `npm`
+// name via execFileSync (no shell) throws ENOENT there instead of running
+// the artifacts step.
+export function npmCommandFor(platform) {
+  return platform === 'win32' ? 'npm.cmd' : 'npm'
+}
+
+export function platformBinariesPresent(dir) {
+  const pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'))
+  const platforms = Object.keys(pkg.optionalDependencies || {}).map(name =>
+    name.replace('@khive-ai/lattice-embed-', '')
+  )
   if (platforms.length === 0) return false
   for (const platform of platforms) {
-    const platformPkgPath = join(nativeDir, 'npm', platform, 'package.json')
+    const platformPkgPath = join(dir, 'npm', platform, 'package.json')
     if (!existsSync(platformPkgPath)) return false
     const platformPkg = JSON.parse(readFileSync(platformPkgPath, 'utf8'))
     const main = platformPkg.main || ''
-    if (!main || !existsSync(join(nativeDir, 'npm', platform, main))) return false
+    if (!isValidPlatformMain(main) || !existsSync(join(dir, 'npm', platform, main))) return false
   }
   return true
 }
 
-if (platformBinariesPresent()) {
-  console.log(
-    'Platform prebuilds already present for every configured target; skipping `napi artifacts`.'
-  )
-} else {
-  execFileSync('npm', ['run', 'artifacts'], { cwd: nativeDir, stdio: 'inherit' })
+const isMainModule = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+if (isMainModule) {
+  if (platformBinariesPresent(nativeDir)) {
+    console.log(
+      'Platform prebuilds already present for every configured target; skipping `napi artifacts`.'
+    )
+  } else {
+    execFileSync(npmCommandFor(process.platform), ['run', 'artifacts'], { cwd: nativeDir, stdio: 'inherit' })
+  }
 }

--- a/scripts/publish-npm-preflight-selftest.sh
+++ b/scripts/publish-npm-preflight-selftest.sh
@@ -546,6 +546,73 @@ else
 fi
 
 echo
+echo "=== publish-npm.sh platform_binaries_present main-field validation self-test ==="
+# platform_binaries_present funnels its per-platform .node resolution
+# through platform_node_rel -- the same function platform_matrix_guard's
+# exact-path guard uses -- so hardening that one function against an
+# absent/empty "main", a path-separator or ".." value, or a non-".node"
+# extension protects both callers. These arms exercise
+# platform_binaries_present directly, mirroring the JS-side
+# platformBinariesPresent coverage in
+# npm/lattice-embed-native/__test__/guard-artifacts.spec.mjs.
+run_binaries_present_case() {  # $1=NATIVE_DIR
+  RUNNER="$MSB/binpresent-runner.sh"
+  {
+    echo 'PUBLISH_NPM_SH_LIB_ONLY=1'
+    printf '. %q\n' "$SRC"
+    printf 'NATIVE_DIR=%q\n' "$1"
+    printf 'platform_binaries_present\n'
+    printf 'echo BINARIES_PRESENT_TRUE\n'
+  } > "$RUNNER"
+  OUT="$(/bin/sh -c "set -e; . '$RUNNER'" 2>&1)"
+  return $?
+}
+
+# (bp1) must-PASS control: a fully valid single-platform matrix returns true.
+NATIVE="$MSB/bp1-binpresent-valid"; build_native_fixture "$NATIVE" "darwin-arm64:1.2.3"
+add_valid_platform "$NATIVE" "darwin-arm64" "1.2.3"
+run_binaries_present_case "$NATIVE"; rc=$?
+check "(bp1) platform_binaries_present valid matrix returns true" 0 $rc
+if printf '%s' "$OUT" | grep -qF "BINARIES_PRESENT_TRUE"; then
+  echo "  PASS:   -> function returned success"; pass=$((pass+1))
+else
+  echo "  FAIL:   -> did not reach success marker (got: $(printf '%s' "$OUT" | tr '\n' '|'))"; fail=$((fail+1))
+fi
+
+# (bp2) empty "main" returns false.
+NATIVE="$MSB/bp2-binpresent-emptymain"; build_native_fixture "$NATIVE" "darwin-arm64:1.2.3"
+d="$NATIVE/npm/darwin-arm64"; mkdir -p "$d"
+cat > "$d/package.json" <<'EOF'
+{"name": "@khive-ai/lattice-embed-darwin-arm64", "version": "1.2.3", "main": ""}
+EOF
+run_binaries_present_case "$NATIVE"; rc=$?
+check "(bp2) platform_binaries_present empty main returns false" 1 $rc
+
+# (bp3) a "main" that escapes the platform directory via "..". The escaped
+# file is created and DOES exist on disk, so a defeated validation rule
+# would make this arm go green for the wrong reason (a missing-file
+# coincidence) instead of holding rc 1 from the rejected-format check.
+NATIVE="$MSB/bp3-binpresent-evil"; build_native_fixture "$NATIVE" "darwin-arm64:1.2.3"
+d="$NATIVE/npm/darwin-arm64"; mkdir -p "$d"
+cat > "$d/package.json" <<'EOF'
+{"name": "@khive-ai/lattice-embed-darwin-arm64", "version": "1.2.3", "main": "../evil.js"}
+EOF
+printf 'arbitrary file escaping the platform directory\n' > "$NATIVE/npm/evil.js"
+run_binaries_present_case "$NATIVE"; rc=$?
+check "(bp3) platform_binaries_present path-traversal main returns false" 1 $rc
+
+# (bp4) a "main" with no separator and no ".." but the wrong extension --
+# also present on disk, isolating the extension check from the two above.
+NATIVE="$MSB/bp4-binpresent-wrongext"; build_native_fixture "$NATIVE" "darwin-arm64:1.2.3"
+d="$NATIVE/npm/darwin-arm64"; mkdir -p "$d"
+cat > "$d/package.json" <<'EOF'
+{"name": "@khive-ai/lattice-embed-darwin-arm64", "version": "1.2.3", "main": "README.md"}
+EOF
+printf '# not a binary\n' > "$d/README.md"
+run_binaries_present_case "$NATIVE"; rc=$?
+check "(bp4) platform_binaries_present non-.node main returns false" 1 $rc
+
+echo
 echo "=== publish-npm.sh npm-pack-command-failure guard self-test ==="
 # publish-npm.sh's platform_matrix_guard fails closed when `npm pack
 # --dry-run --json` itself returns nonzero -- distinct from the packlist

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -71,6 +71,49 @@ check_platform_pkgjson() {  # $1=platform $2=pkgdir $3=pkgjson
     fi
 }
 
+# Guard: print the exact .node filename platform pkgjson's "main" field
+# names, or nothing if it names none. Shared by platform_matrix_guard's
+# fail-closed check below and platform_binaries_present's yes/no probe, so
+# the "exact filename from main, not a *.node glob" resolution rule lives in
+# exactly one place.
+platform_node_rel() {  # $1=pkgjson
+    node -p "require('$1').main || ''"
+}
+
+# Probe: report via exit status alone (never a hard error) whether every
+# platform in $NATIVE_DIR/package.json optionalDependencies already has the
+# exact .node file its own npm/<platform>/package.json "main" field names --
+# the same per-platform resolution platform_matrix_guard enforces below, run
+# here as a plain yes/no check instead of a fail-closed exit.
+#
+# This exists because "napi artifacts --output-dir . --npm-dir npm"
+# reconciles --npm-dir against --output-dir: when CI has already downloaded
+# every platform's binary straight into npm/<platform>/ (the publish job's
+# "Download validated platform packages" step) and --output-dir holds no
+# freshly built .node files, the reconciliation deletes the binaries already
+# in place and then exits nonzero with "Missing artifacts for configured
+# targets" -- there is nothing for it to place. Only when a platform's
+# binary is genuinely absent (the local-build fill-in path this step exists
+# for) does running it do anything useful.
+platform_binaries_present() {
+    expected=$(node -p "Object.keys(require('$NATIVE_DIR/package.json').optionalDependencies || {}).map(n => n.replace('@khive-ai/lattice-embed-', '')).join(' ')" 2>/dev/null) || return 1
+    if [ -z "$expected" ]; then
+        return 1
+    fi
+    for platform in $expected; do
+        pkgdir="$NATIVE_DIR/npm/$platform/"
+        pkgjson="${pkgdir}package.json"
+        if [ ! -f "$pkgjson" ]; then
+            return 1
+        fi
+        node_rel=$(platform_node_rel "$pkgjson") || return 1
+        if [ -z "$node_rel" ] || [ ! -f "${pkgdir}${node_rel}" ]; then
+            return 1
+        fi
+    done
+    return 0
+}
+
 # Guard: require every platform advertised in the main package's
 # optionalDependencies to carry its native binary -- not any nonempty subset,
 # and not a zero-length set either (an empty optionalDependencies object is
@@ -126,7 +169,7 @@ platform_matrix_guard() {
         pkgjson="${pkgdir}package.json"
         check_platform_pkgjson "$platform" "$pkgdir" "$pkgjson"
 
-        node_rel=$(node -p "require('$pkgjson').main || ''")
+        node_rel=$(platform_node_rel "$pkgjson")
         node_path="${pkgdir}${node_rel}"
         if [ -z "$node_rel" ] || [ ! -f "$node_path" ]; then
             echo "ERROR: missing native binary for platform '$platform': expected $node_path" >&2
@@ -273,8 +316,8 @@ run_version_checks() {
 
 # Guard: dry-run the ENTIRE release before any real publish. This packs wasm
 # (prepack rebuild), every present platform subpackage, and the native main
-# package (its prepublishOnly runs `napi artifacts && npm test`). Any
-# failure here aborts before a single package is published.
+# package (its prepublishOnly runs the artifacts guard script, then `npm
+# test`). Any failure here aborts before a single package is published.
 #
 # No explicit `exit N` here -- this relies entirely on the script's own
 # top-level `set -e` to abort on the first nonzero `npm publish --dry-run`.
@@ -349,9 +392,17 @@ main() {
     # subpackages have their binary. Cross-platform binaries come from the napi
     # build matrix in CI (npm-prebuild.yml's `publish` job downloads the
     # collector-validated `npm-native-prebuilds` artifact before this script
-    # runs), so this is a no-op in that path and only fills in the current
-    # platform for a local run.
-    ( cd "$NATIVE_DIR" && npm run artifacts >/dev/null 2>&1 || true )
+    # runs), so when every platform is already populated this step has
+    # nothing to do -- and running it anyway would delete those downloaded
+    # binaries instead of leaving them alone (see platform_binaries_present
+    # above). Skip it in that case; otherwise run it unsuppressed so a real
+    # failure aborts here instead of surfacing later as a misleadingly
+    # generic "missing binaries" report from platform_matrix_guard.
+    if platform_binaries_present; then
+        echo "Platform prebuilds already present for every configured target; skipping 'npm run artifacts'."
+    else
+        ( cd "$NATIVE_DIR" && npm run artifacts )
+    fi
 
     platform_matrix_guard
 

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -72,12 +72,23 @@ check_platform_pkgjson() {  # $1=platform $2=pkgdir $3=pkgjson
 }
 
 # Guard: print the exact .node filename platform pkgjson's "main" field
-# names, or nothing if it names none. Shared by platform_matrix_guard's
-# fail-closed check below and platform_binaries_present's yes/no probe, so
-# the "exact filename from main, not a *.node glob" resolution rule lives in
-# exactly one place.
+# names, or nothing if it names none OR the value is not trustworthy as a
+# bare filename within the platform directory. Shared by
+# platform_matrix_guard's fail-closed check below and
+# platform_binaries_present's yes/no probe, so both the "exact filename from
+# main, not a *.node glob" resolution rule AND this validation rule live in
+# exactly one place: a present-but-untrusted "main" (a path separator, a
+# ".." segment, or a non-".node" extension) must resolve the same as an
+# absent one, since every caller already treats an empty result as
+# fail-closed via its own `[ -z "$node_rel" ]` check.
 platform_node_rel() {  # $1=pkgjson
-    node -p "require('$1').main || ''"
+    node -e '
+        const fs = require("fs")
+        const pkg = JSON.parse(fs.readFileSync(process.argv[1], "utf8"))
+        const main = pkg.main || ""
+        const valid = main && !main.includes("/") && !main.includes("\\") && !main.includes("..") && main.endsWith(".node")
+        process.stdout.write(valid ? main : "")
+    ' "$1"
 }
 
 # Probe: report via exit status alone (never a hard error) whether every


### PR DESCRIPTION
## Summary

`scripts/publish-npm.sh` ran `( cd "$NATIVE_DIR" && npm run artifacts >/dev/null 2>&1 || true )` unconditionally, with output suppressed and the exit code swallowed. `npm run artifacts` invokes `napi artifacts --output-dir . --npm-dir npm` (`@napi-rs/cli`), which reconciles `--npm-dir` against `--output-dir`: any platform `.node` binary already present under `npm/<platform>/` with no matching fresh build under `--output-dir` gets **deleted**, and the command then exits non-zero once nothing is left to place. Once CI's publish job has already downloaded every platform's binary straight into `npm/<platform>/` (nothing fresh sits in `--output-dir` at that point), this step silently deleted all of them and failed — the failure was hidden by the redirect + `|| true`, so `platform_matrix_guard` reported the binaries missing further down the script instead of surfacing the real cause where it happened. This is exactly how the v0.9.0 npm publish attempt failed after all platform builds and the packaging job had already succeeded.

## Fix

- `scripts/publish-npm.sh`: added `platform_binaries_present()`, a yes/no probe that checks whether every platform in `optionalDependencies` already has the exact `.node` file its own `npm/<platform>/package.json` `"main"` field names (same per-platform resolution `platform_matrix_guard` already enforces, factored into a shared `platform_node_rel()` helper so the exact-filename rule lives in one place). `main()` now skips `npm run artifacts` entirely when every platform is already populated, and otherwise runs it unsuppressed with no `|| true`, so a real failure aborts loudly at the point of failure instead of surfacing later as a misleading "missing binaries" report.
- Sibling invocation path, same defect class: `npm/lattice-embed-native/package.json`'s `prepublishOnly` ran `"npm run artifacts && npm test"` unconditionally, so a real `npm publish` of the native package would re-trigger the same destructive reconciliation *after* the preflight above had already passed. Added `npm/lattice-embed-native/scripts/guard-artifacts.mjs`, which applies the equivalent populated-check in JS before the artifacts step; `prepublishOnly` now reads `"node scripts/guard-artifacts.mjs && npm test"`.
- Checked for a third invocation path: `.github/workflows/npm-prebuild.yml`'s `package` job also runs `npm run artifacts`, but at that point in the workflow `--output-dir` genuinely holds freshly downloaded build outputs and `--npm-dir` holds nothing yet (created empty by `npm run create-npm-dirs`), so that invocation is the legitimate "collect a fresh build into place" use the step exists for — left unchanged. Grepped the repo for every `npm run artifacts` / `napi artifacts` occurrence; these three are the only executable call sites, the rest are comments/error strings referencing them.
- `@napi-rs/cli` version and the workflow YAML are unchanged — the fix is entirely in the script layer.

## Verification

Full transcript of commands and outputs is in the branch history of this change (each claim in the working notes names its producing command). Summary:

- Reproduced the original defect in a scratch copy outside the repo (dummy `.node` files per platform, real `@napi-rs/cli` installed via `npm install --ignore-scripts`): the unfixed unconditional-swallowed form deleted all 7 dummy binaries (`7` → `0` files) with a silently-swallowed exit `0`.
- Fixed script, all platforms populated: `npm run artifacts` skipped, all 7 dummy files survive byte-identical (`diff -rq` + per-file `cmp`).
- Fixed script, one platform missing: reaches `npm run artifacts` unsuppressed, napi's own `Internal Error: Missing artifacts for configured targets: ...` is visible verbatim, script exits `1`.
- Mutation check: reverting to the unconditional swallowed form reproduces the deletion; restoring the fix, the files survive again.
- Guard script (`prepublishOnly` sibling): `npm pack --dry-run` does not trigger `prepublishOnly` (only `npm publish` does), so the guard script was driven directly per the verification plan's fallback clause. All-populated → skip, byte-identical survival. One missing → reaches `npm run artifacts` unsuppressed, napi's error visible, process exits `1`. Reverting to the old unconditional `prepublishOnly` form reproduces deletion even when fully populated, confirming the sibling needed its own guard.
- `sh -n scripts/publish-npm.sh` → syntax OK. `node --check npm/lattice-embed-native/scripts/guard-artifacts.mjs` → syntax OK. `shellcheck -s sh scripts/publish-npm.sh` → no findings.

## Bench-compare disposition

No `crates/` code touched — npm scripts and shell only; bench harness unreachable by construction.