### PR TITLE
bench(harness): allow selecting the lattice-embed bench target and features, gated by an explicit calibration allowlist

### DIFF
--- a/scripts/lib/bench-compare-impl.sh
+++ b/scripts/lib/bench-compare-impl.sh
@@ -21,6 +21,8 @@
 # Optional Criterion filters:
 #   BENCH_GROUPS_INFERENCE="rms_norm|gelu" scripts/bench-compare.sh
 #   BENCH_GROUPS_EMBED="simd_dot_product|int8_raw" scripts/bench-compare.sh
+# Optional bench target selection:
+#   BENCHES_EMBED="embeddings" CARGO_FEATURES_EMBED="native" scripts/bench-compare.sh
 # Unset filters run all groups in the default bench targets:
 #   lattice-inference: elementwise_cpu_bench
 #   lattice-embed: simd
@@ -49,8 +51,11 @@
 # scripts/perf-bench-gate.py --selftest); their benchmarks are still fully
 # measured and rendered — the informational section plus the
 # all-measurements table record every number — but classified informational,
-# so they cannot produce a FAIL verdict. Every non-demoted target this script
-# benches (the lattice-inference one) is classified gating in --quick.
+# so they cannot produce a FAIL verdict. This manifest is only the quick-noise
+# policy. Independently, the embed configuration calibration allowlist below
+# keeps every uncalibrated target/feature pair informational at BOTH
+# resolutions. A quick-mode embed result gates only if its exact configuration
+# is calibrated and its target is absent from the quick-noise manifest.
 #
 # Criterion 0.5 permits `/` in group names and uses the same character to join
 # group/function/parameter in `--list`, so a flat listing cannot recover the
@@ -61,13 +66,15 @@
 # guessed string prefix, and same-named groups in different targets cannot
 # affect one another.
 #
-# --full applies no informational demotion: every group it benches is
-# classified gating, simd included. Every invocation brackets its measurements
-# in ABBA order (base₁, head₁, head₂, base₂); the gate combines the forward and
-# reverse ratios in log space and widens the result by the measured order-bias
-# envelope. Report-only controls only whether the verdict is propagated, not
-# which evidence is collected. Three caveats keep full mode from meaning "a
-# regression cannot get past this".
+# --full disables the quick-noise manifest only. It does not grant an
+# uncalibrated embed configuration gating authority: exact default `simd` with
+# no feature override gates at full resolution, while any configuration absent
+# from the calibration allowlist remains informational. Every invocation
+# brackets its measurements in ABBA order (base₁, head₁, head₂, base₂); the gate
+# combines the forward and reverse ratios in log space and widens the result by
+# the measured order-bias envelope. Report-only controls only whether the
+# verdict is propagated, not which evidence is collected. Three caveats keep
+# full mode from meaning "a regression cannot get past this".
 #
 # Enforcement: neither mode enforces BY DEFAULT. The gate's exit status is
 # captured into GATE_RC at the bottom and re-raised only under
@@ -83,11 +90,17 @@
 # `make bench-gate` runs the same two default targets unfiltered against the
 # perf-baselines branch and returns perf-bench-gate.py's status directly.
 #
-# Scope: this script benches two targets, not the workspace's full bench set
-# — lattice-inference:$BENCHES_INFERENCE (default elementwise_cpu_bench) and
-# lattice-embed:simd. The optional BENCH_GROUPS_* filters above narrow it
-# further, so a filtered --full run classifies only the selected groups of
-# those two.
+# Scope: this script benches two caller-selectable targets, not the workspace's
+# full bench set — lattice-inference:$BENCHES_INFERENCE (default
+# elementwise_cpu_bench) and lattice-embed:$BENCHES_EMBED (default simd). The
+# optional BENCH_GROUPS_* filters above narrow it further, so a filtered --full
+# run classifies only the selected groups of those two.
+#
+# A non-default embed target or feature selection is measured and reported
+# informationally at both resolutions until its exact configuration is added to
+# the explicit full-gate calibration predicate below with reviewed A/A evidence.
+# Selecting a target widens the instrument; existence gives it no gating
+# authority.
 #
 # Automation: bench-update.yml runs those targets at full resolution on main
 # — on every push touching the perf paths (which include embed's simd source
