### PR TITLE
feat(inference): add checked SafeTensors framing facts

### DIFF
--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -1098,6 +1098,11 @@ pub(crate) const MAX_WEIGHT_MAP_ENTRIES: usize = 1_000_000;
 /// not error handling downstream of the allocation.
 const MAX_SAFETENSORS_HEADER_BYTES: usize = 4_194_304;
 
+/// Crate-private compatibility ceiling for dormant prepared framing checks.
+pub(crate) const fn max_safetensors_header_bytes() -> usize {
+    MAX_SAFETENSORS_HEADER_BYTES
+}
+
 /// Upper bound on JSON container nesting depth (`{` / `[`) while parsing a safetensors
 /// header, tracked by [`JsonParser::depth`] and enforced in [`JsonParser::skip_value`].
 ///

--- a/crates/inference/src/weights/mod.rs
+++ b/crates/inference/src/weights/mod.rs
@@ -5,6 +5,8 @@ pub mod f32_weights;
 pub(crate) mod half_bits;
 pub(crate) mod ingress;
 pub(crate) mod mmap_trust;
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) mod prepared_safetensors;
 pub mod q3_weights;
 pub mod q4_weights;
 pub mod q8_weights;

--- a/crates/inference/src/weights/prepared_safetensors.rs
+++ b/crates/inference/src/weights/prepared_safetensors.rs
@@ -1,0 +1,453 @@
+//! Dormant SafeTensors framing facts for sealed native preparation.
+//!
+//! This module is a pure scalar planner. It performs no I/O, allocation,
+//! mapping, JSON parsing, or tensor/layout validation and has no live caller.
+//! A successful plan is not an inspected or trusted checkpoint, does not bind
+//! bytes to an opened handle, and provides no TOCTOU protection or admission
+//! lease. A later reader must obtain the prefix and declared length from the
+//! same bounded handle, read exactly the planned header range, and separately
+//! validate the complete inventory before mapping or loading.
+
+use std::num::NonZeroU64;
+use std::ops::Range;
+
+/// Prepared mode cannot admit a header the existing ADR-003 loader rejects.
+pub(crate) const PREPARED_SAFETENSORS_HARD_MAX_HEADER_BYTES: u64 =
+    super::f32_weights::max_safetensors_header_bytes() as u64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PreparedSafetensorsSizeAxis {
+    WeightFileBytes,
+    HeaderBytes,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PreparedSafetensorsHeaderError {
+    Exceeded {
+        axis: PreparedSafetensorsSizeAxis,
+        actual: u64,
+        limit: u64,
+    },
+    PlatformUnrepresentable {
+        axis: PreparedSafetensorsSizeAxis,
+        value: u64,
+    },
+    HeaderFrameExceedsFileLimit {
+        header_frame: u64,
+        file_limit: u64,
+    },
+    FileTooShort {
+        declared_file_len: u64,
+    },
+    EmptyHeader,
+    HeaderFrameOverflow {
+        header_len: u64,
+    },
+    HeaderPastEnd {
+        header_end: u64,
+        declared_file_len: u64,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PreparedSafetensorsFramingLimits {
+    max_weight_file_bytes: NonZeroU64,
+    max_header_bytes: NonZeroU64,
+    platform_span_max: u64,
+}
+
+impl PreparedSafetensorsFramingLimits {
+    pub(crate) fn try_new(
+        max_weight_file_bytes: NonZeroU64,
+        max_header_bytes: NonZeroU64,
+    ) -> Result<Self, PreparedSafetensorsHeaderError> {
+        let usize_max = u64::try_from(usize::MAX).unwrap_or(u64::MAX);
+        let isize_max = u64::try_from(isize::MAX).unwrap_or(u64::MAX);
+        let platform_span_max = usize_max.min(isize_max);
+        Self::try_new_with_platform_max(max_weight_file_bytes, max_header_bytes, platform_span_max)
+    }
+
+    fn try_new_with_platform_max(
+        max_weight_file_bytes: NonZeroU64,
+        max_header_bytes: NonZeroU64,
+        platform_span_max: u64,
+    ) -> Result<Self, PreparedSafetensorsHeaderError> {
+        let file_limit = max_weight_file_bytes.get();
+        let header_limit = max_header_bytes.get();
+
+        if header_limit > PREPARED_SAFETENSORS_HARD_MAX_HEADER_BYTES {
+            return Err(PreparedSafetensorsHeaderError::Exceeded {
+                axis: PreparedSafetensorsSizeAxis::HeaderBytes,
+                actual: header_limit,
+                limit: PREPARED_SAFETENSORS_HARD_MAX_HEADER_BYTES,
+            });
+        }
+        validate_platform(
+            PreparedSafetensorsSizeAxis::WeightFileBytes,
+            file_limit,
+            platform_span_max,
+        )?;
+        validate_platform(
+            PreparedSafetensorsSizeAxis::HeaderBytes,
+            header_limit,
+            platform_span_max,
+        )?;
+        let header_frame = checked_header_end(header_limit)?;
+        if header_frame > file_limit {
+            return Err(
+                PreparedSafetensorsHeaderError::HeaderFrameExceedsFileLimit {
+                    header_frame,
+                    file_limit,
+                },
+            );
+        }
+
+        Ok(Self {
+            max_weight_file_bytes,
+            max_header_bytes,
+            platform_span_max,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PreparedSafetensorsHeaderPlan {
+    declared_file_len: usize,
+    header_len: usize,
+    header_end: usize,
+    data_len: usize,
+}
+
+impl PreparedSafetensorsHeaderPlan {
+    pub(crate) fn declared_file_len(&self) -> usize {
+        self.declared_file_len
+    }
+
+    pub(crate) fn header_len(&self) -> usize {
+        self.header_len
+    }
+
+    pub(crate) fn header_end(&self) -> usize {
+        self.header_end
+    }
+
+    pub(crate) fn data_len(&self) -> usize {
+        self.data_len
+    }
+
+    pub(crate) fn header_range(&self) -> Range<usize> {
+        8..self.header_end
+    }
+
+    pub(crate) fn data_range(&self) -> Range<usize> {
+        self.header_end..self.declared_file_len
+    }
+}
+
+pub(crate) fn plan_prepared_safetensors_header(
+    prefix: [u8; 8],
+    declared_file_len: u64,
+    limits: &PreparedSafetensorsFramingLimits,
+) -> Result<PreparedSafetensorsHeaderPlan, PreparedSafetensorsHeaderError> {
+    if declared_file_len > limits.max_weight_file_bytes.get() {
+        return Err(PreparedSafetensorsHeaderError::Exceeded {
+            axis: PreparedSafetensorsSizeAxis::WeightFileBytes,
+            actual: declared_file_len,
+            limit: limits.max_weight_file_bytes.get(),
+        });
+    }
+    validate_platform(
+        PreparedSafetensorsSizeAxis::WeightFileBytes,
+        declared_file_len,
+        limits.platform_span_max,
+    )?;
+    if declared_file_len < 8 {
+        return Err(PreparedSafetensorsHeaderError::FileTooShort { declared_file_len });
+    }
+
+    let header_len = u64::from_le_bytes(prefix);
+    if header_len > limits.max_header_bytes.get() {
+        return Err(PreparedSafetensorsHeaderError::Exceeded {
+            axis: PreparedSafetensorsSizeAxis::HeaderBytes,
+            actual: header_len,
+            limit: limits.max_header_bytes.get(),
+        });
+    }
+    validate_platform(
+        PreparedSafetensorsSizeAxis::HeaderBytes,
+        header_len,
+        limits.platform_span_max,
+    )?;
+    if header_len == 0 {
+        return Err(PreparedSafetensorsHeaderError::EmptyHeader);
+    }
+    let header_end = checked_header_end(header_len)?;
+    if header_end > declared_file_len {
+        return Err(PreparedSafetensorsHeaderError::HeaderPastEnd {
+            header_end,
+            declared_file_len,
+        });
+    }
+    let data_len = declared_file_len.checked_sub(header_end).ok_or(
+        PreparedSafetensorsHeaderError::HeaderPastEnd {
+            header_end,
+            declared_file_len,
+        },
+    )?;
+
+    Ok(PreparedSafetensorsHeaderPlan {
+        declared_file_len: to_usize(
+            PreparedSafetensorsSizeAxis::WeightFileBytes,
+            declared_file_len,
+        )?,
+        header_len: to_usize(PreparedSafetensorsSizeAxis::HeaderBytes, header_len)?,
+        header_end: to_usize(PreparedSafetensorsSizeAxis::HeaderBytes, header_end)?,
+        data_len: to_usize(PreparedSafetensorsSizeAxis::WeightFileBytes, data_len)?,
+    })
+}
+
+fn validate_platform(
+    axis: PreparedSafetensorsSizeAxis,
+    value: u64,
+    platform_max: u64,
+) -> Result<(), PreparedSafetensorsHeaderError> {
+    if value > platform_max {
+        return Err(PreparedSafetensorsHeaderError::PlatformUnrepresentable { axis, value });
+    }
+    Ok(())
+}
+
+fn checked_header_end(header_len: u64) -> Result<u64, PreparedSafetensorsHeaderError> {
+    8_u64
+        .checked_add(header_len)
+        .ok_or(PreparedSafetensorsHeaderError::HeaderFrameOverflow { header_len })
+}
+
+fn to_usize(
+    axis: PreparedSafetensorsSizeAxis,
+    value: u64,
+) -> Result<usize, PreparedSafetensorsHeaderError> {
+    usize::try_from(value)
+        .map_err(|_| PreparedSafetensorsHeaderError::PlatformUnrepresentable { axis, value })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn nz(value: u64) -> NonZeroU64 {
+        NonZeroU64::new(value).unwrap()
+    }
+
+    fn limits(file: u64, header: u64) -> PreparedSafetensorsFramingLimits {
+        PreparedSafetensorsFramingLimits::try_new(nz(file), nz(header)).unwrap()
+    }
+
+    fn prefix(header_len: u64) -> [u8; 8] {
+        header_len.to_le_bytes()
+    }
+
+    #[test]
+    fn exact_bounds_produce_exact_scalar_ranges() {
+        let plan = plan_prepared_safetensors_header(prefix(8), 24, &limits(24, 8)).unwrap();
+
+        assert_eq!(plan.declared_file_len(), 24);
+        assert_eq!(plan.header_len(), 8);
+        assert_eq!(plan.header_end(), 16);
+        assert_eq!(plan.data_len(), 8);
+        assert_eq!(plan.header_range(), 8..16);
+        assert_eq!(plan.data_range(), 16..24);
+    }
+
+    #[test]
+    fn limit_constructor_pins_hard_cap_platform_and_frame_relation() {
+        let hard = PREPARED_SAFETENSORS_HARD_MAX_HEADER_BYTES;
+        let span_max = u64::try_from(isize::MAX).unwrap();
+        assert_eq!(hard, 4_194_304, "prepared ADR-003 cap is an exact golden");
+        assert!(PreparedSafetensorsFramingLimits::try_new(nz(hard + 8), nz(hard)).is_ok());
+        assert!(PreparedSafetensorsFramingLimits::try_new(nz(span_max), nz(1)).is_ok());
+        assert_eq!(
+            PreparedSafetensorsFramingLimits::try_new(nz(span_max + 1), nz(1)).unwrap_err(),
+            PreparedSafetensorsHeaderError::PlatformUnrepresentable {
+                axis: PreparedSafetensorsSizeAxis::WeightFileBytes,
+                value: span_max + 1,
+            }
+        );
+        assert_eq!(
+            PreparedSafetensorsFramingLimits::try_new(nz(hard + 9), nz(hard + 1)).unwrap_err(),
+            PreparedSafetensorsHeaderError::Exceeded {
+                axis: PreparedSafetensorsSizeAxis::HeaderBytes,
+                actual: hard + 1,
+                limit: hard,
+            }
+        );
+        assert_eq!(
+            PreparedSafetensorsFramingLimits::try_new_with_platform_max(
+                nz(hard + 9),
+                nz(hard + 1),
+                hard,
+            )
+            .unwrap_err(),
+            PreparedSafetensorsHeaderError::Exceeded {
+                axis: PreparedSafetensorsSizeAxis::HeaderBytes,
+                actual: hard + 1,
+                limit: hard,
+            },
+            "absolute ADR-003 cap precedes synthetic platform and relation failures",
+        );
+        assert_eq!(
+            PreparedSafetensorsFramingLimits::try_new(nz(15), nz(8)).unwrap_err(),
+            PreparedSafetensorsHeaderError::HeaderFrameExceedsFileLimit {
+                header_frame: 16,
+                file_limit: 15,
+            }
+        );
+
+        assert!(
+            PreparedSafetensorsFramingLimits::try_new_with_platform_max(nz(32), nz(24), 32,)
+                .is_ok()
+        );
+        assert_eq!(
+            PreparedSafetensorsFramingLimits::try_new_with_platform_max(nz(33), nz(24), 32)
+                .unwrap_err(),
+            PreparedSafetensorsHeaderError::PlatformUnrepresentable {
+                axis: PreparedSafetensorsSizeAxis::WeightFileBytes,
+                value: 33,
+            }
+        );
+        assert_eq!(
+            PreparedSafetensorsFramingLimits::try_new_with_platform_max(nz(34), nz(25), 24)
+                .unwrap_err(),
+            PreparedSafetensorsHeaderError::PlatformUnrepresentable {
+                axis: PreparedSafetensorsSizeAxis::WeightFileBytes,
+                value: 34,
+            }
+        );
+        assert_eq!(
+            PreparedSafetensorsFramingLimits::try_new_with_platform_max(nz(24), nz(17), 16)
+                .unwrap_err(),
+            PreparedSafetensorsHeaderError::PlatformUnrepresentable {
+                axis: PreparedSafetensorsSizeAxis::WeightFileBytes,
+                value: 24,
+            }
+        );
+        assert_eq!(
+            PreparedSafetensorsFramingLimits::try_new_with_platform_max(nz(24), nz(25), 24)
+                .unwrap_err(),
+            PreparedSafetensorsHeaderError::PlatformUnrepresentable {
+                axis: PreparedSafetensorsSizeAxis::HeaderBytes,
+                value: 25,
+            },
+            "header span platform failure precedes the relation failure",
+        );
+    }
+
+    #[test]
+    fn checked_header_frame_arithmetic_has_exact_overflow_boundary() {
+        assert_eq!(checked_header_end(u64::MAX - 8), Ok(u64::MAX));
+        assert_eq!(
+            checked_header_end(u64::MAX - 7),
+            Err(PreparedSafetensorsHeaderError::HeaderFrameOverflow {
+                header_len: u64::MAX - 7,
+            })
+        );
+        assert_eq!(
+            checked_header_end(u64::MAX),
+            Err(PreparedSafetensorsHeaderError::HeaderFrameOverflow {
+                header_len: u64::MAX,
+            })
+        );
+    }
+
+    #[test]
+    fn little_endian_prefix_is_the_only_header_length_authority() {
+        let expected = 0x0000_0000_0001_0203_u64;
+        let plan = plan_prepared_safetensors_header(
+            [0x03, 0x02, 0x01, 0, 0, 0, 0, 0],
+            8 + expected,
+            &limits(8 + expected, expected),
+        )
+        .unwrap();
+        assert_eq!(plan.header_len(), usize::try_from(expected).unwrap());
+    }
+
+    #[test]
+    fn actual_file_and_header_caps_accept_exact_and_reject_plus_one() {
+        let bounded = limits(24, 8);
+        assert!(plan_prepared_safetensors_header(prefix(8), 24, &bounded).is_ok());
+        assert_eq!(
+            plan_prepared_safetensors_header(prefix(8), 25, &bounded).unwrap_err(),
+            PreparedSafetensorsHeaderError::Exceeded {
+                axis: PreparedSafetensorsSizeAxis::WeightFileBytes,
+                actual: 25,
+                limit: 24,
+            }
+        );
+        assert_eq!(
+            plan_prepared_safetensors_header(prefix(9), 24, &bounded).unwrap_err(),
+            PreparedSafetensorsHeaderError::Exceeded {
+                axis: PreparedSafetensorsSizeAxis::HeaderBytes,
+                actual: 9,
+                limit: 8,
+            }
+        );
+    }
+
+    #[test]
+    fn framing_rejects_short_file_empty_header_and_header_past_end() {
+        let bounded = limits(32, 16);
+        assert_eq!(
+            plan_prepared_safetensors_header(prefix(1), 7, &bounded).unwrap_err(),
+            PreparedSafetensorsHeaderError::FileTooShort {
+                declared_file_len: 7,
+            }
+        );
+        assert_eq!(
+            plan_prepared_safetensors_header(prefix(u64::MAX), 7, &bounded).unwrap_err(),
+            PreparedSafetensorsHeaderError::FileTooShort {
+                declared_file_len: 7,
+            },
+            "an impossible-to-read prefix cannot outrank physical framing",
+        );
+        assert_eq!(
+            plan_prepared_safetensors_header(prefix(0), 8, &bounded).unwrap_err(),
+            PreparedSafetensorsHeaderError::EmptyHeader
+        );
+        assert_eq!(
+            plan_prepared_safetensors_header(prefix(16), 23, &bounded).unwrap_err(),
+            PreparedSafetensorsHeaderError::HeaderPastEnd {
+                header_end: 24,
+                declared_file_len: 23,
+            }
+        );
+    }
+
+    #[test]
+    fn cap_errors_win_before_later_prefix_or_extent_checks() {
+        let bounded = limits(24, 8);
+        assert_eq!(
+            plan_prepared_safetensors_header(prefix(u64::MAX), 25, &bounded).unwrap_err(),
+            PreparedSafetensorsHeaderError::Exceeded {
+                axis: PreparedSafetensorsSizeAxis::WeightFileBytes,
+                actual: 25,
+                limit: 24,
+            }
+        );
+        assert_eq!(
+            plan_prepared_safetensors_header(prefix(9), 8, &bounded).unwrap_err(),
+            PreparedSafetensorsHeaderError::Exceeded {
+                axis: PreparedSafetensorsSizeAxis::HeaderBytes,
+                actual: 9,
+                limit: 8,
+            }
+        );
+    }
+
+    #[test]
+    fn header_may_consume_the_file_and_leave_empty_data() {
+        let plan = plan_prepared_safetensors_header(prefix(2), 10, &limits(10, 2)).unwrap();
+        assert_eq!(plan.header_range(), 8..10);
+        assert_eq!(plan.data_range(), 10..10);
+        assert_eq!(plan.data_len(), 0);
+    }
+}


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Draft / governance gate

This stacked implementation PR remains **Draft** while ADR-088 is Proposed. It must not merge before ADR-088 is accepted and the earlier stack dependencies are ready. It adds no public or doc-hidden API and does not activate prepared loading, attestation, or any downstream migration.

Stacked on #1422 at base `ecf92f6b5331664cbc365cc1836d5ef341c1a14b`.

Frozen framing-module SHA-256: `265424bba29808f1206b9d8dad32f7975deec729be8cb58fca4e0997a05376b8`.

## Summary

- add a dormant, crate-private scalar planner for SafeTensors prefix/header framing
- derive the prepared 4 MiB hard cap through a new inert crate-private accessor to the unchanged legacy loader constant
- validate caller file/header ceilings against the hard cap, `min(usize::MAX, isize::MAX)`, and checked `8 + max_header_bytes <= max_weight_file_bytes`
- decode the exact eight-byte little-endian header length and produce checked header/data ranges
- pin typed failure precedence for caller caps, platform span, short files, empty headers, arithmetic overflow, and headers extending past the declared file

## Safety and scope boundary

The production helper performs no I/O, allocation, mmap, JSON parsing, tensor/layout validation, model loading, or serving work. It has no live production caller.

A successful plan is not an inspected or trusted checkpoint. It does not bind the prefix and declared length to one opened handle, provide TOCTOU protection, acquire an admission lease, read header bytes, validate an inventory, or authorize mapping or loading.

## Legacy hazards deliberately unchanged

This PR neither changes nor blesses the existing `SafetensorsFile` path as prepared admission:

- the live legacy parser still converts the untrusted `u64` header length with `as usize` before ADR-088 caller/platform validation
- the live loader still maps or owns the complete backing before parsing the header
- legacy metadata materialization is not governed by ADR-088 caller ceilings for tensor count, decoded-name bytes, rank, dimensions, retained metadata, or parse-work bytes
- legacy loading, error behavior, and benchmark call paths remain unchanged

Those are activation gates for a later same-handle bounded reader/parser, not claims made by this framing-only slice.

## TDD and mutation evidence

The compile-first RED exited 101 with 25 planned missing-symbol errors and one unused-import warning. The final focused suite is GREEN at 8/8.

Nine production mutations were applied individually, observed RED, and restored:

1. little-endian prefix decoding → big-endian decoding
2. actual file-cap comparison `>` → `>=`
3. configured header-frame/file-limit comparison `>` → `>=`
4. platform-span selection `min` → `max`
5. absolute 4 MiB hard-cap comparison `>` → `>=`
6. short-file boundary `< 8` → `< 7`
7. actual header past-end comparison `>` → `>=`
8. checked header-end addition → wrapping addition
9. data-range start `header_end` → `header_end + 1`

## Verification

```text
Focused prepared_safetensors tests
8 passed; 0 failed

RUSTC_WRAPPER= cargo test -p lattice-inference --lib -j4 --quiet
2,646 passed; 17 ignored; 0 failed
41.15s

RUSTC_WRAPPER= cargo clippy -p lattice-inference --lib --tests -j4 -- -D warnings
PASS

cargo fmt --all -- --check
PASS

git diff --check
PASS

repository pre-commit hook
PASS
```

All-target/all-feature clippy was also attempted. It remains blocked only by eight pre-existing, unrelated GPU/WGPU lints:

- `forward/gpu/inner/dims.rs`: two `manual_is_multiple_of`
- `forward/gpu/inner/util.rs`: one `manual_div_ceil`
- `forward/gpu_gemm.rs`: one `redundant_closure`, two `manual_div_ceil`, one `manual_slice_size_calculation`, and one `manual_is_multiple_of`

This PR does not modify those paths. A final independent read-only review found 0 Blocker, 0 High, and 0 Medium findings on the frozen diff.

## bench-compare disposition

Evaluated at PR head `8bd4a23c5ef24cd4016c5b46cc4b1cacca2ccace` against the 25-target `lattice-inference` benchmark surface at base `ecf92f6b5331664cbc365cc1836d5ef341c1a14b`. This statement is void if either ref moves.

The diff changes no manifest, dependency or lockfile version, feature set, profile, build script, generated source, benchmark definition, or harness input.

The reached-file changes are additive only:

- `weights/mod.rs` adds one crate-private dormant module item and modifies no existing item
- `f32_weights.rs` adds one inert crate-private `const fn` accessor over the unchanged legacy hard-cap constant and modifies no existing item
- the new module contains only crate-private scalar data/functions, one compile-time constant, and `cfg(test)` tests; it adds no global/static initializer, allocator, linker/codegen attribute, macro, unsafe code, trait implementation on an existing type, or production callsite

None of the 25 declared benchmark targets reaches the new planner or accessor at runtime.

Ungated targets inspected: `differential_attention_bench`, `native_sparse_attention_bench`, `gated_attention_bench`, `inference_bench`, `tokenizer_bench`, `e2e_bench`, `inference_perf`, `topk_readback`, `quarot_hadamard_bench`, `lm_head_bench`, `elementwise_cpu_bench`, `grammar_mask_bench`, `elementwise_bench`, `attn_opt_bench`, `metrics_bench`, `pruning_bench`, `kv_cache_f16_bench`, and `attention_dispatch_bench`.

Feature-gated targets inspected: `decode_attn_bench` (`f16`), `kv_cache_layout_bench` (`bench-internals`), `metal_decode_bench` (`metal-gpu`, `f16`), `cross_turn_prefix_cache_bench` (`metal-gpu`, `f16`), `mtp_decode` (`metal-gpu`, `f16`), `backward_stage0` (`train-backward`), and `f16_convert_bench` (`bench-internals`).

`e2e_bench` reaches the unchanged legacy BERT loader, and `f16_convert_bench` reaches the unchanged legacy `SafetensorsFile` path; neither reaches the new framing planner or accessor. Runtime cost is therefore **unmeasured, not performance-neutral**. The first same-handle reader, parser, mapper, or loader callsite must re-evaluate reachability and provide targeted measurement before activation.

## Out of scope / gates before activation

- same-handle length/prefix acquisition and exact bounded header reads
- cursor-position and no-payload-read proofs
- UTF-8, strict JSON, padding, duplicate-key, dtype, shape, and range validation
- deterministic complete-inventory construction
- tensor/name/rank/dimension/metadata/parse-work accounting
- translation from ADR-088 preparation limits and resource leases
- required-BERT name, layer, shape, pooler, and cross-artifact validation
- snapshot copying, short/growth probes, mmap/alignment disposition, model loading, publication, and serving


## Child draft

- #1424 — bounded dormant SafeTensors inventory facts
