### PR TITLE
feat(inference): validate prepared BERT file presence

### DIFF
--- a/crates/inference/src/model/bert.rs
+++ b/crates/inference/src/model/bert.rs
@@ -32,6 +32,9 @@ mod prepared_tensor_inventory;
 #[cfg_attr(not(test), allow(dead_code))]
 mod prepared_tokenizer_selection;
 
+#[cfg_attr(not(test), allow(dead_code))]
+mod prepared_file_presence;
+
 /// Per-layer fused Q/K/V weight+bias, built once at model-load time from a
 /// `TransformerLayerWeights` layer's separate `query`/`key`/`value` tensors.
 ///

--- a/crates/inference/src/model/bert/prepared_file_presence.rs
+++ b/crates/inference/src/model/bert/prepared_file_presence.rs
@@ -1,0 +1,202 @@
+//! Dormant prepared-BERT recognized-file presence contract.
+
+use super::prepared_tokenizer_selection::{
+    PreparedBertTokenizerLayout, PreparedBertTokenizerSelection,
+    PreparedBertTokenizerSelectionError, RawBertTokenizerCandidatePresence,
+    select_prepared_bert_tokenizer_layout,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct RawPreparedBertFilePresence {
+    model_safetensors: bool,
+    config_json: bool,
+    tokenizer_config_json: bool,
+    tokenizer_json: bool,
+    vocab_json: bool,
+    merges_txt: bool,
+    vocab_txt: bool,
+    tokenizer_model: bool,
+}
+
+impl RawPreparedBertFilePresence {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        model_safetensors: bool,
+        config_json: bool,
+        tokenizer_config_json: bool,
+        tokenizer_json: bool,
+        vocab_json: bool,
+        merges_txt: bool,
+        vocab_txt: bool,
+        tokenizer_model: bool,
+    ) -> Self {
+        Self {
+            model_safetensors,
+            config_json,
+            tokenizer_config_json,
+            tokenizer_json,
+            vocab_json,
+            merges_txt,
+            vocab_txt,
+            tokenizer_model,
+        }
+    }
+
+    pub(super) fn mask(self) -> u8 {
+        u8::from(self.model_safetensors) << 7
+            | u8::from(self.config_json) << 6
+            | u8::from(self.tokenizer_config_json) << 5
+            | u8::from(self.tokenizer_json) << 4
+            | u8::from(self.vocab_json) << 3
+            | u8::from(self.merges_txt) << 2
+            | u8::from(self.vocab_txt) << 1
+            | u8::from(self.tokenizer_model)
+    }
+
+    fn tokenizer_candidates(self) -> RawBertTokenizerCandidatePresence {
+        RawBertTokenizerCandidatePresence::new(
+            self.tokenizer_json,
+            self.vocab_json,
+            self.merges_txt,
+            self.vocab_txt,
+            self.tokenizer_model,
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PreparedBertFilePresenceError {
+    MissingModelSafetensors,
+    MissingConfigJson,
+    MissingTokenizerConfigJson,
+    Tokenizer(PreparedBertTokenizerSelectionError),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct PreparedBertFilePresence {
+    presence: RawPreparedBertFilePresence,
+    tokenizer: PreparedBertTokenizerSelection,
+}
+
+impl PreparedBertFilePresence {
+    pub(super) fn presence(self) -> RawPreparedBertFilePresence {
+        self.presence
+    }
+
+    pub(super) fn tokenizer_layout(self) -> PreparedBertTokenizerLayout {
+        self.tokenizer.layout()
+    }
+}
+
+pub(super) fn validate_prepared_bert_file_presence(
+    presence: RawPreparedBertFilePresence,
+) -> Result<PreparedBertFilePresence, PreparedBertFilePresenceError> {
+    if !presence.model_safetensors {
+        return Err(PreparedBertFilePresenceError::MissingModelSafetensors);
+    }
+    if !presence.config_json {
+        return Err(PreparedBertFilePresenceError::MissingConfigJson);
+    }
+    if !presence.tokenizer_config_json {
+        return Err(PreparedBertFilePresenceError::MissingTokenizerConfigJson);
+    }
+
+    let tokenizer = select_prepared_bert_tokenizer_layout(presence.tokenizer_candidates())
+        .map_err(PreparedBertFilePresenceError::Tokenizer)?;
+
+    Ok(PreparedBertFilePresence {
+        presence,
+        tokenizer,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::prepared_tokenizer_selection::{
+        PreparedBertTokenizerLayout, PreparedBertTokenizerSelectionError,
+    };
+    use super::*;
+
+    fn presence(mask: u8) -> RawPreparedBertFilePresence {
+        RawPreparedBertFilePresence::new(
+            mask & 0b1000_0000 != 0,
+            mask & 0b0100_0000 != 0,
+            mask & 0b0010_0000 != 0,
+            mask & 0b0001_0000 != 0,
+            mask & 0b0000_1000 != 0,
+            mask & 0b0000_0100 != 0,
+            mask & 0b0000_0010 != 0,
+            mask & 0b0000_0001 != 0,
+        )
+    }
+
+    #[test]
+    fn required_files_fail_in_model_config_tokenizer_config_order() {
+        for (mask, expected) in [
+            (
+                0b0001_0000,
+                PreparedBertFilePresenceError::MissingModelSafetensors,
+            ),
+            (
+                0b1001_0000,
+                PreparedBertFilePresenceError::MissingConfigJson,
+            ),
+            (
+                0b1101_0000,
+                PreparedBertFilePresenceError::MissingTokenizerConfigJson,
+            ),
+        ] {
+            assert_eq!(
+                validate_prepared_bert_file_presence(presence(mask)),
+                Err(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn tokenizer_validation_and_precedence_are_delegated_to_the_selector() {
+        use PreparedBertTokenizerLayout::{
+            TokenizerJson, TokenizerModel, VocabJsonMerges, VocabTxt, VocabTxtMerges,
+        };
+
+        for (mask, expected) in [
+            (0b1111_1111, Ok(TokenizerJson)),
+            (0b1110_1101, Ok(VocabJsonMerges)),
+            (0b1110_0111, Ok(VocabTxtMerges)),
+            (0b1110_0011, Ok(VocabTxt)),
+            (0b1110_0001, Ok(TokenizerModel)),
+            (
+                0b1111_0100,
+                Err(PreparedBertFilePresenceError::Tokenizer(
+                    PreparedBertTokenizerSelectionError::MergesWithoutVocab,
+                )),
+            ),
+            (
+                0b1111_1000,
+                Err(PreparedBertFilePresenceError::Tokenizer(
+                    PreparedBertTokenizerSelectionError::VocabJsonWithoutMerges,
+                )),
+            ),
+        ] {
+            let actual = validate_prepared_bert_file_presence(presence(mask))
+                .map(PreparedBertFilePresence::tokenizer_layout);
+            assert_eq!(actual, expected, "recognized-file mask {mask:08b}");
+        }
+    }
+
+    #[test]
+    fn validated_output_preserves_all_eight_raw_presence_facts() {
+        for mask in [
+            0b1111_1111,
+            0b1110_1101,
+            0b1110_0111,
+            0b1110_0011,
+            0b1110_0001,
+        ] {
+            let raw = presence(mask);
+            let validated = validate_prepared_bert_file_presence(raw).unwrap();
+            assert_eq!(validated.presence(), raw);
+            assert_eq!(validated.presence().mask(), mask);
+        }
+    }
+}


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Governance and stack

Draft implementation work for proposed Lattice ADR-088 and Khive ADR-160. Do not merge until the governing specification is accepted and the parent stack is ready.

Stacked on #1427 (the dormant prepared-BERT tokenizer selector). This slice is private, dormant, and has no production caller.

## What this adds

- a fixed eight-boolean prepared-BERT file-presence value covering `model.safetensors`, `config.json`, `tokenizer_config.json`, `tokenizer.json`, `vocab.json`, `merges.txt`, `vocab.txt`, and `tokenizer.model`
- validation of the required trio: `model.safetensors`, `config.json`, and `tokenizer_config.json`
- reuse of the parent tokenizer selector for the five recognized tokenizer candidates and its global partial-layout validation and precedence
- a selected result that preserves the complete raw eight-file presence alongside the chosen tokenizer layout, including complete lower-priority candidates

This slice performs no filesystem access and accepts presence facts only. It adds no path handling, byte lengths, index or shard support, open-file handles, content reads, attestation, snapshot/TOCTOU closure, loader integration, publication, or live behavior.

## TDD evidence

Compile-first RED exited 101 with 11 missing production-symbol errors and one expected unused-import warning.

Focused `prepared_file_presence` tests: 3 passed; 0 failed.

## Verification

```text
RUSTC_WRAPPER= cargo clippy -p lattice-inference --lib --tests -j4 -- -D warnings
PASS

cargo fmt --all -- --check
PASS

git diff --check
PASS

repository pre-commit hook
PASS

focused Blocker/High production review
0 Blocker; 0 High
```

## ADR-087 benchmark disposition

Evaluated at PR head `b7e28ef84a9fc8702a38763922786ae628cf222b` against the 25-target `lattice-inference` benchmark surface at base `35745989de134995e4c49c87780a25b1205eacdb`; this proof is void if either ref moves.

The diff changes no manifest, dependency or lockfile version, feature set, profile, build script, generated source, benchmark definition, or harness input. The reached `model/bert.rs` hunk adds only one private dormant module item and modifies no existing item. Recursively, the new module contains only new private constants, types, inherent/derived implementations, functions, and `cfg(test)` tests: no production caller, global/static initializer, linker/codegen attribute, exported symbol, unsafe/extern code, macro registration/export, allocator hook, or trait implementation on an existing type.

Ungated targets inspected: `differential_attention_bench`, `native_sparse_attention_bench`, `gated_attention_bench`, `inference_bench`, `tokenizer_bench`, `e2e_bench`, `inference_perf`, `topk_readback`, `quarot_hadamard_bench`, `lm_head_bench`, `elementwise_cpu_bench`, `grammar_mask_bench`, `elementwise_bench`, `attn_opt_bench`, `metrics_bench`, `pruning_bench`, `kv_cache_f16_bench`, and `attention_dispatch_bench`.

Feature-gated targets inspected: `decode_attn_bench` (`f16`), `kv_cache_layout_bench` (`bench-internals`), `metal_decode_bench` (`metal-gpu`, `f16`), `cross_turn_prefix_cache_bench` (`metal-gpu`, `f16`), `mtp_decode` (`metal-gpu`, `f16`), `backward_stage0` (`train-backward`), and `f16_convert_bench` (`bench-internals`).

`e2e_bench` reaches the untouched legacy directory/parser path and `inference_bench` constructs public `BertConfig` directly. None of the 25 targets imports or calls the new module. This slice is unmeasured, not performance-neutral. Any future filesystem reader, loader, or prepared-mode callsite must re-evaluate reachability and, if reachable, provide targeted measurement.

## Explicit exclusions

- filesystem inventory, paths, byte lengths, reads, growth probes, handles, snapshots, or TOCTOU closure
- tokenizer content validation, tensor inventory or matching, index/shard support, geometry validation, or model-label agreement
- descriptor construction, attestation, cache policy, model loading, publication, or serving
- public API, legacy behavior changes, Qwen, Metal, or remote providers

## Child draft

- #1429 — dormant bounded tokenizer-config sequence-cap parser