@@ -441,26 +454,39 @@ cleanup() {
 trap cleanup EXIT
 
 # --- Bench list (same as ADR-058 Phase 1) ---
-# BENCHES_INFERENCE / CARGO_FEATURES_INFERENCE are overridable so a PR can
-# point this script at a different inference bench target (e.g. one gated
-# behind `bench-internals`) without hand-rolling a separate A/B script.
+# BENCHES_INFERENCE / BENCHES_EMBED are overridable so a PR can point this
+# script at a different existing bench target without hand-rolling a separate
+# A/B script. The matching CARGO_FEATURES_* value supports targets gated behind
+# crate features and is passed as one exact `--features` argument in every arm.
 BENCHES_INFERENCE="${BENCHES_INFERENCE:-elementwise_cpu_bench}"
 CARGO_FEATURES_INFERENCE="${CARGO_FEATURES_INFERENCE:-}"
-BENCHES_EMBED="simd"
+BENCHES_EMBED="${BENCHES_EMBED:-simd}"
+CARGO_FEATURES_EMBED="${CARGO_FEATURES_EMBED:-}"
 BENCH_GROUPS_INFERENCE="${BENCH_GROUPS_INFERENCE:-}"
 BENCH_GROUPS_EMBED="${BENCH_GROUPS_EMBED:-}"
 BENCH_BASELINE_NAME="compare-base"
 BENCH_HEAD_BASELINE_NAME="compare-head"
 
+# Full-resolution gating is an allowlist because choosing another target or
+# feature selection changes the instrument before any benchmark function
+# executes. Additions require reviewed same-configuration A/A calibration and
+# threshold evidence under ADR-087 D3/D5; otherwise the target remains
+# informational at every resolution.
+embed_configuration_has_full_gate_calibration() {
+  case "$1|$2" in
+    'simd|') return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Keep Criterion evidence target-qualified without giving up Cargo's shared
 # compilation target. CRITERION_HOME controls only Criterion's report/baseline
 # tree; Cargo continues to use each worktree's normal target directory.
 #
-# Root paths are keyed by BENCH TARGET, not just by crate: BENCHES_INFERENCE
-# is caller-overridable (BENCHES_EMBED is a fixed "simd" today, keyed the same
-# way for consistency should that change), so two runs that pick different
-# targets must never share a directory — Criterion's own report tree keys by
-# group/function only, and two different bench targets can and do declare
+# Root paths are keyed by BENCH TARGET, not just by crate: both target names
+# are caller-overridable, so two runs that pick different targets must never
+# share a directory — Criterion's own report tree keys by group/function only,
+# and two different bench targets can and do declare
 # same-named or different groups into what would otherwise be one shared
 # directory. A target name reaches the filesystem as a path component here,
 # so it is sanitized first: anything outside [A-Za-z0-9._-] becomes '_', and
@@ -618,7 +644,7 @@ BASE_PHASE_RC=0
     require_measured "base lattice-inference:$BENCHES_INFERENCE build (--no-run)" 1
     echo "  ($BENCHES_INFERENCE not present on $BASE_SHA — skipping)"
   fi
-  run_bench "time:" env CRITERION_HOME="$BASE_EMBED_CRITERION_ROOT" cargo bench --locked -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --save-baseline "$BENCH_BASELINE_NAME" --noplot $QUICK_FLAGS
+  run_bench "time:" env CRITERION_HOME="$BASE_EMBED_CRITERION_ROOT" cargo bench --locked -p lattice-embed --bench "$BENCHES_EMBED" ${CARGO_FEATURES_EMBED:+--features "$CARGO_FEATURES_EMBED"} -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --save-baseline "$BENCH_BASELINE_NAME" --noplot $QUICK_FLAGS
   require_measured "base lattice-embed:$BENCHES_EMBED" "$BENCH_RC" "$BENCH_LINES"
 ) || BASE_PHASE_RC=$?
 # `exit` inside `( ... )` leaves the SUBSHELL, so the status has to be caught
@@ -687,7 +713,7 @@ HEAD_PHASE_RC=0
     require_measured "head lattice-inference:$BENCHES_INFERENCE build (--no-run)" 1
     echo "  ($BENCHES_INFERENCE not present on $HEAD_SHA — skipping)"
   fi
-  run_bench "time:|change:" env CRITERION_HOME="$EMBED_CRITERION_ROOT" cargo bench --locked -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --baseline "$BENCH_BASELINE_NAME" --noplot $QUICK_FLAGS
+  run_bench "time:|change:" env CRITERION_HOME="$EMBED_CRITERION_ROOT" cargo bench --locked -p lattice-embed --bench "$BENCHES_EMBED" ${CARGO_FEATURES_EMBED:+--features "$CARGO_FEATURES_EMBED"} -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --baseline "$BENCH_BASELINE_NAME" --noplot $QUICK_FLAGS
   require_measured "head lattice-embed:$BENCHES_EMBED" "$BENCH_RC" "$BENCH_LINES"
 ) || HEAD_PHASE_RC=$?
 if [ "$HEAD_PHASE_RC" -ne 0 ]; then exit "$HEAD_PHASE_RC"; fi
@@ -703,7 +729,7 @@ HEAD_CONTROL_PHASE_RC=0
   cd "$HEAD_DIR"
   run_bench "time:" env CRITERION_HOME="$HEAD_CONTROL_INFERENCE_CRITERION_ROOT" cargo bench --locked -p lattice-inference --bench "$BENCHES_INFERENCE" ${CARGO_FEATURES_INFERENCE:+--features "$CARGO_FEATURES_INFERENCE"} -- ${BENCH_GROUPS_INFERENCE:+"$BENCH_GROUPS_INFERENCE"} --save-baseline "$BENCH_HEAD_BASELINE_NAME" --noplot $QUICK_FLAGS
   require_measured "head control lattice-inference:$BENCHES_INFERENCE" "$BENCH_RC" "$BENCH_LINES"
-  run_bench "time:" env CRITERION_HOME="$HEAD_CONTROL_EMBED_CRITERION_ROOT" cargo bench --locked -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --save-baseline "$BENCH_HEAD_BASELINE_NAME" --noplot $QUICK_FLAGS
+  run_bench "time:" env CRITERION_HOME="$HEAD_CONTROL_EMBED_CRITERION_ROOT" cargo bench --locked -p lattice-embed --bench "$BENCHES_EMBED" ${CARGO_FEATURES_EMBED:+--features "$CARGO_FEATURES_EMBED"} -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --save-baseline "$BENCH_HEAD_BASELINE_NAME" --noplot $QUICK_FLAGS
   require_measured "head control lattice-embed:$BENCHES_EMBED" "$BENCH_RC" "$BENCH_LINES"
 ) || HEAD_CONTROL_PHASE_RC=$?
 if [ "$HEAD_CONTROL_PHASE_RC" -ne 0 ]; then exit "$HEAD_CONTROL_PHASE_RC"; fi
@@ -726,7 +752,7 @@ BASE_CONTROL_PHASE_RC=0
   cd "$WT"
   run_bench "time:|change:" env CRITERION_HOME="$BASE_CONTROL_INFERENCE_CRITERION_ROOT" cargo bench --locked -p lattice-inference --bench "$BENCHES_INFERENCE" ${CARGO_FEATURES_INFERENCE:+--features "$CARGO_FEATURES_INFERENCE"} -- ${BENCH_GROUPS_INFERENCE:+"$BENCH_GROUPS_INFERENCE"} --baseline "$BENCH_HEAD_BASELINE_NAME" --noplot $QUICK_FLAGS
   require_measured "base control lattice-inference:$BENCHES_INFERENCE" "$BENCH_RC" "$BENCH_LINES"
