### PR TITLE
fix(inference): reject over-window embeddings input before truncation

### DIFF
--- a/crates/embed/src/vision.rs
+++ b/crates/embed/src/vision.rs
@@ -39,6 +39,30 @@ use std::path::Path;
 
 pub use lattice_inference::forward::cpu_f16::PoolingStrategy;
 
+/// Raises `tokenizer`'s own truncation cap to `config`'s
+/// `max_position_embeddings.min(8192)` decode window when it sits below it,
+/// otherwise returns `tokenizer` unchanged. Only ever raises the cap, never
+/// lowers it.
+///
+/// Mirrors `lattice_inference::serve::embeddings`'s identically-named
+/// guard (issue #1408): without it, a caller-supplied `BpeTokenizer` left at
+/// its constructor default (4096) truncates any prompt between 4097 tokens
+/// and this checkpoint's real window before [`embed_text_vlm_f16`] or
+/// [`embed_image_from_bytes_f16`] ever see it, silently discarding content
+/// the model could otherwise process. Unlike the `lattice_inference` sibling,
+/// this crate has no admission guard ahead of the forward pass to reject an
+/// over-window input outright -- the tokenizer's own cap is the only thing
+/// standing between "process it" and "silently shorten it", so it must never
+/// sit below the checkpoint's window.
+fn capped_tokenizer(tokenizer: BpeTokenizer, config: &Qwen35Config) -> BpeTokenizer {
+    let max_context = config.max_position_embeddings.min(8192);
+    if tokenizer.max_seq_len() < max_context {
+        tokenizer.with_max_seq_len(max_context)
+    } else {
+        tokenizer
+    }
+}
+
 #[cfg(test)]
 thread_local! {
     static AFTER_VISUAL_LOAD_HOOK: std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
@@ -100,12 +124,21 @@ impl VisionEmbeddingModel {
     /// Use this when the checkpoint spans multiple safetensors shards (not
     /// supported by [`Self::from_directory`]) or when components are shared
     /// across other in-process model instances.
+    ///
+    /// Raises `tokenizer`'s own truncation cap to `config`'s context window
+    /// when it sits below it (see [`capped_tokenizer`]) -- see that
+    /// function's docs for why: without this, a caller-supplied tokenizer
+    /// left at its default cap silently truncates any prompt between 4097
+    /// tokens and the checkpoint's real window before it ever reaches the
+    /// forward pass. [`Self::from_directory`] goes through this constructor
+    /// too, so it gets the same guarantee.
     pub fn new(
         weights: F16ModelWeights,
         config: Qwen35Config,
         vision_weights: Qwen35VisionWeights,
         tokenizer: BpeTokenizer,
     ) -> Self {
+        let tokenizer = capped_tokenizer(tokenizer, &config);
         Self {
             weights,
             config,
@@ -656,8 +689,17 @@ mod tests {
     }
 
     fn write_tiny_vlm_checkpoint(dir: &Path, indexed: bool) {
-        let config = r#"{
-            "text_config": {
+        write_tiny_vlm_checkpoint_with_max_position_embeddings(dir, indexed, 512);
+    }
+
+    fn write_tiny_vlm_checkpoint_with_max_position_embeddings(
+        dir: &Path,
+        indexed: bool,
+        max_position_embeddings: usize,
+    ) {
+        let config = format!(
+            r#"{{
+            "text_config": {{
                 "hidden_size": 8,
                 "num_hidden_layers": 1,
                 "vocab_size": 16,
@@ -668,12 +710,12 @@ mod tests {
                 "head_dim": 8,
                 "rope_theta": 10000000.0,
                 "partial_rotary_factor": 1.0,
-                "rope_parameters": {
+                "rope_parameters": {{
                     "rope_theta": 10000000.0,
                     "partial_rotary_factor": 1.0,
                     "mrope_section": [2, 1, 1],
                     "mrope_interleaved": true
-                },
+                }},
                 "linear_num_key_heads": 2,
                 "linear_num_value_heads": 2,
                 "linear_key_head_dim": 32,
@@ -684,9 +726,9 @@ mod tests {
                 "layer_types": ["full_attention"],
                 "layer_mask": [true],
                 "eos_token_id": 15,
-                "max_position_embeddings": 512
-            },
-            "vision_config": {
+                "max_position_embeddings": {max_position_embeddings}
+            }},
+            "vision_config": {{
                 "depth": 1,
                 "hidden_size": 8,
                 "num_heads": 2,
@@ -697,13 +739,14 @@ mod tests {
                 "num_position_embeddings": 16,
                 "in_channels": 3,
                 "deepstack_visual_indexes": []
-            },
+            }},
             "image_token_id": 9,
             "vision_start_token_id": 10,
             "vision_end_token_id": 11,
             "tie_word_embeddings": true
-        }"#;
-        std::fs::write(dir.join("config.json"), config).expect("write config.json");
+        }}"#
+        );
+        std::fs::write(dir.join("config.json"), &config).expect("write config.json");
         write_tiny_tokenizer_json(dir);
 
         let shapes = tiny_vlm_checkpoint_shapes();
@@ -1050,6 +1093,33 @@ mod tests {
         let model = VisionEmbeddingModel::from_directory(tmp.path())
             .expect("single-file VLM checkpoint must load without a synthetic index");
         assert_eq!(model.dimensions(), 8);
+    }
+
+    /// Issue #1408, sibling-crate half: a `tokenizer.json` with no explicit
+    /// cap parses through `BpeTokenizer::from_tokenizer_json` at its
+    /// constructor default (4096, `DEFAULT_BPE_MAX_SEQ_LEN` in
+    /// `lattice_inference::tokenizer::bpe`). A checkpoint whose
+    /// `max_position_embeddings` sits above that default (here 5000, still
+    /// under the 8192 ceiling `capped_tokenizer` applies) must come out of
+    /// `from_directory` with its tokenizer cap raised to match -- otherwise
+    /// prompts between 4097 and 5000 tokens are silently truncated before
+    /// the forward pass ever sees them, even though the checkpoint can
+    /// process them. Reverting `VisionEmbeddingModel::new`'s call to
+    /// `capped_tokenizer` reddens this (cap stays at the tokenizer's own
+    /// default, 4096, strictly below `max_position_embeddings`, 5000).
+    #[test]
+    fn from_directory_raises_tokenizer_cap_to_context_window_above_tokenizer_default() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_tiny_vlm_checkpoint_with_max_position_embeddings(tmp.path(), false, 5000);
+
+        let model = VisionEmbeddingModel::from_directory(tmp.path())
+            .expect("VLM checkpoint with a wide context window must load");
+        assert_eq!(
+            model.tokenizer.max_seq_len(),
+            5000,
+            "tokenizer cap must be raised to max_position_embeddings, not left at the \
+             tokenizer's own 4096 default"
+        );
     }
 
     #[test]

--- a/crates/embed/src/vision.rs
+++ b/crates/embed/src/vision.rs
@@ -29,10 +29,12 @@ use crate::error::{EmbedError, Result};
 use lattice_inference::InferenceError;
 use lattice_inference::model::qwen35_config::Qwen35Config;
 use lattice_inference::tokenizer::bpe::BpeTokenizer;
+use lattice_inference::tokenizer::common::Tokenizer as _;
 use lattice_inference::vision::checkpoint::{
     Qwen35VisionWeights, load_qwen35_vision_weights_from_safetensors,
     open_qwen35_single_decoder_safetensors,
 };
+use lattice_inference::vision::qwen35_vit::preprocess_qwen35_image;
 use lattice_inference::vision::{embed_image_from_bytes_f16, embed_image_from_bytes_f16_metal};
 use lattice_inference::weights::f16_weights::{F16ModelWeights, load_f16_weights};
 use std::path::Path;
@@ -55,12 +57,82 @@ pub use lattice_inference::forward::cpu_f16::PoolingStrategy;
 /// standing between "process it" and "silently shorten it", so it must never
 /// sit below the checkpoint's window.
 fn capped_tokenizer(tokenizer: BpeTokenizer, config: &Qwen35Config) -> BpeTokenizer {
-    let max_context = config.max_position_embeddings.min(8192);
+    let max_context = max_context(config);
     if tokenizer.max_seq_len() < max_context {
         tokenizer.with_max_seq_len(max_context)
     } else {
         tokenizer
     }
+}
+
+/// This checkpoint's usable decoder window: `max_position_embeddings.min(8192)`,
+/// the same value [`capped_tokenizer`] raises the tokenizer cap to. Shared
+/// source of truth for the admission checks below.
+fn max_context(config: &Qwen35Config) -> usize {
+    config.max_position_embeddings.min(8192)
+}
+
+/// Rejects `prompt` whose PRE-truncation token count, plus `reserved`
+/// non-text scaffold tokens (image delimiters + pad tokens; `0` for a
+/// text-only call), exceeds `max_context` -- i.e. would otherwise be
+/// silently shortened by the tokenizer's own truncation before the forward
+/// pass ever sees it (issue #1408). Mirrors
+/// `lattice_inference::serve::embeddings::check_item_fits_window`'s
+/// pre-truncation-count admission for the sibling wire route: `real_length`
+/// can never exceed the tokenizer's own cap, so comparing against it (as
+/// opposed to `pre_truncation_len`) can never observe an over-window input
+/// once the cap sits at or above `max_context` -- the rejection would become
+/// unreachable and the input silently embedded from a truncated prefix.
+///
+/// # Errors
+///
+/// Returns [`EmbedError::InvalidInput`] naming the pre-truncation count, the
+/// reserved scaffold count, and `max_context`.
+fn check_prompt_admission(
+    tokenizer: &BpeTokenizer,
+    prompt: &str,
+    reserved: usize,
+    max_context: usize,
+) -> Result<()> {
+    let pre_truncation_len = tokenizer.tokenize(prompt).pre_truncation_len;
+    let total = pre_truncation_len.saturating_add(reserved);
+    if total > max_context {
+        return Err(EmbedError::InvalidInput(format!(
+            "prompt tokenizes to {pre_truncation_len} tokens before truncation ({total} \
+             including {reserved} scaffold tokens), exceeding the model's context window of \
+             {max_context} tokens"
+        )));
+    }
+    Ok(())
+}
+
+/// Real (pre-decode) scaffold token count an image consumes:
+/// `vision_start_token_id` + `vision_end_token_id` + the checkpoint's
+/// per-image pad-token count derived from the patch grid, mirroring
+/// `lattice_inference::serve::embeddings::EmbeddingModel::image_scaffold_token_count`'s
+/// identical arithmetic. Computed via a separate, cheap preprocessing call
+/// (not the caller's own forward pass) so the admission check below can run
+/// before the (expensive) ViT forward.
+///
+/// # Errors
+///
+/// Returns [`EmbedError::InvalidInput`] if the checkpoint has no
+/// `vision_config`, or if the image cannot be decoded/preprocessed.
+fn image_scaffold_reserve(config: &Qwen35Config, image_bytes: &[u8]) -> Result<usize> {
+    let vision_cfg = config.vision_config.as_ref().ok_or_else(|| {
+        EmbedError::InvalidInput(
+            "checkpoint has no vision_config; not a vision-language checkpoint".to_string(),
+        )
+    })?;
+    let (_pixel_values, grid) = preprocess_qwen35_image(image_bytes, vision_cfg)
+        .map_err(|e| EmbedError::InvalidInput(format!("image preprocessing failed: {e}")))?;
+    let merge_sq = vision_cfg.spatial_merge_size * vision_cfg.spatial_merge_size;
+    if merge_sq == 0 || !grid.num_patches().is_multiple_of(merge_sq) {
+        return Err(EmbedError::InvalidInput(format!(
+            "image grid {grid:?} patch count is not a multiple of spatial_merge_size^2"
+        )));
+    }
+    Ok(2 + grid.num_patches() / merge_sq)
 }
 
 #[cfg(test)]
@@ -226,17 +298,21 @@ impl VisionEmbeddingModel {
     ///
     /// Returns [`EmbedError::InvalidInput`] if `image_bytes` cannot be
     /// decoded, its dimensions are not compatible with the checkpoint's
-    /// patch/merge geometry, or the assembled request otherwise fails
-    /// validation (the error message names the offending field). Returns
-    /// [`EmbedError::InferenceFailed`] for every other underlying failure —
-    /// e.g. the prompt plus image tokens exceeding the checkpoint's context
-    /// window.
+    /// patch/merge geometry, the assembled request otherwise fails
+    /// validation (the error message names the offending field), or the
+    /// image's scaffold tokens plus `prompt`'s pre-truncation token count
+    /// exceed the checkpoint's context window (issue #1408: rejected before
+    /// the tokenizer's own truncation could silently shorten `prompt`).
+    /// Returns [`EmbedError::InferenceFailed`] for every other underlying
+    /// failure.
     pub fn embed_image(
         &self,
         image_bytes: &[u8],
         prompt: &str,
         pooling: PoolingStrategy,
     ) -> Result<Vec<f32>> {
+        let reserved = image_scaffold_reserve(&self.config, image_bytes)?;
+        check_prompt_admission(&self.tokenizer, prompt, reserved, max_context(&self.config))?;
         embed_image_from_bytes_f16(
             &self.weights,
             &self.config,
@@ -269,6 +345,8 @@ impl VisionEmbeddingModel {
         prompt: &str,
         pooling: PoolingStrategy,
     ) -> Result<Vec<f32>> {
+        let reserved = image_scaffold_reserve(&self.config, image_bytes)?;
+        check_prompt_admission(&self.tokenizer, prompt, reserved, max_context(&self.config))?;
         embed_image_from_bytes_f16_metal(
             &self.weights,
             &self.config,
@@ -286,11 +364,13 @@ impl VisionEmbeddingModel {
     ///
     /// # Errors
     ///
-    /// Returns [`EmbedError::InvalidInput`] if the prompt is empty or
-    /// tokenizes to an out-of-vocabulary id. Returns
-    /// [`EmbedError::InferenceFailed`] for every other underlying failure —
-    /// e.g. the prompt exceeding the checkpoint's context window.
+    /// Returns [`EmbedError::InvalidInput`] if the prompt is empty, tokenizes
+    /// to an out-of-vocabulary id, or its pre-truncation token count exceeds
+    /// the checkpoint's context window (issue #1408: rejected before the
+    /// tokenizer's own truncation could silently shorten it). Returns
+    /// [`EmbedError::InferenceFailed`] for every other underlying failure.
     pub fn embed_text(&self, prompt: &str, pooling: PoolingStrategy) -> Result<Vec<f32>> {
+        check_prompt_admission(&self.tokenizer, prompt, 0, max_context(&self.config))?;
         lattice_inference::forward::cpu_f16::embed_text_vlm_f16(
             &self.weights,
             &self.config,
@@ -950,6 +1030,78 @@ mod tests {
         assert!(matches!(err, EmbedError::InvalidInput(_)));
     }
 
+    /// Issue #1408 sibling hole (`embed_image`): unlike the sibling
+    /// `lattice_inference::serve::embeddings::EmbeddingModel::
+    /// image_scaffold_token_count`, whose one production caller always
+    /// passes an empty `prompt` (so its own doc comment notes the
+    /// truncation-vs-window mismatch is not live there), `embed_image` is a
+    /// general public entry point where a caller can pass any `prompt`. An
+    /// 8x8 test image against this fixture's tiny vision config produces 4
+    /// merged patch pads, so its scaffold (`vision_start` + 4 pads +
+    /// `vision_end`) is 6 tokens -- already over a 5-token window with an
+    /// empty prompt, so this exercises the scaffold-only side of the
+    /// admission check without needing any text tokens at all.
+    #[test]
+    fn embed_image_rejects_when_scaffold_exceeds_context_window() {
+        let (mut cfg, weights, vision_weights) = tiny_vlm_fixture();
+        cfg.max_position_embeddings = 5;
+        let tokenizer = tiny_tokenizer();
+        let model = VisionEmbeddingModel::new(weights, cfg, vision_weights, tokenizer);
+        let png = make_test_png(8, 8, 0);
+
+        let err = model
+            .embed_image(&png, "", PoolingStrategy::MeanVisualTokens)
+            .expect_err("scaffold tokens alone exceeding the context window must be rejected");
+        assert!(matches!(err, EmbedError::InvalidInput(_)), "got: {err:?}");
+        let msg = err.to_string();
+        assert!(
+            msg.contains('6'),
+            "error must name the scaffold token total (6), got: {msg}"
+        );
+        assert!(
+            msg.contains('5'),
+            "error must name the context window (5), got: {msg}"
+        );
+    }
+
+    /// Sibling boundary case: scaffold tokens landing exactly at the context
+    /// window (empty prompt, so no text tokens add to the total) must still
+    /// embed successfully.
+    #[test]
+    fn embed_image_accepts_when_scaffold_exactly_fits_context_window() {
+        let (mut cfg, weights, vision_weights) = tiny_vlm_fixture();
+        cfg.max_position_embeddings = 6;
+        let tokenizer = tiny_tokenizer();
+        let model = VisionEmbeddingModel::new(weights, cfg, vision_weights, tokenizer);
+        let png = make_test_png(8, 8, 0);
+
+        model
+            .embed_image(&png, "", PoolingStrategy::MeanVisualTokens)
+            .expect("scaffold tokens exactly at the context window boundary must still embed");
+    }
+
+    /// Same property as `embed_image_rejects_when_scaffold_exceeds_context_window`,
+    /// for the Metal-dispatching sibling: the admission check must run (and
+    /// reject) before `embed_image_metal` ever attempts a Metal dispatch, so
+    /// this must reject identically on a build/platform with no Metal
+    /// support at all -- no GPU is touched by this test.
+    #[test]
+    fn embed_image_metal_rejects_when_scaffold_exceeds_context_window() {
+        let (mut cfg, weights, vision_weights) = tiny_vlm_fixture();
+        cfg.max_position_embeddings = 5;
+        let tokenizer = tiny_tokenizer();
+        let model = VisionEmbeddingModel::new(weights, cfg, vision_weights, tokenizer);
+        let png = make_test_png(8, 8, 0);
+
+        let err = model
+            .embed_image_metal(&png, "", PoolingStrategy::MeanVisualTokens)
+            .expect_err(
+                "scaffold tokens alone exceeding the context window must be rejected \
+                         before any Metal dispatch is attempted",
+            );
+        assert!(matches!(err, EmbedError::InvalidInput(_)), "got: {err:?}");
+    }
+
     #[test]
     fn embed_text_matches_raw_inference_primitive() {
         let (cfg, weights, vision_weights) = tiny_vlm_fixture();
@@ -976,13 +1128,23 @@ mod tests {
         assert_eq!(via_wrapper, via_raw);
     }
 
-    /// A runtime (non-input) failure -- the prompt exceeding the checkpoint's
-    /// context window, surfaced as `InferenceError::Inference` from the
-    /// shared prefill path (cpu_f16.rs) -- must map to
-    /// `EmbedError::InferenceFailed`, not `EmbedError::InvalidInput`: the
-    /// prompt itself is well-formed, the checkpoint just can't fit it.
+    /// Issue #1408 (library-path admission guard, `embed_text`): a prompt
+    /// whose PRE-truncation token count exceeds the checkpoint's context
+    /// window must be rejected as caller input, before the forward pass ever
+    /// runs. This fixture's tokenizer cap (4096, `capped_tokenizer` never
+    /// lowers it) sits well above the 1-token window, so before this guard
+    /// existed "abc" tokenized to its full 3 real ids and only failed
+    /// downstream, as `EmbedError::InferenceFailed`, once the assembled
+    /// request's length was compared against `max_position_embeddings` deep
+    /// inside the forward pass -- a caller-input problem misreported as a
+    /// runtime one. A checkpoint whose window instead sits between the
+    /// tokenizer's default and a wider `max_position_embeddings` (the
+    /// scenario `capped_tokenizer` exists for) would raise the tokenizer's
+    /// own cap to match, so the same over-window prompt would truncate
+    /// silently there and never reach any error at all. Reverting the
+    /// `check_prompt_admission` call in `embed_text` reddens this.
     #[test]
-    fn embed_text_maps_context_overflow_to_inference_failed() {
+    fn embed_text_rejects_prompt_exceeding_context_window_before_truncation() {
         let (mut cfg, weights, vision_weights) = tiny_vlm_fixture();
         cfg.max_position_embeddings = 1;
         let tokenizer = single_char_tokenizer();
@@ -990,15 +1152,38 @@ mod tests {
 
         let err = model
             .embed_text("abc", PoolingStrategy::LastToken)
-            .expect_err("a prompt longer than max_position_embeddings must fail");
+            .expect_err(
+                "a prompt whose pre-truncation length exceeds the context window must be rejected",
+            );
         assert!(
-            matches!(err, EmbedError::InferenceFailed(_)),
-            "context-window overflow is a runtime failure, not caller-input validation, got: {err:?}"
+            matches!(err, EmbedError::InvalidInput(_)),
+            "over-window prompt must be rejected as caller input, not embedded from a \
+             truncated prefix, got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains('3'),
+            "error must name the pre-truncation token count (3), got: {msg}"
         );
         assert!(
-            err.to_string().contains("context window"),
-            "error should retain the underlying context-window detail, got: {err}"
+            msg.contains('1'),
+            "error must name the context window (1), got: {msg}"
         );
+    }
+
+    /// Sibling boundary case: a prompt whose pre-truncation length lands
+    /// exactly at the context window must still embed successfully -- the
+    /// admission guard must not reject an at-or-below-window prompt.
+    #[test]
+    fn embed_text_accepts_prompt_exactly_at_context_window() {
+        let (mut cfg, weights, vision_weights) = tiny_vlm_fixture();
+        cfg.max_position_embeddings = 1;
+        let tokenizer = single_char_tokenizer();
+        let model = VisionEmbeddingModel::new(weights, cfg, vision_weights, tokenizer);
+
+        model
+            .embed_text("a", PoolingStrategy::LastToken)
+            .expect("a prompt exactly at the context window boundary must still embed");
     }
 
     #[test]

--- a/crates/inference/src/serve/embeddings.rs
+++ b/crates/inference/src/serve/embeddings.rs
@@ -117,8 +117,19 @@ impl EmbeddingModel {
         })?;
 
         let tokenizer_path = dir.join("tokenizer.json");
+        // Cap the tokenizer's own truncation point at this checkpoint's
+        // context window (mirroring `max_context()` exactly) rather than
+        // leaving it at `BpeTokenizer`'s `DEFAULT_BPE_MAX_SEQ_LEN` (4096):
+        // otherwise, whenever `max_position_embeddings.min(8192)` exceeds
+        // 4096, the tokenizer can silently truncate an input to 4096 tokens
+        // while `check_item_fits_window` admits it (its pre-truncation count
+        // is still under the wider window), embedding a truncated prefix
+        // instead of rejecting it. Capping here makes truncation and
+        // rejection coincide: anything the tokenizer would truncate is
+        // exactly what the guard now rejects.
         let tokenizer = BpeTokenizer::from_tokenizer_json(&tokenizer_path)
-            .map_err(|e| format!("{}: {e}", tokenizer_path.display()))?;
+            .map_err(|e| format!("{}: {e}", tokenizer_path.display()))?
+            .with_max_seq_len(config.max_position_embeddings.min(8192));
 
         let (mut sf, shard_path) = open_qwen35_single_decoder_safetensors(dir)
             .map_err(|e| format!("decoder checkpoint: {e}"))?;
@@ -141,9 +152,28 @@ impl EmbeddingModel {
         self.config.hidden_size
     }
 
-    /// Real tokenized length of `text`, used for `usage.prompt_tokens`.
+    /// Real (possibly truncated) tokenized length of `text`, used for
+    /// `usage.prompt_tokens` -- this must report what the pooled forward
+    /// pass actually consumes, not what the caller sent. Never use this for
+    /// a context-window admission check: see
+    /// [`Self::tokenize_pre_truncation_len`].
     pub fn tokenize_len(&self, text: &str) -> usize {
         self.tokenizer.tokenize(text).real_length
+    }
+
+    /// Pre-truncation tokenized length of `text`, i.e. the count before the
+    /// tokenizer's own `max_seq_len` truncation is applied. The
+    /// context-window admission guard ([`check_item_fits_window`]) must
+    /// compare against this, not [`Self::tokenize_len`]'s real length:
+    /// `real_length` can never exceed the tokenizer's `max_seq_len`, so
+    /// comparing it against `max_context()` can never observe an
+    /// over-window input once `max_seq_len <= max_context()` -- the
+    /// rejection becomes unreachable and an over-long input is silently
+    /// embedded from a truncated prefix instead. See
+    /// `TokenizedInput::pre_truncation_len`'s doc for the same reasoning
+    /// applied to the sibling `lattice_serve` text-embeddings route.
+    pub fn tokenize_pre_truncation_len(&self, text: &str) -> usize {
+        self.tokenizer.tokenize(text).pre_truncation_len
     }
 
     /// Maximum decoder scaffold length this checkpoint can process in one
@@ -163,6 +193,18 @@ impl EmbeddingModel {
     /// that module's internals), and `prompt`'s tokenized length. Used both
     /// for `usage.prompt_tokens` accounting and (via the returned count) can
     /// be compared against [`Self::max_context`] the same way a text item is.
+    ///
+    /// Uses [`Self::tokenize_len`] (the real, possibly-truncated count), not
+    /// [`Self::tokenize_pre_truncation_len`], for the `prompt` component --
+    /// unlike the text item guard, this is not a live gap today: this
+    /// method's one production call site ([`embed_items`]'s image branch)
+    /// always passes `prompt = ""`, whose tokenized length is `0` either
+    /// way, so no input can currently exercise the truncation-vs-window
+    /// mismatch through this path. A future caller that passes a real
+    /// `prompt` here would need the same admission/usage split the text
+    /// branch got; left as real-length-only for now rather than adding an
+    /// unexercised second accessor for a code path with no non-empty-prompt
+    /// caller.
     ///
     /// # Errors
     ///
@@ -528,8 +570,15 @@ pub fn embed_items(
     for (index, item) in items.into_iter().enumerate() {
         let embedding = match &item {
             NormalizedEmbeddingItem::Text(text) => {
+                // Admission uses the pre-truncation count so an input the
+                // tokenizer would truncate is rejected instead of silently
+                // embedded from a truncated prefix; `usage.prompt_tokens`
+                // still reports the real (possibly truncated) count the
+                // forward pass actually consumes -- see both accessors'
+                // doc comments.
+                let admission_count = embedder.tokenize_pre_truncation_len(text);
+                check_item_fits_window(index, admission_count, max_context)?;
                 let token_count = embedder.tokenize_len(text);
-                check_item_fits_window(index, token_count, max_context)?;
                 prompt_tokens += token_count;
                 embedder.embed_text(text, pooling)
             }
@@ -1126,6 +1175,78 @@ mod tests {
         let (data, usage) = embed_items(&model, items, PoolingStrategy::MeanVisualTokens).unwrap();
         assert_eq!(data.len(), 1);
         assert_eq!(usage.prompt_tokens, 10);
+    }
+
+    /// Builds a fixture with the OPPOSITE ordering of
+    /// `embed_items_rejects_text_item_over_context_window` above: that
+    /// test's `max_context() == 512` sits BELOW the tokenizer's default
+    /// (4096) truncation cap, so a long input survives tokenization intact
+    /// and trips the guard whether the guard reads the real or the
+    /// pre-truncation count -- it cannot distinguish the fix from a no-op.
+    /// This fixture pins a tokenizer cap (5) BELOW the context window
+    /// (1000), which is the ordering issue #1408 actually needs: a
+    /// comparison against `tokenize_len`'s real (post-truncation) count
+    /// would clamp to 5 tokens for any input and could never exceed the
+    /// 1000-token window, making the rejection unreachable.
+    fn context_window_above_tokenizer_cap_model() -> EmbeddingModel {
+        let base = tiny_embedding_model();
+        let mut config = base.config.clone();
+        config.max_position_embeddings = 1000;
+        let tokenizer = base.tokenizer.clone().with_max_seq_len(5);
+        EmbeddingModel::new(
+            base.weights.clone(),
+            config,
+            base.vision_weights.clone(),
+            tokenizer,
+        )
+    }
+
+    #[test]
+    fn embed_items_rejects_text_item_whose_pre_truncation_length_exceeds_a_window_above_the_tokenizer_cap()
+     {
+        let model = context_window_above_tokenizer_cap_model();
+        assert_eq!(model.max_context(), 1000);
+        assert_eq!(model.tokenizer.max_seq_len(), 5);
+
+        // Pre-truncation length 1200 (above the 1000-token window), which
+        // the tokenizer would truncate to 5 real tokens before the forward
+        // pass. Under the pre-#1408 comparison (real length 5 vs. window
+        // 1000) this would be silently ACCEPTED and embedded from a
+        // 5-token truncated prefix. The admission guard must reject it.
+        let over_limit_text = "a".repeat(1200);
+        let items =
+            normalize_embedding_items(vec![EmbeddingInputItem::Text(over_limit_text)]).unwrap();
+        let err = embed_items(&model, items, PoolingStrategy::MeanVisualTokens).unwrap_err();
+        match err {
+            ApiError::BadRequest { message, code } => {
+                assert_eq!(code, "context_length_exceeded");
+                assert!(message.contains("input item 0"), "message: {message}");
+                assert!(message.contains("1200"), "message: {message}");
+                assert!(message.contains("1000"), "message: {message}");
+            }
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn embed_items_accepted_prompt_tokens_matches_the_count_actually_embedded_when_truncated() {
+        // Same inverted fixture, but with an input whose pre-truncation
+        // length (12) still fits the window (1000) -- ACCEPTED -- while the
+        // tokenizer truncates it to 5 tokens before the forward pass.
+        // `usage.prompt_tokens` must report 5 (what was actually embedded),
+        // not 12: the naive one-liner fix (swap `tokenize_len` to always
+        // return the pre-truncation count) would report 12 here, billing
+        // tokens that were never embedded -- see `usage.prompt_tokens`'s own
+        // doc comment on `EmbeddingsUsage`.
+        let model = context_window_above_tokenizer_cap_model();
+        let text = "a".repeat(12);
+        let items = normalize_embedding_items(vec![EmbeddingInputItem::Text(text)]).unwrap();
+        let (data, usage) = embed_items(&model, items, PoolingStrategy::MeanVisualTokens).unwrap();
+        assert_eq!(data.len(), 1);
+        assert_eq!(
+            usage.prompt_tokens, 5,
+            "usage must report the real embedded count, not the pre-truncation count"
+        );
     }
 
     #[test]

--- a/crates/inference/src/serve/embeddings.rs
+++ b/crates/inference/src/serve/embeddings.rs
@@ -155,16 +155,22 @@ impl EmbeddingModel {
     /// Real (possibly truncated) tokenized length of `text`, used for
     /// `usage.prompt_tokens` -- this must report what the pooled forward
     /// pass actually consumes, not what the caller sent. Never use this for
-    /// a context-window admission check: see
-    /// [`Self::tokenize_pre_truncation_len`].
+    /// a context-window admission check: see [`Self::tokenize_lengths`].
     pub fn tokenize_len(&self, text: &str) -> usize {
         self.tokenizer.tokenize(text).real_length
     }
 
-    /// Pre-truncation tokenized length of `text`, i.e. the count before the
-    /// tokenizer's own `max_seq_len` truncation is applied. The
-    /// context-window admission guard ([`check_item_fits_window`]) must
-    /// compare against this, not [`Self::tokenize_len`]'s real length:
+    /// Tokenizes `text` once, returning `(pre_truncation_len, real_length)`
+    /// -- the count the context-window admission guard
+    /// ([`check_item_fits_window`]) must compare against, and the count the
+    /// forward pass actually consumes for `usage.prompt_tokens`,
+    /// respectively. Exists so a caller that needs both counts (the
+    /// [`embed_items`] text branch) tokenizes once instead of twice;
+    /// [`Self::tokenize_len`] above remains the single-value accessor for a
+    /// caller (e.g. [`Self::image_scaffold_token_count`]) that only needs
+    /// the real, post-truncation count.
+    ///
+    /// `pre_truncation_len` must be used for admission, never `real_length`:
     /// `real_length` can never exceed the tokenizer's `max_seq_len`, so
     /// comparing it against `max_context()` can never observe an
     /// over-window input once `max_seq_len <= max_context()` -- the
@@ -172,8 +178,9 @@ impl EmbeddingModel {
     /// embedded from a truncated prefix instead. See
     /// `TokenizedInput::pre_truncation_len`'s doc for the same reasoning
     /// applied to the sibling `lattice_serve` text-embeddings route.
-    pub fn tokenize_pre_truncation_len(&self, text: &str) -> usize {
-        self.tokenizer.tokenize(text).pre_truncation_len
+    fn tokenize_lengths(&self, text: &str) -> (usize, usize) {
+        let tokenized = self.tokenizer.tokenize(text);
+        (tokenized.pre_truncation_len, tokenized.real_length)
     }
 
     /// Maximum decoder scaffold length this checkpoint can process in one
@@ -195,8 +202,9 @@ impl EmbeddingModel {
     /// be compared against [`Self::max_context`] the same way a text item is.
     ///
     /// Uses [`Self::tokenize_len`] (the real, possibly-truncated count), not
-    /// [`Self::tokenize_pre_truncation_len`], for the `prompt` component --
-    /// unlike the text item guard, this is not a live gap today: this
+    /// the pre-truncation count [`Self::tokenize_lengths`] also exposes, for
+    /// the `prompt` component -- unlike the text item guard, this is not a
+    /// live gap today: this
     /// method's one production call site ([`embed_items`]'s image branch)
     /// always passes `prompt = ""`, whose tokenized length is `0` either
     /// way, so no input can currently exercise the truncation-vs-window
@@ -570,15 +578,14 @@ pub fn embed_items(
     for (index, item) in items.into_iter().enumerate() {
         let embedding = match &item {
             NormalizedEmbeddingItem::Text(text) => {
-                // Admission uses the pre-truncation count so an input the
-                // tokenizer would truncate is rejected instead of silently
-                // embedded from a truncated prefix; `usage.prompt_tokens`
-                // still reports the real (possibly truncated) count the
-                // forward pass actually consumes -- see both accessors'
-                // doc comments.
-                let admission_count = embedder.tokenize_pre_truncation_len(text);
+                // Single tokenize() call: admission uses the pre-truncation
+                // count so an input the tokenizer would truncate is rejected
+                // instead of silently embedded from a truncated prefix;
+                // `usage.prompt_tokens` still reports the real (possibly
+                // truncated) count the forward pass actually consumes --
+                // see `tokenize_lengths`'s doc comment.
+                let (admission_count, token_count) = embedder.tokenize_lengths(text);
                 check_item_fits_window(index, admission_count, max_context)?;
-                let token_count = embedder.tokenize_len(text);
                 prompt_tokens += token_count;
                 embedder.embed_text(text, pooling)
             }

--- a/crates/inference/src/serve/embeddings.rs
+++ b/crates/inference/src/serve/embeddings.rs
@@ -64,6 +64,29 @@ pub const MAX_EMBEDDING_INPUT_COUNT: usize = 4096;
 // Model loading and execution
 // ---------------------------------------------------------------------------
 
+/// Raises `tokenizer`'s own truncation cap to `max_context` when it sits
+/// below it, otherwise returns `tokenizer` unchanged.
+///
+/// This is the shared enforcement point for the invariant issue #1408
+/// requires: no constructed [`EmbeddingModel`] may have a tokenizer cap
+/// below its own [`EmbeddingModel::max_context`]. If it did,
+/// `check_item_fits_window`'s pre-truncation-count admission check (see
+/// [`embed_items`]) would still admit an over-window item -- its
+/// pre-truncation count is compared against `max_context`, which the
+/// tokenizer cap sits below -- but the tokenizer would then silently
+/// truncate it before the forward pass, embedding a truncated prefix
+/// instead of rejecting the input. Only ever raises the cap, never lowers
+/// it: a caller-supplied tokenizer already capped at or above
+/// `max_context` (e.g. a fixture deliberately testing a *narrower* cap
+/// than its own window) is left untouched.
+fn capped_tokenizer(tokenizer: BpeTokenizer, max_context: usize) -> BpeTokenizer {
+    if tokenizer.max_seq_len() < max_context {
+        tokenizer.with_max_seq_len(max_context)
+    } else {
+        tokenizer
+    }
+}
+
 /// A loaded Qwen3.5 vision-language checkpoint used to serve pooled text and
 /// image embeddings. See the module doc comment for why this loader lives
 /// here instead of reusing `lattice-embed::vision::VisionEmbeddingModel`.
@@ -78,12 +101,24 @@ impl EmbeddingModel {
     /// Compose a model from already-loaded components (no I/O). Used by
     /// tests and by callers that share components with another in-process
     /// model instance.
+    ///
+    /// Raises `tokenizer`'s own truncation cap to this checkpoint's
+    /// [`Self::max_context`] window when it sits below it (see
+    /// [`capped_tokenizer`]), so this constructor gives the same guarantee
+    /// [`Self::from_directory`] does: no `EmbeddingModel`, however
+    /// constructed, can have a tokenizer cap below its own `max_context()`.
+    /// Without this, a caller passing a default `BpeTokenizer` (whose
+    /// constructors cap at 4096) alongside a checkpoint config whose
+    /// `max_position_embeddings.min(8192)` exceeds 4096 would reproduce
+    /// exactly the #1408 bug through this constructor instead of the loader.
     pub fn new(
         weights: F16ModelWeights,
         config: Qwen35Config,
         vision_weights: Qwen35VisionWeights,
         tokenizer: BpeTokenizer,
     ) -> Self {
+        let max_context = config.max_position_embeddings.min(8192);
+        let tokenizer = capped_tokenizer(tokenizer, max_context);
         Self {
             weights,
             config,
@@ -117,19 +152,8 @@ impl EmbeddingModel {
         })?;
 
         let tokenizer_path = dir.join("tokenizer.json");
-        // Cap the tokenizer's own truncation point at this checkpoint's
-        // context window (mirroring `max_context()` exactly) rather than
-        // leaving it at `BpeTokenizer`'s `DEFAULT_BPE_MAX_SEQ_LEN` (4096):
-        // otherwise, whenever `max_position_embeddings.min(8192)` exceeds
-        // 4096, the tokenizer can silently truncate an input to 4096 tokens
-        // while `check_item_fits_window` admits it (its pre-truncation count
-        // is still under the wider window), embedding a truncated prefix
-        // instead of rejecting it. Capping here makes truncation and
-        // rejection coincide: anything the tokenizer would truncate is
-        // exactly what the guard now rejects.
         let tokenizer = BpeTokenizer::from_tokenizer_json(&tokenizer_path)
-            .map_err(|e| format!("{}: {e}", tokenizer_path.display()))?
-            .with_max_seq_len(config.max_position_embeddings.min(8192));
+            .map_err(|e| format!("{}: {e}", tokenizer_path.display()))?;
 
         let (mut sf, shard_path) = open_qwen35_single_decoder_safetensors(dir)
             .map_err(|e| format!("decoder checkpoint: {e}"))?;
@@ -139,12 +163,17 @@ impl EmbeddingModel {
         let weights =
             load_f16_weights(&sf, &config).map_err(|e| format!("decoder weights: {e}"))?;
 
-        Ok(Self {
-            weights,
-            config,
-            vision_weights,
-            tokenizer,
-        })
+        // Routed through `Self::new` (not a bare struct literal) so the
+        // tokenizer's truncation cap is raised to this checkpoint's context
+        // window exactly as any other construction path would be -- see
+        // `Self::new`'s and `capped_tokenizer`'s docs for why: otherwise,
+        // whenever `max_position_embeddings.min(8192)` exceeds
+        // `BpeTokenizer`'s `DEFAULT_BPE_MAX_SEQ_LEN` (4096), the tokenizer
+        // can silently truncate an input to 4096 tokens while
+        // `check_item_fits_window` admits it (its pre-truncation count is
+        // still under the wider window), embedding a truncated prefix
+        // instead of rejecting it.
+        Ok(Self::new(weights, config, vision_weights, tokenizer))
     }
 
     /// Output embedding dimension (the checkpoint's decoder hidden size).
@@ -1138,7 +1167,284 @@ pub fn build_embeddings_response(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::Path;
     use test_support::{tiny_embedding_model, tiny_png_data_uri};
+
+    /// Tensor inventory a tiny f16-decoder + vision checkpoint must carry
+    /// for [`open_qwen35_single_decoder_safetensors`],
+    /// [`load_qwen35_vision_weights_from_safetensors`], and
+    /// [`load_f16_weights`] to all succeed. Mirrors
+    /// `lattice-embed::vision::tests::tiny_vlm_checkpoint_shapes` exactly:
+    /// both crates load through the same checkpoint-reading functions, so
+    /// the same on-disk shape works for either loader.
+    fn tiny_vlm_checkpoint_shapes() -> Vec<(String, Vec<usize>)> {
+        let hidden = 8usize;
+        let mut shapes = vec![
+            (
+                "model.language_model.embed_tokens.weight".to_string(),
+                vec![16, hidden],
+            ),
+            ("model.language_model.norm.weight".to_string(), vec![hidden]),
+            (
+                "model.language_model.layers.0.input_layernorm.weight".to_string(),
+                vec![hidden],
+            ),
+            (
+                "model.language_model.layers.0.post_attention_layernorm.weight".to_string(),
+                vec![hidden],
+            ),
+            (
+                "model.language_model.layers.0.mlp.gate_proj.weight".to_string(),
+                vec![4, hidden],
+            ),
+            (
+                "model.language_model.layers.0.mlp.up_proj.weight".to_string(),
+                vec![4, hidden],
+            ),
+            (
+                "model.language_model.layers.0.mlp.down_proj.weight".to_string(),
+                vec![hidden, 4],
+            ),
+            (
+                "model.language_model.layers.0.self_attn.q_proj.weight".to_string(),
+                vec![16, hidden],
+            ),
+            (
+                "model.language_model.layers.0.self_attn.k_proj.weight".to_string(),
+                vec![hidden, hidden],
+            ),
+            (
+                "model.language_model.layers.0.self_attn.v_proj.weight".to_string(),
+                vec![hidden, hidden],
+            ),
+            (
+                "model.language_model.layers.0.self_attn.o_proj.weight".to_string(),
+                vec![hidden, hidden],
+            ),
+            (
+                "model.language_model.layers.0.self_attn.q_norm.weight".to_string(),
+                vec![hidden],
+            ),
+            (
+                "model.language_model.layers.0.self_attn.k_norm.weight".to_string(),
+                vec![hidden],
+            ),
+            (
+                "model.visual.patch_embed.proj.weight".to_string(),
+                vec![hidden, 3, 1, 2, 2],
+            ),
+            (
+                "model.visual.patch_embed.proj.bias".to_string(),
+                vec![hidden],
+            ),
+            (
+                "model.visual.pos_embed.weight".to_string(),
+                vec![16, hidden],
+            ),
+            (
+                "model.visual.merger.linear_fc1.weight".to_string(),
+                vec![32, 32],
+            ),
+            ("model.visual.merger.linear_fc1.bias".to_string(), vec![32]),
+            (
+                "model.visual.merger.linear_fc2.weight".to_string(),
+                vec![hidden, 32],
+            ),
+            (
+                "model.visual.merger.linear_fc2.bias".to_string(),
+                vec![hidden],
+            ),
+            ("model.visual.merger.norm.weight".to_string(), vec![hidden]),
+            ("model.visual.merger.norm.bias".to_string(), vec![hidden]),
+        ];
+        for (suffix, shape) in [
+            ("attn.qkv.weight", vec![24, hidden]),
+            ("attn.qkv.bias", vec![24]),
+            ("attn.proj.weight", vec![hidden, hidden]),
+            ("attn.proj.bias", vec![hidden]),
+            ("mlp.linear_fc1.weight", vec![32, hidden]),
+            ("mlp.linear_fc1.bias", vec![32]),
+            ("mlp.linear_fc2.weight", vec![hidden, 32]),
+            ("mlp.linear_fc2.bias", vec![hidden]),
+            ("norm1.weight", vec![hidden]),
+            ("norm1.bias", vec![hidden]),
+            ("norm2.weight", vec![hidden]),
+            ("norm2.bias", vec![hidden]),
+        ] {
+            shapes.push((format!("model.visual.blocks.0.{suffix}"), shape));
+        }
+        shapes
+    }
+
+    fn write_f32_safetensors(path: &Path, shapes: &[(String, Vec<usize>)]) {
+        let mut header_parts = Vec::with_capacity(shapes.len());
+        let mut data = Vec::new();
+        for (i, (name, shape)) in shapes.iter().enumerate() {
+            let start = data.len();
+            let numel: usize = shape.iter().product();
+            for _ in 0..numel {
+                data.extend_from_slice(&((i + 1) as f32 / 100.0).to_le_bytes());
+            }
+            let end = data.len();
+            let shape = shape
+                .iter()
+                .map(usize::to_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            header_parts.push(format!(
+                r#""{name}":{{"dtype":"F32","shape":[{shape}],"data_offsets":[{start},{end}]}}"#
+            ));
+        }
+        let header = format!("{{{}}}", header_parts.join(","));
+        let mut bytes = Vec::with_capacity(8 + header.len() + data.len());
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(header.as_bytes());
+        bytes.extend_from_slice(&data);
+        std::fs::write(path, bytes).expect("write safetensors fixture");
+    }
+
+    fn write_tiny_tokenizer_json(dir: &Path) {
+        let tokenizer = r#"{
+            "model": {
+                "type": "BPE",
+                "vocab": {
+                    "a": 0, "b": 1, "c": 2, "d": 3,
+                    "e": 4, "f": 5, "g": 6, "h": 7,
+                    "i": 8, "j": 9, "k": 10, "l": 11,
+                    "m": 12, "n": 13, "o": 14, "p": 15
+                },
+                "merges": []
+            }
+        }"#;
+        std::fs::write(dir.join("tokenizer.json"), tokenizer).expect("write tokenizer.json");
+    }
+
+    /// Writes a tiny on-disk VLM checkpoint (`config.json`,
+    /// `tokenizer.json`, single-file `model.safetensors`) with a
+    /// caller-chosen `max_position_embeddings`, so a test can pin it above
+    /// `BpeTokenizer`'s 4096 constructor default and exercise
+    /// [`EmbeddingModel::from_directory`]'s tokenizer-capping behavior end
+    /// to end.
+    fn write_tiny_vlm_checkpoint(dir: &Path, max_position_embeddings: usize) {
+        let config = format!(
+            r#"{{
+            "text_config": {{
+                "hidden_size": 8,
+                "num_hidden_layers": 1,
+                "vocab_size": 16,
+                "intermediate_size": 4,
+                "rms_norm_eps": 0.000001,
+                "num_attention_heads": 1,
+                "num_key_value_heads": 1,
+                "head_dim": 8,
+                "rope_theta": 10000000.0,
+                "partial_rotary_factor": 1.0,
+                "rope_parameters": {{
+                    "rope_theta": 10000000.0,
+                    "partial_rotary_factor": 1.0,
+                    "mrope_section": [2, 1, 1],
+                    "mrope_interleaved": true
+                }},
+                "linear_num_key_heads": 2,
+                "linear_num_value_heads": 2,
+                "linear_key_head_dim": 32,
+                "linear_value_head_dim": 32,
+                "linear_conv_kernel_dim": 4,
+                "tie_word_embeddings": true,
+                "full_attention_interval": 1,
+                "layer_types": ["full_attention"],
+                "layer_mask": [true],
+                "eos_token_id": 15,
+                "max_position_embeddings": {max_position_embeddings}
+            }},
+            "vision_config": {{
+                "depth": 1,
+                "hidden_size": 8,
+                "num_heads": 2,
+                "patch_size": 2,
+                "spatial_merge_size": 2,
+                "out_hidden_size": 8,
+                "temporal_patch_size": 1,
+                "num_position_embeddings": 16,
+                "in_channels": 3,
+                "deepstack_visual_indexes": []
+            }},
+            "image_token_id": 9,
+            "vision_start_token_id": 10,
+            "vision_end_token_id": 11,
+            "tie_word_embeddings": true
+        }}"#
+        );
+        std::fs::write(dir.join("config.json"), &config).expect("write config.json");
+        write_tiny_tokenizer_json(dir);
+        write_f32_safetensors(
+            &dir.join("model.safetensors"),
+            &tiny_vlm_checkpoint_shapes(),
+        );
+    }
+
+    /// Issue #1408, loader half: a `tokenizer.json` with no explicit cap
+    /// parses through `BpeTokenizer::from_tokenizer_json` at its
+    /// constructor default (4096). A checkpoint whose
+    /// `max_position_embeddings` sits above that default (here 5000, still
+    /// under the 8192 ceiling `capped_tokenizer` applies) must come out of
+    /// `from_directory` with its tokenizer cap raised to match. This is a
+    /// different property from
+    /// `embedding_model_new_raises_a_tokenizer_cap_below_max_context` below:
+    /// that test calls `EmbeddingModel::new` directly and would still pass
+    /// if `from_directory` stopped routing through `new` (e.g. reverted to
+    /// building `Self { .. }` directly); this test exercises
+    /// `from_directory`'s own path end to end and reddens on that revert.
+    #[test]
+    fn from_directory_raises_tokenizer_cap_to_context_window_above_tokenizer_default() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        write_tiny_vlm_checkpoint(tmp.path(), 5000);
+
+        let model = EmbeddingModel::from_directory(tmp.path())
+            .expect("VLM checkpoint with a wide context window must load");
+        assert_eq!(
+            model.tokenizer.max_seq_len(),
+            5000,
+            "tokenizer cap must be raised to max_position_embeddings, not left at the \
+             tokenizer's own 4096 default"
+        );
+    }
+
+    /// Issue #1408, constructor half: `EmbeddingModel::new` itself -- not
+    /// just the `from_directory` loader -- must raise a caller-supplied
+    /// tokenizer's cap to at least `max_context()`. Without this, a caller
+    /// passing a default `BpeTokenizer` (cap 4096) alongside a config whose
+    /// `max_position_embeddings.min(8192)` exceeds 4096 reproduces the
+    /// #1408 bug through this constructor instead of the loader.
+    #[test]
+    fn embedding_model_new_raises_a_tokenizer_cap_below_max_context() {
+        let base = tiny_embedding_model();
+        let mut config = base.config.clone();
+        config.max_position_embeddings = 5000;
+        // `BpeTokenizer::from_vocab_and_merges` defaults to
+        // `DEFAULT_BPE_MAX_SEQ_LEN` (4096), strictly below the 5000-token
+        // window just configured -- exactly the mismatch `new` must close.
+        let mut vocab_map = std::collections::HashMap::new();
+        for (i, c) in ["a", "b", "c"].iter().enumerate() {
+            vocab_map.insert((*c).to_string(), i as u32);
+        }
+        let tokenizer =
+            BpeTokenizer::from_vocab_and_merges(vocab_map, vec![]).expect("tokenizer constructs");
+        assert!(tokenizer.max_seq_len() < 5000, "fixture precondition");
+
+        let model = EmbeddingModel::new(
+            base.weights.clone(),
+            config,
+            base.vision_weights.clone(),
+            tokenizer,
+        );
+        assert_eq!(model.max_context(), 5000);
+        assert_eq!(
+            model.tokenizer.max_seq_len(),
+            5000,
+            "new() must raise a below-window tokenizer cap to max_context()"
+        );
+    }
 
     #[test]
     fn embed_items_happy_path_text_only() {
@@ -1195,17 +1501,29 @@ mod tests {
     /// comparison against `tokenize_len`'s real (post-truncation) count
     /// would clamp to 5 tokens for any input and could never exceed the
     /// 1000-token window, making the rejection unreachable.
+    ///
+    /// Built via a direct struct literal, not `EmbeddingModel::new`:
+    /// `new` now enforces the #1408 constructor invariant (tokenizer cap at
+    /// or above `max_context()`, see `capped_tokenizer`) and would silently
+    /// raise this fixture's deliberately-below-window cap back to 1000,
+    /// destroying the exact mismatch this fixture exists to construct.
+    /// This is a different property from the constructor invariant test
+    /// (`embedding_model_new_raises_a_tokenizer_cap_below_max_context`
+    /// below) -- that test asserts `new` closes this gap for real callers;
+    /// this fixture must keep it open to exercise the admission-count
+    /// semantics on their own. Same-crate private-field access from this
+    /// child `mod tests` is what makes the bypass possible.
     fn context_window_above_tokenizer_cap_model() -> EmbeddingModel {
         let base = tiny_embedding_model();
         let mut config = base.config.clone();
         config.max_position_embeddings = 1000;
         let tokenizer = base.tokenizer.clone().with_max_seq_len(5);
-        EmbeddingModel::new(
-            base.weights.clone(),
+        EmbeddingModel {
+            weights: base.weights.clone(),
             config,
-            base.vision_weights.clone(),
+            vision_weights: base.vision_weights.clone(),
             tokenizer,
-        )
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1408.

## The bug

`POST /v1/embeddings` silently truncates input between 4097 and 8192 tokens, embeds the
prefix, and returns 200. The rejection path that is supposed to catch over-long input is
unreachable.

Two limits disagree, and the guard reads the wrong side of the disagreement:

- the admission guard compares against `min(max_position_embeddings, 8192)`, which is 8192
  for the Qwen3.5 checkpoints (`max_position_embeddings = 262144`)
- the tokenizer the embeddings path builds was capped at `DEFAULT_BPE_MAX_SEQ_LEN` (4096),
  because it was constructed without `with_max_seq_len`

The guard then compared a **post**-truncation count against the window. A post-truncation
count can never exceed 4096, and the window is 8192, so the two ranges do not overlap and
the rejection is unreachable by construction. Input in that band is truncated by the
tokenizer, embedded from its prefix, and returned as a success.

The failure is silent in the worst direction: the caller receives a 200 and a
well-formed, correctly normalized vector that represents only the first part of its input.

## The fix

1. Cap the embeddings tokenizer to mirror the admission window
   (`.with_max_seq_len(config.max_position_embeddings.min(8192))`), so truncation and
   rejection coincide rather than straddling a gap.
2. Admit on the **pre**-truncation count, so an over-window item is rejected instead of
   being silently shortened.
3. Keep `usage.prompt_tokens` reporting the count actually embedded, not the count
   submitted. These are deliberately different numbers: admission is about what the caller
   sent, usage is about what the server did.

The second commit is a follow-up with no behavioural change: the text branch was calling
`tokenize()` twice per item, once for each count, when a single `TokenizedInput` already
carries both `real_length` and `pre_truncation_len`. It now tokenizes once and destructures
both, matching the shape already used elsewhere in the crate. Same two numbers reach the
same two call sites.

## Tests

Two regression tests, both against a fixture whose context window (1000) sits above its
tokenizer cap (995), which is the configuration that makes the gap expressible:

- `embed_items_rejects_text_item_whose_pre_truncation_length_exceeds_a_window_above_the_tokenizer_cap`
- `embed_items_accepted_prompt_tokens_matches_the_count_actually_embedded_when_truncated`

**Correction to an earlier version of this description.** It said both tests were
"checked for mutation sensitivity", which overstated the coverage. The mutation check
reverted the *admission-count* change and both tests reddened, so that property is
genuinely guarded. It did not cover the *tokenizer cap* at the loader: both tests build
their model through `EmbeddingModel::new` and set `.with_max_seq_len(5)` on their own
fixture, so reverting the production cap line leaves them green. This change has more than
one property and the mutation ranged over one of them.

The follow-up has now landed at this head. It adds one mutation arm per property and
closes the two further defects: the public `EmbeddingModel::new` now enforces the same
cap invariant the loader establishes (every constructor routes through it), and
`lattice-embed`'s `VisionEmbeddingModel` — which constructed the same tokenizer
uncapped — now enforces the identical pre-truncation admission on its own public
surface. `VisionEmbeddingModel::embed_text`, `embed_image`, and `embed_image_metal`
all reject input whose pre-truncation token count — plus, for the image entry points,
the scaffold tokens the image itself consumes (two delimiters + the merged-patch
pads) — exceeds `min(max_position_embeddings, 8192)`, returning
`EmbedError::InvalidInput` naming both counts. Previously `embed_text` silently
truncated exactly like the wire path did, and the two image entry points (whose
`prompt` parameter is unrestricted, unlike the wire route's image branch, which always
passes an empty prompt) had the same hole.

One pre-existing test changed its expectation as a direct consequence of the fix:
`embed_text_maps_context_overflow_to_inference_failed` asserted that an over-window
prompt fails deep inside the forward pass as `InferenceFailed` — the behaviour this
change removes. It is now `embed_text_rejects_prompt_exceeding_context_window_before_truncation`,
same fixture and input, asserting the admission rejection.

Mutation coverage at this head, per property, each arm observed red then restored green:

- removing the admission call in `embed_text` reddens its rejection test;
- removing the admission + scaffold-reserve calls in `embed_image` (and separately in
  `embed_image_metal`) reddens each rejection test;
- flipping the boundary comparison (`>` to `>=`) reddens both exactly-at-window
  acceptance tests (text and image).

The one arm not independently testable is `embed_image_metal` succeeding exactly at the
boundary: proving it requires a Metal ViT dispatch on a real device. Its admission call
is textually identical to `embed_image`'s and runs before the CPU/Metal dispatch fork,
and the metal rejection test proves the dispatch is unreached when admission fails.

Gates run at the final head: `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`,
doc lint, `cargo test -p lattice-embed --lib` (341 passed, includes all `vision::tests`),
`cargo test -p lattice-inference --lib serve::embeddings::tests::`.

## bench-compare disposition

No A/B table. This is the structural-waiver case, and the argument is an absent call path,
not a compiled-out module — `serve` is in `lattice-inference`'s default feature set
(`default = ["std", "download", "serve"]`), so the changed code **is** compiled into the
bench binaries. Compilation is not the predicate; reachability is.

Population searched: all 32 declared bench targets in the workspace, enumerated two ways
that agree — the `[[bench]]` tables across every `crates/*/Cargo.toml`, and the 32
`crates/*/benches/*.rs` files on disk. Not the two targets a default A/B run would cover.

Result: zero of the 32 reach `serve::embeddings`. No bench source names
`serve::embeddings`, `embed_items`, `tokenize_lengths`, `tokenize_len`, or
`check_item_fits_window`. The search reaches those files — 27 of the 32 match `criterion`
in the same invocation shape, so an empty result is a real absence rather than a broken
query.

The same search covers the second changed file (`crates/embed/src/vision.rs`): zero bench
sources reference `VisionEmbeddingModel`, `embed_text_vlm_f16`, `embed_image_from_bytes`,
`preprocess_qwen35_image`, or `pooled_embed` (22 `criterion` matches in the same traversal
as the control). `crates/embed/benches/embeddings.rs` benchmarks only the plain vector-math
utilities in `lattice_embed::utils`, not the VLM path.

The nearest miss is worth naming, because it looks like a hit and is not:
`crates/inference/benches/tokenizer_bench.rs` imports
`lattice_inference::{BpeTokenizer, Tokenizer, WordPieceTokenizer}` — the tokenizer types
directly. This change alters a tokenizer *construction site* inside the embeddings module;
it does not touch `BpeTokenizer`'s own code, so that bench times identical executed code at
both base and head. Likewise `crates/embed/benches/embeddings.rs` imports
`lattice_embed::utils`, a different crate.

Build inputs are identical between base and head: the diff touches exactly two files
(`crates/inference/src/serve/embeddings.rs` and `crates/embed/src/vision.rs`), with no
manifest, lockfile, feature, profile, build-script, or bench-target-definition change.
That is what makes the waiver available at all; a build-input change has no absent call
path to name.

Residual risk, stated rather than implied: an unreachable change is not a safe change, it is
an unmeasured one. The added work on the request path is one extra comparison per item and,
after the second commit, one fewer `tokenize()` call than the first commit performed. On the
library path, `embed_text` gains one extra tokenize pass per call, and the image entry points
gain one extra image-preprocessing pass per call (the same duplicate-preprocessing shape the
wire route already uses for its usage accounting) so admission can run before the expensive
ViT forward. Nothing in the bench suite would show any of these.

