### PR TITLE
feat(inference): select prepared BERT tokenizer layout

### DIFF
--- a/crates/inference/src/model/bert.rs
+++ b/crates/inference/src/model/bert.rs
@@ -29,6 +29,9 @@ mod prepared_config;
 #[cfg_attr(not(test), allow(dead_code))]
 mod prepared_tensor_inventory;
 
+#[cfg_attr(not(test), allow(dead_code))]
+mod prepared_tokenizer_selection;
+
 /// Per-layer fused Q/K/V weight+bias, built once at model-load time from a
 /// `TransformerLayerWeights` layer's separate `query`/`key`/`value` tensors.
 ///

--- a/crates/inference/src/model/bert/prepared_tokenizer_selection.rs
+++ b/crates/inference/src/model/bert/prepared_tokenizer_selection.rs
@@ -1,0 +1,206 @@
+//! Dormant prepared-BERT tokenizer candidate-presence selection contract.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct RawBertTokenizerCandidatePresence {
+    tokenizer_json: bool,
+    vocab_json: bool,
+    merges_txt: bool,
+    vocab_txt: bool,
+    tokenizer_model: bool,
+}
+
+impl RawBertTokenizerCandidatePresence {
+    pub(super) fn new(
+        tokenizer_json: bool,
+        vocab_json: bool,
+        merges_txt: bool,
+        vocab_txt: bool,
+        tokenizer_model: bool,
+    ) -> Self {
+        Self {
+            tokenizer_json,
+            vocab_json,
+            merges_txt,
+            vocab_txt,
+            tokenizer_model,
+        }
+    }
+
+    pub(super) fn mask(self) -> u8 {
+        u8::from(self.tokenizer_json) << 4
+            | u8::from(self.vocab_json) << 3
+            | u8::from(self.merges_txt) << 2
+            | u8::from(self.vocab_txt) << 1
+            | u8::from(self.tokenizer_model)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PreparedBertTokenizerLayout {
+    TokenizerJson,
+    VocabJsonMerges,
+    VocabTxtMerges,
+    VocabTxt,
+    TokenizerModel,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PreparedBertTokenizerSelectionError {
+    MissingRepresentation,
+    VocabJsonWithoutMerges,
+    MergesWithoutVocab,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct PreparedBertTokenizerSelection {
+    layout: PreparedBertTokenizerLayout,
+    presence: RawBertTokenizerCandidatePresence,
+}
+
+impl PreparedBertTokenizerSelection {
+    pub(super) fn layout(self) -> PreparedBertTokenizerLayout {
+        self.layout
+    }
+
+    pub(super) fn presence(self) -> RawBertTokenizerCandidatePresence {
+        self.presence
+    }
+}
+
+pub(super) fn select_prepared_bert_tokenizer_layout(
+    presence: RawBertTokenizerCandidatePresence,
+) -> Result<PreparedBertTokenizerSelection, PreparedBertTokenizerSelectionError> {
+    if presence.vocab_json && !presence.merges_txt {
+        return Err(PreparedBertTokenizerSelectionError::VocabJsonWithoutMerges);
+    }
+    if presence.merges_txt && !presence.vocab_json && !presence.vocab_txt {
+        return Err(PreparedBertTokenizerSelectionError::MergesWithoutVocab);
+    }
+
+    let layout = if presence.tokenizer_json {
+        PreparedBertTokenizerLayout::TokenizerJson
+    } else if presence.vocab_json && presence.merges_txt {
+        PreparedBertTokenizerLayout::VocabJsonMerges
+    } else if presence.vocab_txt && presence.merges_txt {
+        PreparedBertTokenizerLayout::VocabTxtMerges
+    } else if presence.vocab_txt {
+        PreparedBertTokenizerLayout::VocabTxt
+    } else if presence.tokenizer_model {
+        PreparedBertTokenizerLayout::TokenizerModel
+    } else {
+        return Err(PreparedBertTokenizerSelectionError::MissingRepresentation);
+    };
+
+    Ok(PreparedBertTokenizerSelection { layout, presence })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MISSING: PreparedBertTokenizerSelectionError =
+        PreparedBertTokenizerSelectionError::MissingRepresentation;
+    const PARTIAL_VOCAB_JSON: PreparedBertTokenizerSelectionError =
+        PreparedBertTokenizerSelectionError::VocabJsonWithoutMerges;
+    const ORPHAN_MERGES: PreparedBertTokenizerSelectionError =
+        PreparedBertTokenizerSelectionError::MergesWithoutVocab;
+
+    const J: PreparedBertTokenizerLayout = PreparedBertTokenizerLayout::TokenizerJson;
+    const VM: PreparedBertTokenizerLayout = PreparedBertTokenizerLayout::VocabJsonMerges;
+    const TM: PreparedBertTokenizerLayout = PreparedBertTokenizerLayout::VocabTxtMerges;
+    const T: PreparedBertTokenizerLayout = PreparedBertTokenizerLayout::VocabTxt;
+    const S: PreparedBertTokenizerLayout = PreparedBertTokenizerLayout::TokenizerModel;
+
+    fn presence(mask: u8) -> RawBertTokenizerCandidatePresence {
+        RawBertTokenizerCandidatePresence::new(
+            mask & 0b1_0000 != 0,
+            mask & 0b0_1000 != 0,
+            mask & 0b0_0100 != 0,
+            mask & 0b0_0010 != 0,
+            mask & 0b0_0001 != 0,
+        )
+    }
+
+    #[test]
+    fn all_32_presence_states_have_one_exact_result() {
+        let expected = [
+            Err(MISSING),
+            Ok(S),
+            Ok(T),
+            Ok(T),
+            Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Ok(TM),
+            Ok(TM),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Ok(VM),
+            Ok(VM),
+            Ok(VM),
+            Ok(VM),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Ok(J),
+            Ok(J),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+        ];
+
+        for (mask, expected_layout) in expected.into_iter().enumerate() {
+            let raw = presence(u8::try_from(mask).unwrap());
+            assert_eq!(
+                select_prepared_bert_tokenizer_layout(raw)
+                    .map(PreparedBertTokenizerSelection::layout),
+                expected_layout,
+                "JVMTS mask {mask:05b}"
+            );
+        }
+    }
+
+    #[test]
+    fn global_partial_validation_precedes_even_tokenizer_json() {
+        for mask in [0b1_0100, 0b1_0101] {
+            assert_eq!(
+                select_prepared_bert_tokenizer_layout(presence(mask)),
+                Err(ORPHAN_MERGES),
+                "orphan merges must fail under tokenizer.json for {mask:05b}"
+            );
+        }
+        for mask in [0b1_1000, 0b1_1001, 0b1_1010, 0b1_1011] {
+            assert_eq!(
+                select_prepared_bert_tokenizer_layout(presence(mask)),
+                Err(PARTIAL_VOCAB_JSON),
+                "partial vocab.json must fail under tokenizer.json for {mask:05b}"
+            );
+        }
+    }
+
+    #[test]
+    fn selected_layout_preserves_the_complete_raw_presence_fact() {
+        for (mask, layout) in [
+            (0b1_1111, J),
+            (0b0_1111, VM),
+            (0b0_0111, TM),
+            (0b0_0011, T),
+            (0b0_0001, S),
+        ] {
+            let raw = presence(mask);
+            let selected = select_prepared_bert_tokenizer_layout(raw).unwrap();
+            assert_eq!(selected.layout(), layout);
+            assert_eq!(selected.presence(), raw);
+            assert_eq!(selected.presence().mask(), mask);
+        }
+    }
+}


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Governance and stack

Draft implementation work for proposed Lattice ADR-088 and Khive ADR-160. Do not merge until the governing specification is accepted and the parent stack is ready.

Stacked on #1426 (`codex/adr-160-prepared-bert-config-parser`). This slice is private, dormant, and has no production caller.

## What this adds

- a fixed five-bit raw presence fact for `tokenizer.json`, `vocab.json`, `merges.txt`, `vocab.txt`, and `tokenizer.model`
- global fail-closed validation for partial `vocab.json`/`merges.txt` layouts, including partial layouts shadowed by `tokenizer.json`
- exact prepared precedence: `tokenizer.json` → `vocab.json`+`merges.txt` → `vocab.txt`+`merges.txt` → `vocab.txt` → `tokenizer.model`
- a selection fact that retains the complete raw candidate presence rather than pruning shadowed candidates
- typed missing-representation, partial-vocab, and orphan-merges errors

Presence does not imply valid content. A selected candidate that is malformed must fail in a later content validator without fallback; every present shadowed candidate remains future identity-bearing input.

There is no filesystem/path access, allocation, content parsing, tokenizer construction, attestation, sequence-cap logic, loader integration, publication, serving callsite, or legacy behavior change in this slice.

## TDD evidence

Compile-first RED failed with 23 missing production-symbol errors and one expected unused-import warning. GREEN locks all 32 presence masks, global partial-layout failure under a higher-priority `tokenizer.json`, exact precedence, and complete raw-presence retention.

## Verification

```text
Focused prepared_tokenizer_selection tests
3 passed; 0 failed

RUSTC_WRAPPER= cargo clippy -p lattice-inference --lib --tests -j4 -- -D warnings
PASS

cargo fmt --all -- --check
PASS

git diff --check
PASS

repository pre-commit hook
PASS

focused Blocker/High production review
0 Blocker; 0 High
```

## ADR-087 benchmark disposition

Evaluated at PR head `35745989de134995e4c49c87780a25b1205eacdb` against the 25-target `lattice-inference` benchmark surface at base `8604fccc3e46f8cf946393dacd206ad0789255f5`; this proof is void if either ref moves.

The diff changes no manifest, dependency or lockfile version, feature set, profile, build script, generated source, benchmark definition, or harness input. The reached `model/bert.rs` hunk adds only one private dormant module item and modifies no existing item. Recursively, the new module contains only new private fixed-size types, inherent/derived implementations, functions, and `cfg(test)` tests: no production caller, heap allocation, global/static initializer, linker/codegen attribute, exported symbol, unsafe/extern code, macro registration/export, allocator hook, or trait implementation on an existing type.

Ungated targets inspected: `differential_attention_bench`, `native_sparse_attention_bench`, `gated_attention_bench`, `inference_bench`, `tokenizer_bench`, `e2e_bench`, `inference_perf`, `topk_readback`, `quarot_hadamard_bench`, `lm_head_bench`, `elementwise_cpu_bench`, `grammar_mask_bench`, `elementwise_bench`, `attn_opt_bench`, `metrics_bench`, `pruning_bench`, `kv_cache_f16_bench`, and `attention_dispatch_bench`.

Feature-gated targets inspected: `decode_attn_bench` (`f16`), `kv_cache_layout_bench` (`bench-internals`), `metal_decode_bench` (`metal-gpu`, `f16`), `cross_turn_prefix_cache_bench` (`metal-gpu`, `f16`), `mtp_decode` (`metal-gpu`, `f16`), `backward_stage0` (`train-backward`), and `f16_convert_bench` (`bench-internals`).

None of the 25 targets imports or calls the new module. This slice is unmeasured, not performance-neutral. Any future live tokenizer-selection or prepared-mode callsite must re-evaluate reachability and, if reachable, provide targeted measurement.

## Explicit exclusions

- authoritative source inventory, required-file checks, declared lengths, index/shard rejection, opened handles, or snapshot accounting
- tokenizer JSON/vocabulary content validation, sequence-cap resolution, or tokenizer construction
- descriptor construction, attestation, cache policy, model loading, publication, or serving
- public API, legacy behavior changes, Qwen, Metal, or remote providers

## Child draft

- #1428 — dormant fixed prepared-BERT file-presence validation