-  run_bench "time:|change:" env CRITERION_HOME="$BASE_CONTROL_EMBED_CRITERION_ROOT" cargo bench --locked -p lattice-embed --bench "$BENCHES_EMBED" -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --baseline "$BENCH_HEAD_BASELINE_NAME" --noplot $QUICK_FLAGS
+  run_bench "time:|change:" env CRITERION_HOME="$BASE_CONTROL_EMBED_CRITERION_ROOT" cargo bench --locked -p lattice-embed --bench "$BENCHES_EMBED" ${CARGO_FEATURES_EMBED:+--features "$CARGO_FEATURES_EMBED"} -- ${BENCH_GROUPS_EMBED:+"$BENCH_GROUPS_EMBED"} --baseline "$BENCH_HEAD_BASELINE_NAME" --noplot $QUICK_FLAGS
   require_measured "base control lattice-embed:$BENCHES_EMBED" "$BENCH_RC" "$BENCH_LINES"
 ) || BASE_CONTROL_PHASE_RC=$?
 if [ "$BASE_CONTROL_PHASE_RC" -ne 0 ]; then exit "$BASE_CONTROL_PHASE_RC"; fi
@@ -750,7 +776,7 @@ write_run_provenance() {
 
   mkdir -p "$(dirname "$PROVENANCE_FILE")"
   {
-    printf 'schema=lattice-bench-provenance-v1\n'
+    printf 'schema=lattice-bench-provenance-v2\n'
     printf 'started_utc=%s\n' "$RUN_STARTED_UTC"
     printf 'finished_utc=%s\n' "$finished_utc"
     printf 'host_id=%s\n' "$RUN_HOST_ID"
@@ -771,6 +797,7 @@ write_run_provenance() {
     printf 'targets=lattice-inference:%s, lattice-embed:%s\n' \
       "$BENCHES_INFERENCE" "$BENCHES_EMBED"
     printf 'inference_features=%s\n' "${CARGO_FEATURES_INFERENCE:-<none>}"
+    printf 'embed_features=%s\n' "${CARGO_FEATURES_EMBED:-<none>}"
     printf "filters=inference='%s' embed='%s'\n" \
       "${BENCH_GROUPS_INFERENCE:-<all>}" "${BENCH_GROUPS_EMBED:-<all>}"
     printf 'enforcement=%s\n' "$enforcement"
@@ -802,6 +829,7 @@ print_execution_provenance
 echo "  resolution: ${QUICK_FLAGS:---full}"
 echo "  targets: lattice-inference:$BENCHES_INFERENCE, lattice-embed:$BENCHES_EMBED"
 echo "  inference features: ${CARGO_FEATURES_INFERENCE:-<none>}"
+echo "  embed features: ${CARGO_FEATURES_EMBED:-<none>}"
 echo "  filters: inference='${BENCH_GROUPS_INFERENCE:-<all>}' embed='${BENCH_GROUPS_EMBED:-<all>}'"
 echo "  enforcement: $([ "$FAIL_ON_REGRESSION" = "1" ] && echo "--fail-on-regression (regression status propagated)" || echo "report-only (regressions reported; measurement failures still refuse)")"
 echo "  arm order: ABBA (base₁ → head₁ → head₂ → base₂)"
@@ -931,7 +959,13 @@ run_target_gate() {
     --order-control-baseline-name "$BENCH_HEAD_BASELINE_NAME"
   )
 
-  if [ -n "$QUICK_FLAGS" ]; then
+  if [[ "$target" == lattice-embed:* ]] &&
+     ! embed_configuration_has_full_gate_calibration \
+         "${target#lattice-embed:}" "$CARGO_FEATURES_EMBED"; then
+    # A selected target that has not calibrated this gate is still useful
+    # measurement evidence, but cannot vote at either resolution.
+    gate_args+=(--informational-target "$target")
+  elif [ -n "$QUICK_FLAGS" ]; then
     if "$REPO/scripts/lib/bench-informational-targets.sh" \
          --is-informational "$target"; then
       gate_args+=(--informational-target "$target")

--- a/scripts/lib/bench-informational-targets.sh
+++ b/scripts/lib/bench-informational-targets.sh
@@ -7,19 +7,23 @@
 # therefore stays at the policy's real unit: the `<crate>:<bench-target>` key.
 # bench-compare gives each target its own CRITERION_HOME and passes that exact
 # key to perf-bench-gate.py; this helper only answers whether the target is in
-# the reviewed quick-mode demotion manifest.
+# the reviewed quick-mode noise-demotion manifest. It does not decide whether
+# an embed target/feature pair has full-gate calibration; bench-compare's
+# independent configuration allowlist owns that policy at both resolutions.
 #
 # `--print-targets` emits the normalized manifest for the selftest. The
 # `--is-informational <target>` predicate exits 0 for a listed target and 1 for
 # an unlisted target. Invalid manifest input exits 2, so malformed suppression
 # policy cannot silently broaden the informational set.
 #
-# FULL mode (`bench-compare.sh --full`, or `make bench-gate`) ignores this
-# mechanism entirely: every group those paths bench is classified gating,
-# with no demotion. Classification is not enforcement — `bench-compare.sh`
+# FULL mode (`bench-compare.sh --full`, or `make bench-gate`) ignores THIS
+# quick-noise mechanism. It still consults bench-compare's independent embed
+# configuration calibration allowlist: exact default `simd` with no feature
+# override may gate, while uncalibrated target/feature pairs remain
+# informational. Classification is not enforcement — `bench-compare.sh`
 # discards its gate's exit status unless the caller passes
 # --fail-on-regression, so a FAIL verdict becomes a non-zero exit only under
-# that flag or via `make bench-gate`. Both bench the same two targets rather
+# that flag or via `make bench-gate`. Both bench two selected targets rather
 # than the workspace's full bench set, and --full additionally honors
 # bench-compare.sh's BENCH_GROUPS_* filters.
 #

--- a/scripts/lib/bench-quick-informational-targets.txt
+++ b/scripts/lib/bench-quick-informational-targets.txt
@@ -5,20 +5,25 @@
 # Format: one `<crate>:<bench-target>` key per line; `#` starts a comment.
 # scripts/lib/bench-informational-targets.sh (the production shell path) and
 # scripts/perf-bench-gate.py --selftest (the validator) both read THIS file.
-# There is no other copy of the demoted-target set anywhere.
+# There is no other copy of this quick-noise demoted-target set anywhere. The
+# independent embed configuration calibration allowlist lives in
+# bench-compare-impl.sh; it is not a second copy of this policy and applies at
+# both resolutions.
 #
 # Semantics: in QUICK mode, every Criterion benchmark of a listed target is
 # reported informationally — fully measured, rendered in the report's
 # informational section and the all-measurements table, excluded only from
 # the gating verdict and exit code. FULL mode (`scripts/bench-compare.sh
-# --full`, or `make bench-gate` against the perf-baselines branch) ignores
-# this manifest: every group those paths bench is classified gating at full
-# resolution (--full also honors bench-compare.sh's BENCH_GROUPS_* filters,
-# and neither path covers the workspace's full bench set). Being classified
-# gating is not the same as being enforced: bench-compare.sh discards its
-# gate's exit status unless the caller passes --fail-on-regression, so a FAIL
-# verdict becomes a non-zero exit only under that flag or via
-# `make bench-gate`.
+# --full`, or `make bench-gate` against the perf-baselines branch) ignores THIS
+# quick-noise manifest. Full resolution still consults the independent embed
+# configuration calibration allowlist: exact default `simd` with no feature
+# override is eligible to gate, while an uncalibrated target/feature pair stays
+# informational. (`--full` also honors bench-compare.sh's BENCH_GROUPS_*
+# filters, and neither path covers the workspace's full bench set.) Being
+# classified gating is not the same as being enforced: bench-compare.sh
+# discards its gate's exit status unless the caller passes
+# --fail-on-regression, so a FAIL verdict becomes a non-zero exit only under
+# that flag or via `make bench-gate`.
 #
 # Two automated jobs bench these targets at full resolution on main.
 # bench-update.yml runs on perf-path pushes and weekly and saves the
@@ -27,9 +32,11 @@
 # on a regression, so it REPORTS. perf-postmerge-gate.yml runs
 # `bench-compare.sh --full --fail-on-regression` on perf-path merges,
 # against the merged commit's own parent, and fails on a confirmed
-# regression, so it ENFORCES. A demoted target is therefore reported AND
-# enforced at full resolution; the demotion only removes it from the quick
-# mode gate. Targets not listed here are classified gating in quick mode.
+# regression, so it ENFORCES. Under those jobs' default embed configuration,
+# `simd` is therefore reported AND enforced at full resolution; this manifest
+# removes it only from the quick-mode gate. A target absent from this manifest
+# is not automatically gating: an embed configuration must also appear in the
+# independent calibration allowlist.
 #
 # bench-compare keeps each target's Criterion data in a separate output root.
 # That target boundary is required: Criterion permits `/` in group names and

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -53,16 +53,21 @@ writes an atomic perf-bench-gate-status/v1 document. Ambient refusal is checked
 before the final exit/status verdict, so exit 3 outranks pass or regression for
 every target in the run. Excessive order bias is the other exit-3 cause.
 
---informational-target (lattice#714): quick-mode Criterion runs on
-sub-microsecond micro-benches (lattice-embed's `simd` bench target) are
-dominated by scheduler/thermal jitter rather than code changes — confirmed
-by two same-toolchain quick-mode A/A runs on identical refs flipping FAIL/
-WARN sign across dozens of entries (lattice#714). bench-compare isolates each
-bench target in its own Criterion output root, passes that root's exact target
-key through --target, and marks the key informational only when the reviewed
-manifest says so. Every result in that root is still measured and reported,
-but excluded from the FAIL/WARN gate and exit code. Full mode omits
---informational-target, so every result gates normally.
+--informational-target: bench-compare isolates each bench target in its own
+Criterion output root and passes that root's exact key through --target. A
+reviewed caller policy may mark that same key informational: the quick-mode
+noise-demotion manifest does this for lattice-embed's `simd` target (#714),
+and the embed target/feature calibration allowlist does it at either resolution
+for selected configurations that have not calibrated the gate. Every result in
+an informational root is still measured and reported, but excluded from the
+FAIL/WARN verdict and exit code. This classifier validates exact target identity;
+the caller owns the policy decision to withhold gating authority.
+
+Run provenance is schema-versioned. New bench-compare runs write
+lattice-bench-provenance-v2, where embed_features is required. The reader also
+accepts legacy v1, which predates embed feature selection and therefore
+normalizes that absent concept to embed_features=<none> for display. A v1 record
+that contains embed_features is rejected rather than silently redefining v1.
 """
 
 from __future__ import annotations
@@ -89,7 +94,8 @@ except ImportError:
 if sys.version_info[:2] < (3, 11):
     raise SystemExit(_PYTHON_REQUIREMENT_ERROR)
 
-PROVENANCE_SCHEMA = "lattice-bench-provenance-v1"
+PROVENANCE_SCHEMA_V1 = "lattice-bench-provenance-v1"
+PROVENANCE_SCHEMA_V2 = "lattice-bench-provenance-v2"
 MACHINE_STATE_SCHEMA = "lattice-machine-state-v1"
 PHASE_LABELS = ("before first arm", "between order strata", "after final arm")
 PROVENANCE_FIELDS = (
@@ -112,9 +118,17 @@ PROVENANCE_FIELDS = (
     "baseline_name",
     "targets",
     "inference_features",
+    "embed_features",
     "filters",
     "enforcement",
 )
+PROVENANCE_V1_FIELDS = tuple(
+    field for field in PROVENANCE_FIELDS if field != "embed_features"
+)
+PROVENANCE_FIELDS_BY_SCHEMA = {
+    PROVENANCE_SCHEMA_V1: PROVENANCE_V1_FIELDS,
+    PROVENANCE_SCHEMA_V2: PROVENANCE_FIELDS,
+}
 
 # Thresholds — ADR-058 §D3. Edit here; the workflow imports nothing else.
 #
@@ -514,6 +528,7 @@ def order_balance_results(
 
 @dataclass(frozen=True)
 class RunProvenance:
+    schema: str
     fields: dict[str, str]
     locks: tuple[str, ...]
     ambient_samples: tuple[str, ...]
@@ -689,14 +704,27 @@ def load_run_provenance(path: Path) -> RunProvenance:
         else:
             fields[key] = value
 
-    if fields.get("schema") != PROVENANCE_SCHEMA:
+    schema = fields.get("schema")
+    if schema not in PROVENANCE_FIELDS_BY_SCHEMA:
         raise ValueError(
-            f"{path}: schema must be {PROVENANCE_SCHEMA!r}, got "
-            f"{fields.get('schema')!r}"
+            f"{path}: schema must be one of "
+            f"{tuple(PROVENANCE_FIELDS_BY_SCHEMA)!r}, got {schema!r}"
         )
-    missing = [field for field in PROVENANCE_FIELDS if field not in fields]
+    schema_fields = PROVENANCE_FIELDS_BY_SCHEMA[schema]
+    unexpected = sorted(set(fields) - {"schema", *schema_fields})
+    if unexpected:
+        raise ValueError(
+            f"{path}: {schema} does not allow provenance fields: "
+            f"{', '.join(unexpected)}"
+        )
+    missing = [field for field in schema_fields if field not in fields]
     if missing:
         raise ValueError(f"{path}: missing provenance fields: {', '.join(missing)}")
+    if schema == PROVENANCE_SCHEMA_V1:
+        # v1 predates embed target feature selection. Its only representable
+        # meaning is the legacy default, so normalize that historical meaning
+        # for the v2-shaped report without accepting a v2 field under v1.
+        fields["embed_features"] = "<none>"
     started = parse_utc_timestamp(fields["started_utc"], "started_utc")
     finished = parse_utc_timestamp(fields["finished_utc"], "finished_utc")
     if finished < started:
@@ -799,6 +827,7 @@ def load_run_provenance(path: Path) -> RunProvenance:
 
     fields.pop("schema")
     return RunProvenance(
+        schema=schema,
         fields=fields,
         locks=tuple(repeated["lock"]),
         ambient_samples=tuple(repeated["ambient"]),
@@ -1302,6 +1331,7 @@ def render_run_provenance(
         )
         lines.append("")
     else:
+        lines.append(f"    schema={provenance.schema}")
         blocked_checkpoints = [
             state for state in provenance.machine_states
             if state.get("gate", {}).get("status") == "blocked"
@@ -1450,9 +1480,8 @@ def render_report(results: list[BenchResult], arch: str, target: str | None = No
 
     if info:
         lines.append(
-            f"**ℹ️ {len(info)} informational** (below quick-mode resolution — "
-            f"lattice-embed SIMD micro-benches, tracked in #714; not gated here, "
-            f"re-run `--full` for a gated verdict)"
+            f"**ℹ️ {len(info)} informational** (explicit target policy; "
+            f"measured and reported, excluded from the verdict)"
         )
         if decision_suppressed_reason is None and (
             info_fails or info_warns or info_unattributable or info_wins
@@ -1537,8 +1566,8 @@ def render_report(results: list[BenchResult], arch: str, target: str | None = No
         )
     if informational_target is not None:
         lines.append(
-            f"_Target `{informational_target}` classified informational-only in quick mode "
-            f"(lattice#714); its {len(info)} measurement(s) are excluded from the verdict._\n"
+            f"_Target `{informational_target}` classified informational-only by explicit "
+            f"target policy; its {len(info)} measurement(s) are excluded from the verdict._\n"
         )
     else:
         lines.append("")
@@ -2592,6 +2621,7 @@ def run_selftest() -> int:
             "baseline_name": "compare-base",
             "targets": "lattice-inference:fixture",
             "inference_features": "<none>",
+            "embed_features": "<none>",
             "filters": "inference='<all>' embed='<all>'",
             "enforcement": "fail-on-regression",
         }
@@ -2650,7 +2680,7 @@ def run_selftest() -> int:
             },
         ]
         provenance_lines = [
-            f"schema={PROVENANCE_SCHEMA}",
+            "schema=lattice-bench-provenance-v2",
             *[f"{field}={provenance_fields[field]}" for field in PROVENANCE_FIELDS],
             "lock=bench-window: acquired",
             "lock=Metal GPU: acquired",
@@ -2683,6 +2713,7 @@ def run_selftest() -> int:
             )
         for expected in (
             "<summary>Run provenance</summary>",
+            "schema=lattice-bench-provenance-v2",
             "host_id=hostname-sha256:0123456789abcdef",
             "criterion_base_samples=4 Linear (1 benchmark)",
             "criterion_head_samples=2 Flat (1 benchmark)",
@@ -2697,6 +2728,96 @@ def run_selftest() -> int:
                 failures.append(
                     f"run-provenance: stored report omitted {expected!r}"
                 )
+
+        legacy_v1_path = Path(td) / "legacy-v1-provenance.txt"
+        legacy_v1_path.write_text(
+            "\n".join(
+                "schema=lattice-bench-provenance-v1"
+                if line.startswith("schema=")
+                else line
+                for line in provenance_lines
+                if not line.startswith("embed_features=")
+            )
+            + "\n"
+        )
+        legacy_v1_run = _run(
+            provenance_root,
+            "--provenance-file",
+            str(legacy_v1_path),
+            "--require-provenance",
+        )
+        if (
+            legacy_v1_run.returncode != 0
+            or "schema=lattice-bench-provenance-v1" not in legacy_v1_run.stdout
+            or "embed_features=<none>" not in legacy_v1_run.stdout
+        ):
+            failures.append(
+                "run-provenance: legacy v1 was not accepted with the "
+                "deterministic embed_features=<none> default"
+            )
+        else:
+            print(
+                "SCHEMA PROOF: legacy provenance v1 accepted and rendered "
+                "with embed_features=<none>"
+            )
+
+        v1_with_v2_field_path = Path(td) / "v1-with-v2-field-provenance.txt"
+        v1_with_v2_field_path.write_text(
+            "\n".join(
+                "schema=lattice-bench-provenance-v1"
+                if line.startswith("schema=")
+                else line
+                for line in provenance_lines
+            )
+            + "\n"
+        )
+        v1_with_v2_field_run = _run(
+            provenance_root,
+            "--provenance-file",
+            str(v1_with_v2_field_path),
+            "--require-provenance",
+        )
+        if (
+            v1_with_v2_field_run.returncode != 2
+            or "v1 does not allow provenance fields: embed_features"
+            not in v1_with_v2_field_run.stderr
+        ):
+            failures.append(
+                "run-provenance: v1 silently accepted the v2 embed_features field"
+            )
+        else:
+            print(
+                "SCHEMA PROOF: provenance v1 rejects the v2-only "
+                "embed_features field"
+            )
+
+        incomplete_v2_path = Path(td) / "incomplete-v2-provenance.txt"
+        incomplete_v2_path.write_text(
+            "\n".join(
+                line
+                for line in provenance_lines
+                if not line.startswith("embed_features=")
+            )
+            + "\n"
+        )
+        incomplete_v2_run = _run(
+            provenance_root,
+            "--provenance-file",
+            str(incomplete_v2_path),
+            "--require-provenance",
+        )
+        if (
+            incomplete_v2_run.returncode != 2
+            or "missing provenance fields: embed_features"
+            not in incomplete_v2_run.stderr
+        ):
+            failures.append(
+                "run-provenance: v2 accepted a missing embed_features field"
+            )
+        else:
+            print(
+                "SCHEMA PROOF: provenance v2 requires embed_features"
+            )
 
         darwin_ungated = Path(td) / "darwin-ungated-provenance.txt"
         darwin_ungated.write_text(
@@ -2904,8 +3025,8 @@ def run_selftest() -> int:
           "slash-bearing group, demoted target informational, non-demoted target gated), "
           "require-measurements (empty root, gating pass, explicit informational target, "
           "mismatch refusal, partial-run refusal), ABBA directional-drift correction, "
-          "malformed reverse-number refusal, selected-baseline completeness, and "
-          "stale-head freshness all correct")
+          "malformed reverse-number refusal, selected-baseline completeness, provenance "
+          "v1/v2 compatibility, and stale-head freshness all correct")
     return 0
 
 
@@ -2924,7 +3045,7 @@ def main() -> int:
                          "root. bench-compare passes this for every target.")
     ap.add_argument("--informational-target",
                     help="Classify this exact target as informational-only. Must equal --target; "
-                         "omit for gating/full-mode runs.")
+                         "the caller owns the reviewed policy decision.")
     ap.add_argument("--resolution", choices=("quick", "full"), default="full",
                     help="Measurement resolution used for verdict classification "
                          "(default: full).")
@@ -2952,7 +3073,8 @@ def main() -> int:
                          "No report is generated.")
     ap.add_argument("--provenance-file", type=Path,
                     help="Strict bench-compare key=value provenance handoff to embed in the "
-                         "Markdown report.")
+                         "Markdown report. Accepts legacy v1 and current v2; v1 defaults "
+                         "the then-unrepresented embed_features field to <none>.")
     ap.add_argument("--require-provenance", action="store_true",
                     help="Fail (exit 2) unless complete run provenance and actual Criterion "
                          "base/head sample metadata are available.")

--- a/tests/test_bench_compare_measurement.py
+++ b/tests/test_bench_compare_measurement.py
@@ -17,6 +17,7 @@ shape that used to pass.
 import importlib.util
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -153,6 +154,13 @@ set -euo pipefail
 if [[ "${1:-}" == "--version" ]]; then
   printf '%s\n' 'cargo 1.94.1 (fixture)'
   exit 0
+fi
+
+if [[ -n "${STUB_CARGO_ARGV_FILE:-}" ]]; then
+  {
+    printf '%q ' "$@"
+    printf '\n'
+  } >> "$STUB_CARGO_ARGV_FILE"
 fi
 
 if [[ "${1:-}" == "bench" && "${STUB_REQUIRE_LOCKED:-0}" == "1" ]]; then
@@ -319,6 +327,17 @@ elif [[ "$scenario" == "true-regression" ]]; then
   reverse_point="-0.15"
   reverse_low="-0.152"
   reverse_high="-0.148"
+elif [[ "$scenario" == "stable" ]]; then
+  a1="100.0"
+  b1="100.0"
+  b2="100.0"
+  a2="100.0"
+  forward_point="0.0"
+  forward_low="-0.001"
+  forward_high="0.001"
+  reverse_point="0.0"
+  reverse_low="-0.001"
+  reverse_high="0.001"
 else
   printf 'unknown STUB_SCENARIO=%s\n' "$scenario" >&2
   exit 9
@@ -408,9 +427,9 @@ def _run(
         # crates/<crate>/benches/<target>.rs from the checked-out worktree, so
         # the fixture needs stub sources declaring the same groups the stub
         # cargo fixtures above write results for (rms_norm, simd_dot_product).
-        # Every test defaults to BENCHES_INFERENCE=elementwise_cpu_bench and
-        # BENCHES_EMBED=simd (none override them), so one fixed pair covers
-        # the whole file.
+        # Tests default to BENCHES_INFERENCE=elementwise_cpu_bench and
+        # BENCHES_EMBED=simd. Override cases add and commit their selected
+        # target's fixture source before the detached worktrees are created.
         inference_benches = root / "crates" / "inference" / "benches"
         inference_benches.mkdir(parents=True)
         (inference_benches / "elementwise_cpu_bench.rs").write_text(
@@ -490,6 +509,37 @@ def _run(
         if post_run is not None:
             post_run(root)
         return result
+
+
+def _add_embeddings_bench_source(root):
+    # The cargo fixtures fabricate simd_dot_product for every embed target,
+    # so the selected source declares that group for the harness's
+    # declared-vs-measured reconciliation step.
+    path = root / "crates" / "embed" / "benches" / "embeddings.rs"
+    path.write_text('let mut group = c.benchmark_group("simd_dot_product");\n')
+    subprocess.run(
+        [*GIT, "-C", str(root), "add", "-f", str(path)], check=True
+    )
+    subprocess.run(
+        [*GIT, "-C", str(root), "commit", "-qm", "add embeddings fixture"],
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+        },
+    )
+
+
+def _captured_embed_argv(path):
+    invocations = [shlex.split(line) for line in path.read_text().splitlines()]
+    return [
+        argv
+        for argv in invocations
+        if "-p" in argv
+        and argv.index("-p") + 1 < len(argv)
+        and argv[argv.index("-p") + 1] == "lattice-embed"
+    ]
 
 
 class ClearSelectedBaselineArtifactsSiblingPrune(unittest.TestCase):
@@ -1384,6 +1434,149 @@ class BenchCompareMeasurementGuard(unittest.TestCase):
             f"different BENCHES_INFERENCE values shared a root: "
             f"{inference_first} vs {inference_second}",
         )
+
+    def test_embed_bench_target_honors_caller_override(self):
+        """BENCHES_EMBED selects an existing embed target for the whole run.
+
+        Mutation-sensitive: restore the pre-fix bare ``BENCHES_EMBED="simd"``
+        assignment and all four captured embed commands and roots remain keyed
+        by ``simd`` rather than the caller-selected ``embeddings`` target.
+        """
+        with tempfile.TemporaryDirectory() as temporary:
+            argv_file = Path(temporary) / "cargo-argv.txt"
+            result = _run(
+                [],
+                stub_cargo=STALE_CHANGE_CARGO,
+                emit_criterion_home=True,
+                extra_env={
+                    "BENCHES_EMBED": "embeddings",
+                    "STUB_CARGO_ARGV_FILE": str(argv_file),
+                },
+                setup=_add_embeddings_bench_source,
+            )
+            embed_argv = _captured_embed_argv(argv_file)
+        self.assertEqual(
+            result.returncode, 0,
+            f"embed target override failed\nstdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}",
+        )
+        self.assertEqual(len(embed_argv), 4, embed_argv)
+        for argv in embed_argv:
+            bench_index = argv.index("--bench")
+            self.assertEqual(argv[bench_index + 1], "embeddings", argv)
+            self.assertNotIn("simd", argv)
+            self.assertNotIn("--features", argv)
+        roots = set(re.findall(r"criterion-home=(\S+)", result.stdout))
+        embed_roots = {path for path in roots if "/embed/" in path}
+        self.assertEqual(
+            len(embed_roots), 4,
+            f"expected one embed root per ABBA phase, saw {embed_roots}\n"
+            f"stdout:\n{result.stdout}",
+        )
+        self.assertTrue(
+            all("/embed/embeddings/criterion" in path for path in embed_roots),
+            embed_roots,
+        )
+        self.assertIn(
+            "targets: lattice-inference:elementwise_cpu_bench, "
+            "lattice-embed:embeddings",
+            result.stdout,
+        )
+        self.assertIn("embed features: <none>", result.stdout)
+        self.assertIn("embed_features=<none>", result.stdout)
+
+    def test_embed_features_reach_all_four_abba_commands_and_provenance(self):
+        """CARGO_FEATURES_EMBED is one exact argv value in every embed arm."""
+        with tempfile.TemporaryDirectory() as temporary:
+            argv_file = Path(temporary) / "cargo-argv.txt"
+            captured_provenance = []
+
+            def capture_provenance(root):
+                captured_provenance.append(
+                    (root / ".cache" / "bench-run-provenance.txt").read_text()
+                )
+
+            result = _run(
+                [],
+                stub_cargo=STALE_CHANGE_CARGO,
+                extra_env={
+                    "BENCHES_EMBED": "embeddings",
+                    "CARGO_FEATURES_EMBED": "native,prepared-bench",
+                    "STUB_CARGO_ARGV_FILE": str(argv_file),
+                },
+                setup=_add_embeddings_bench_source,
+                post_run=capture_provenance,
+            )
+            embed_argv = _captured_embed_argv(argv_file)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(embed_argv), 4, embed_argv)
+        for argv in embed_argv:
+            self.assertEqual(argv.count("--features"), 1, argv)
+            feature_index = argv.index("--features")
+            self.assertEqual(argv[feature_index + 1], "native,prepared-bench", argv)
+        self.assertIn("embed features: native,prepared-bench", result.stdout)
+        self.assertIn("embed_features=native,prepared-bench", result.stdout)
+        self.assertEqual(len(captured_provenance), 1)
+        self.assertTrue(
+            captured_provenance[0].startswith(
+                "schema=lattice-bench-provenance-v2\n"
+            ),
+            captured_provenance[0],
+        )
+
+    def test_uncalibrated_embed_target_is_informational_at_every_resolution(self):
+        """A custom embed target cannot inherit simd's calibrated full gate.
+
+        Mutation-sensitive: classify every selected embed target as calibrated
+        and the fabricated +20% custom-target regression exits 1 in both quick
+        and full enforcing modes.
+        """
+        for flags, resolution in (([], "quick"), (["--full"], "full")):
+            with self.subTest(resolution=resolution):
+                with tempfile.TemporaryDirectory() as temporary:
+                    order_file = Path(temporary) / "order.txt"
+                    result = _run(
+                        [*flags, "--fail-on-regression"],
+                        stub_cargo=ORDER_BALANCE_CARGO,
+                        extra_env={
+                            "BENCHES_EMBED": "embeddings",
+                            "STUB_ORDER_FILE": str(order_file),
+                            "STUB_INFERENCE_SCENARIO": "stable",
+                            "STUB_EMBED_SCENARIO": "true-regression",
+                        },
+                        setup=_add_embeddings_bench_source,
+                    )
+                self.assertEqual(
+                    result.returncode, 0,
+                    f"uncalibrated {resolution} target voted on a regression\n"
+                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+                )
+                self.assertIn("**ℹ️ 1 informational**", result.stdout)
+                self.assertIn("explicit target policy", result.stdout)
+                self.assertNotIn("re-run `--full` for a gated verdict", result.stdout)
+                self.assertNotIn("informational-only in quick mode", result.stdout)
+                self.assertNotIn("gate reported a confirmed regression", result.stderr)
+
+    def test_feature_changed_default_embed_target_is_not_calibrated(self):
+        """Full-gate calibration binds the target and feature selection."""
+        with tempfile.TemporaryDirectory() as temporary:
+            order_file = Path(temporary) / "order.txt"
+            result = _run(
+                ["--full", "--fail-on-regression"],
+                stub_cargo=ORDER_BALANCE_CARGO,
+                extra_env={
+                    "CARGO_FEATURES_EMBED": "native,local",
+                    "STUB_ORDER_FILE": str(order_file),
+                    "STUB_INFERENCE_SCENARIO": "stable",
+                    "STUB_EMBED_SCENARIO": "true-regression",
+                },
+            )
+        self.assertEqual(
+            result.returncode, 0,
+            "a feature-modified simd target inherited the default instrument's "
+            f"full gate\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        self.assertIn("**ℹ️ 1 informational**", result.stdout)
 
 
 class _FailOnEmptyTestProgram(unittest.TestProgram):

--- a/tests/test_bench_locks.py
+++ b/tests/test_bench_locks.py
@@ -475,7 +475,7 @@ class RunProvenanceHandoff(unittest.TestCase):
             lines = provenance.read_text().splitlines()
 
             for prefix in (
-                "schema=lattice-bench-provenance-v1",
+                "schema=lattice-bench-provenance-v2",
                 "started_utc=",
                 "finished_utc=",
                 "host_id=local-random:",
@@ -495,6 +495,7 @@ class RunProvenanceHandoff(unittest.TestCase):
                 "baseline_name=compare-base",
                 "targets=lattice-inference:elementwise_cpu_bench, lattice-embed:simd",
                 "inference_features=<none>",
+                "embed_features=<none>",
                 "filters=inference='<all>' embed='<all>'",
                 "enforcement=report-only",
                 "lock=",


### PR DESCRIPTION
## Summary

- Let `scripts/bench-compare.sh` honor a caller-supplied `BENCHES_EMBED` target.
- Add `CARGO_FEATURES_EMBED` and pass its exact value through all four embed ABBA arms.
- Preserve `simd` with no feature override as the exact default and only currently calibrated full-gating embed configuration.
- Keep uncalibrated target/feature pairs informational at both quick and full resolution until reviewed same-configuration A/A evidence exists.
- Version run provenance as v2 with required `embed_features`, while strictly accepting and normalizing legacy v1 records.
- Keep every base/head and reverse-order Criterion root keyed by the selected embed target and prove the actual Cargo argv uses that target.

This is an independently safe ADR-087 harness improvement. It is not part of the proposed ADR-088 implementation stack, but it unblocks target-specific A/B evidence for later prepared load/embed slices.

## TDD evidence

- RED: with `BENCHES_EMBED=embeddings`, all four embed ABBA roots still used `/embed/simd/criterion` because the script overwrote the caller value.
- RED: a custom target or feature-modified `simd` configuration could cast a gating vote without calibration; embed features were absent from all four Cargo invocations and provenance.
- RED: making `embed_features` required under the unchanged strict v1 schema broke compatibility with every existing v1 handoff.
- GREEN: `${BENCHES_EMBED:-simd}` preserves the default; the exact target and one quoted feature value reach all four Cargo commands; only `simd|<empty>` is calibrated; provenance v2 is strict and legacy v1 deterministically normalizes to `embed_features=<none>`.
- Mutation sensitivity: the suite catches restoring the hard-coded target, dropping feature propagation from any one arm, broadening calibration to a custom configuration, treating feature-modified `simd` as calibrated, and restoring stale quick-only informational-policy prose.

## Test plan

- [x] `python3 tests/test_bench_compare_measurement.py` — 32 passed
- [x] focused selection/calibration/provenance measurement tests — 4 passed
- [x] `python3 tests/test_bench_locks.py -v` — 40 passed
- [x] focused provenance handoff test — 1 passed
- [x] `python3 tests/test_bench_targets.py -v` — 6 passed
- [x] `python3 scripts/perf-bench-gate.py --selftest`
- [x] `bash -n scripts/lib/bench-compare-impl.sh`
- [x] `bash -n scripts/lib/bench-informational-targets.sh`
- [x] repository pre-commit checks
- [x] `git diff --check`

No real Criterion measurement was run. This changes benchmark orchestration, configuration classification, and provenance—not benchmarked production code. Executable behavior is covered by the hermetic Python/shell harness, and the normal repository pre-commit checks passed.

## Bench-compare disposition

The default measurement target and feature set remain equivalent for callers that do not set the new variables. Selecting an existing target widens the instrument but does not grant it gating authority: only the reviewed `simd` + empty-features tuple can gate at full resolution today. Quick-noise demotion and full-gate calibration remain separate, explicit policies.

The provenance schema changes from v1 to v2 because feature selection is now part of the run identity. The reader accepts the exact historical v1 field set, renders its actual schema, and supplies only the one historically representable default (`embed_features=<none>`); mixed-schema and incomplete-v2 records fail closed.

## AI-assisted contribution checklist

- [x] PR body starts with the required attribution
- [x] Default `simd` automation behavior is regression-guarded
- [x] Override behavior is mutation-sensitive and checks all four embed roots and Cargo argv vectors
- [x] Uncalibrated target/feature configurations cannot return a regression status
- [x] Independent final review: 0 Blocker, 0 High, 0 Medium

