### PR TITLE
feat(inference): resolve prepared BERT sequence caps

### DIFF
--- a/crates/inference/src/model/bert.rs
+++ b/crates/inference/src/model/bert.rs
@@ -38,6 +38,9 @@ mod prepared_file_presence;
 #[cfg_attr(not(test), allow(dead_code))]
 mod prepared_tokenizer_config;
 
+#[cfg_attr(not(test), allow(dead_code))]
+mod prepared_sequence_cap;
+
 /// Per-layer fused Q/K/V weight+bias, built once at model-load time from a
 /// `TransformerLayerWeights` layer's separate `query`/`key`/`value` tensors.
 ///

--- a/crates/inference/src/model/bert/prepared_sequence_cap.rs
+++ b/crates/inference/src/model/bert/prepared_sequence_cap.rs
@@ -1,0 +1,226 @@
+//! Dormant cross-file prepared-BERT sequence-cap resolution contract.
+
+use std::num::NonZeroU64;
+
+const PREPARED_BERT_SEQUENCE_CAP: u64 = 2048;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PreparedBertSequenceCapSource {
+    TokenizerConfigJson,
+    ConfigJson,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PreparedBertSequenceCapKey {
+    ModelMaxLength,
+    MaxPositionEmbeddings,
+    NPositions,
+    MaxSeqLen,
+    TruncationMaxLength,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct RawPreparedBertSequenceCapCandidate {
+    key: PreparedBertSequenceCapKey,
+    raw_value: u64,
+}
+
+impl RawPreparedBertSequenceCapCandidate {
+    pub(super) fn new(key: PreparedBertSequenceCapKey, raw_value: u64) -> Self {
+        Self { key, raw_value }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct RawPreparedBertSequenceCapCandidates {
+    tokenizer_config_json: Option<RawPreparedBertSequenceCapCandidate>,
+    config_json: Option<RawPreparedBertSequenceCapCandidate>,
+}
+
+impl RawPreparedBertSequenceCapCandidates {
+    pub(super) fn new(
+        tokenizer_config_json: Option<RawPreparedBertSequenceCapCandidate>,
+        config_json: Option<RawPreparedBertSequenceCapCandidate>,
+    ) -> Self {
+        Self {
+            tokenizer_config_json,
+            config_json,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PreparedBertSequenceCapError {
+    Zero {
+        source: PreparedBertSequenceCapSource,
+        key: PreparedBertSequenceCapKey,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct PreparedBertSequenceCap {
+    source: PreparedBertSequenceCapSource,
+    key: PreparedBertSequenceCapKey,
+    raw_value: NonZeroU64,
+    capped_value: NonZeroU64,
+}
+
+impl PreparedBertSequenceCap {
+    pub(super) fn source(self) -> PreparedBertSequenceCapSource {
+        self.source
+    }
+
+    pub(super) fn key(self) -> PreparedBertSequenceCapKey {
+        self.key
+    }
+
+    pub(super) fn raw_value(self) -> NonZeroU64 {
+        self.raw_value
+    }
+
+    pub(super) fn capped_value(self) -> NonZeroU64 {
+        self.capped_value
+    }
+}
+
+pub(super) fn resolve_prepared_bert_sequence_cap(
+    candidates: RawPreparedBertSequenceCapCandidates,
+) -> Result<Option<PreparedBertSequenceCap>, PreparedBertSequenceCapError> {
+    let selected = candidates
+        .tokenizer_config_json
+        .map(|candidate| {
+            (
+                PreparedBertSequenceCapSource::TokenizerConfigJson,
+                candidate,
+            )
+        })
+        .or_else(|| {
+            candidates
+                .config_json
+                .map(|candidate| (PreparedBertSequenceCapSource::ConfigJson, candidate))
+        });
+    let Some((source, candidate)) = selected else {
+        return Ok(None);
+    };
+    let raw_value =
+        NonZeroU64::new(candidate.raw_value).ok_or(PreparedBertSequenceCapError::Zero {
+            source,
+            key: candidate.key,
+        })?;
+    let capped_value = NonZeroU64::new(raw_value.get().min(PREPARED_BERT_SEQUENCE_CAP)).ok_or(
+        PreparedBertSequenceCapError::Zero {
+            source,
+            key: candidate.key,
+        },
+    )?;
+    Ok(Some(PreparedBertSequenceCap {
+        source,
+        key: candidate.key,
+        raw_value,
+        capped_value,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(
+        key: PreparedBertSequenceCapKey,
+        raw_value: u64,
+    ) -> RawPreparedBertSequenceCapCandidate {
+        RawPreparedBertSequenceCapCandidate::new(key, raw_value)
+    }
+
+    #[test]
+    fn tokenizer_config_precedes_config_for_all_file_slot_masks() {
+        use PreparedBertSequenceCapKey::{MaxPositionEmbeddings, ModelMaxLength};
+        use PreparedBertSequenceCapSource::{ConfigJson, TokenizerConfigJson};
+
+        for (raw, expected) in [
+            (RawPreparedBertSequenceCapCandidates::new(None, None), None),
+            (
+                RawPreparedBertSequenceCapCandidates::new(
+                    None,
+                    Some(candidate(MaxPositionEmbeddings, 22)),
+                ),
+                Some((ConfigJson, MaxPositionEmbeddings, 22)),
+            ),
+            (
+                RawPreparedBertSequenceCapCandidates::new(
+                    Some(candidate(ModelMaxLength, 11)),
+                    None,
+                ),
+                Some((TokenizerConfigJson, ModelMaxLength, 11)),
+            ),
+            (
+                RawPreparedBertSequenceCapCandidates::new(
+                    Some(candidate(ModelMaxLength, 11)),
+                    Some(candidate(MaxPositionEmbeddings, 22)),
+                ),
+                Some((TokenizerConfigJson, ModelMaxLength, 11)),
+            ),
+        ] {
+            let actual = resolve_prepared_bert_sequence_cap(raw)
+                .unwrap()
+                .map(|cap| (cap.source(), cap.key(), cap.raw_value().get()));
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn selected_raw_value_is_preserved_and_capped_at_exactly_2048() {
+        use PreparedBertSequenceCapKey::{
+            MaxPositionEmbeddings, MaxSeqLen, ModelMaxLength, NPositions, TruncationMaxLength,
+        };
+
+        for key in [
+            ModelMaxLength,
+            MaxPositionEmbeddings,
+            NPositions,
+            MaxSeqLen,
+            TruncationMaxLength,
+        ] {
+            for (raw_value, capped_value) in [(1, 1), (2048, 2048), (2049, 2048), (u64::MAX, 2048)]
+            {
+                let resolved =
+                    resolve_prepared_bert_sequence_cap(RawPreparedBertSequenceCapCandidates::new(
+                        Some(candidate(key, raw_value)),
+                        None,
+                    ))
+                    .unwrap()
+                    .unwrap();
+                assert_eq!(resolved.key(), key);
+                assert_eq!(resolved.raw_value().get(), raw_value);
+                assert_eq!(resolved.capped_value().get(), capped_value);
+            }
+        }
+    }
+
+    #[test]
+    fn selected_zero_fails_without_falling_back_to_the_other_file() {
+        use PreparedBertSequenceCapKey::{MaxPositionEmbeddings, ModelMaxLength};
+        use PreparedBertSequenceCapSource::{ConfigJson, TokenizerConfigJson};
+
+        assert_eq!(
+            resolve_prepared_bert_sequence_cap(RawPreparedBertSequenceCapCandidates::new(
+                Some(candidate(ModelMaxLength, 0)),
+                Some(candidate(MaxPositionEmbeddings, 512)),
+            )),
+            Err(PreparedBertSequenceCapError::Zero {
+                source: TokenizerConfigJson,
+                key: ModelMaxLength,
+            })
+        );
+        assert_eq!(
+            resolve_prepared_bert_sequence_cap(RawPreparedBertSequenceCapCandidates::new(
+                None,
+                Some(candidate(MaxPositionEmbeddings, 0)),
+            )),
+            Err(PreparedBertSequenceCapError::Zero {
+                source: ConfigJson,
+                key: MaxPositionEmbeddings,
+            })
+        );
+    }
+}


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Governance and stack

Draft implementation work for proposed Lattice ADR-088 and Khive ADR-160. Do not merge until the governing specification is accepted and the parent stack is ready.

Stacked on #1429. This slice is private, dormant, and has no production caller.

## What this adds

- a fixed two-slot input for already-selected `tokenizer_config.json` and `config.json` sequence-cap candidates
- exact file precedence: `tokenizer_config.json` before `config.json`
- typed zero rejection on the selected higher-priority file, with no fallback
- owned source, key, raw positive `u64`, and exact `min(raw, 2048)` capped facts
- support for all five closed candidate keys without `usize` conversion or allocation

This is a pure resolution substrate. It does not parse either file, construct the config-side candidate, adapt #1429 facts, validate against configured `P` or actual position rows, or claim the complete ADR-088 realized-cap protocol.

There is no filesystem/path access, parsing, allocation, tokenizer/model construction, attestation, loader integration, publication, serving callsite, or legacy behavior change.

## TDD evidence

Compile-first RED exited 101 with 22 missing production-symbol errors and one expected unused-import warning. GREEN locks all four file-slot masks, tokenizer-config precedence, selected-zero no-fallback, all five keys, and exact cap boundaries at 1/2048/2049/`u64::MAX`.

## Verification

```text
Focused prepared_sequence_cap tests
3 passed; 0 failed

RUSTC_WRAPPER= cargo clippy -p lattice-inference --lib --tests -j4 -- -D warnings
PASS

cargo fmt --all -- --check
PASS

git diff --check
PASS

repository pre-commit hook
PASS

focused Blocker/High production review
0 Blocker; 0 High
```

## ADR-087 benchmark disposition

Evaluated at PR head `fa48e9e4974dfcd672b761069c1c40142a449046` against the 25-target `lattice-inference` benchmark surface at base `6792c2fc0d8ae9b079f27174bf32ebf6d3aa191f`; this proof is void if either ref moves.

The diff changes no manifest, dependency or lockfile version, feature set, profile, build script, generated source, benchmark definition, or harness input. The reached `model/bert.rs` hunk adds only one private dormant module item and modifies no existing item. Recursively, the new module contains only new private constants, fixed-size types, inherent/derived implementations, functions, and `cfg(test)` tests: no production caller, heap allocation, global/static initializer, linker/codegen attribute, exported symbol, unsafe/extern code, macro registration/export, allocator hook, or trait implementation on an existing type.

Ungated targets inspected: `differential_attention_bench`, `native_sparse_attention_bench`, `gated_attention_bench`, `inference_bench`, `tokenizer_bench`, `e2e_bench`, `inference_perf`, `topk_readback`, `quarot_hadamard_bench`, `lm_head_bench`, `elementwise_cpu_bench`, `grammar_mask_bench`, `elementwise_bench`, `attn_opt_bench`, `metrics_bench`, `pruning_bench`, `kv_cache_f16_bench`, and `attention_dispatch_bench`.

Feature-gated targets inspected: `decode_attn_bench` (`f16`), `kv_cache_layout_bench` (`bench-internals`), `metal_decode_bench` (`metal-gpu`, `f16`), `cross_turn_prefix_cache_bench` (`metal-gpu`, `f16`), `mtp_decode` (`metal-gpu`, `f16`), `backward_stage0` (`train-backward`), and `f16_convert_bench` (`bench-internals`).

None of the 25 targets imports or calls the new module. This slice is unmeasured, not performance-neutral. Any future parser adapter, loader, or prepared-mode callsite must re-evaluate reachability and, if reachable, provide targeted measurement.

## Explicit exclusions

- config-side candidate extraction and malformed-higher-key enforcement
- parser adapters, cross-artifact `P`/position-row checks, final descriptor fields, or full D4 realization
- filesystem inventory, handles, snapshots, copy, or TOCTOU closure
- tokenizer content validation, attestation, model loading, publication, or serving
- public API, legacy behavior changes, Qwen, Metal, or remote providers

## Child draft

- #1431 — dormant prepared tokenizer.json model-type classifier