### PR TITLE
feat(inference): classify prepared tokenizer JSON models

### DIFF
--- a/crates/inference/src/model/bert.rs
+++ b/crates/inference/src/model/bert.rs
@@ -41,6 +41,9 @@ mod prepared_tokenizer_config;
 #[cfg_attr(not(test), allow(dead_code))]
 mod prepared_sequence_cap;
 
+#[cfg_attr(not(test), allow(dead_code))]
+mod prepared_tokenizer_json_model;
+
 /// Per-layer fused Q/K/V weight+bias, built once at model-load time from a
 /// `TransformerLayerWeights` layer's separate `query`/`key`/`value` tensors.
 ///

--- a/crates/inference/src/model/bert/prepared_tokenizer_json_model.rs
+++ b/crates/inference/src/model/bert/prepared_tokenizer_json_model.rs
@@ -1,0 +1,70 @@
+//! Dormant prepared-BERT `tokenizer.json` decoded model-type contract.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PreparedBertTokenizerJsonModel {
+    WordPiece,
+    Bpe,
+    Unigram,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PreparedBertTokenizerJsonModelError {
+    Missing,
+    Empty,
+    Unsupported,
+}
+
+pub(super) fn classify_prepared_bert_tokenizer_json_model_type(
+    model_type: Option<&str>,
+) -> Result<PreparedBertTokenizerJsonModel, PreparedBertTokenizerJsonModelError> {
+    match model_type {
+        None => Err(PreparedBertTokenizerJsonModelError::Missing),
+        Some("") => Err(PreparedBertTokenizerJsonModelError::Empty),
+        Some("WordPiece") => Ok(PreparedBertTokenizerJsonModel::WordPiece),
+        Some("BPE") => Ok(PreparedBertTokenizerJsonModel::Bpe),
+        Some("Unigram" | "SentencePieceUnigram") => Ok(PreparedBertTokenizerJsonModel::Unigram),
+        Some(_) => Err(PreparedBertTokenizerJsonModelError::Unsupported),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn four_supported_spellings_map_to_three_canonical_models() {
+        use PreparedBertTokenizerJsonModel::{Bpe, Unigram, WordPiece};
+
+        for (model_type, expected) in [
+            ("WordPiece", WordPiece),
+            ("BPE", Bpe),
+            ("Unigram", Unigram),
+            ("SentencePieceUnigram", Unigram),
+        ] {
+            assert_eq!(
+                classify_prepared_bert_tokenizer_json_model_type(Some(model_type)),
+                Ok(expected)
+            );
+        }
+    }
+
+    #[test]
+    fn missing_empty_unknown_and_wrong_case_fail_without_fallback() {
+        use PreparedBertTokenizerJsonModelError::{Empty, Missing, Unsupported};
+
+        assert_eq!(
+            classify_prepared_bert_tokenizer_json_model_type(None),
+            Err(Missing)
+        );
+        assert_eq!(
+            classify_prepared_bert_tokenizer_json_model_type(Some("")),
+            Err(Empty)
+        );
+        for unsupported in ["BertWordPiece", "wordpiece", "bpe", "SentencePiece"] {
+            assert_eq!(
+                classify_prepared_bert_tokenizer_json_model_type(Some(unsupported)),
+                Err(Unsupported)
+            );
+        }
+    }
+}


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Governance and stack

Draft implementation work for proposed Lattice ADR-088 and Khive ADR-160. Do not merge until the governing specification is accepted and the parent stack is ready.

Stacked on #1430. This slice is private, dormant, and has no production caller.

## What this adds

- a classifier for an already-decoded selected `tokenizer.json` `model.type`
- exact accepted spellings: `WordPiece`, `BPE`, `Unigram`, and `SentencePieceUnigram`
- three canonical facts: WordPiece, BPE, and Unigram
- typed missing, empty, and unsupported failures; wrong case is unsupported and never falls back

This slice deliberately starts after bounded JSON decoding. It does not inspect bytes, parse a document, validate vocabularies or token IDs, construct a tokenizer, inspect lower layouts, or claim content validation.

There is no filesystem/path access, allocation, attestation, loader integration, publication, serving callsite, or legacy behavior change.

## TDD evidence

Compile-first RED exited 101 with 6 missing production-symbol errors and one expected unused-import warning. GREEN locks all four supported spellings, their three canonical results, and missing/empty/unknown/wrong-case failures.

## Verification

```text
Focused prepared_tokenizer_json_model tests
2 passed; 0 failed

RUSTC_WRAPPER= cargo clippy -p lattice-inference --lib --tests -j4 -- -D warnings
PASS

cargo fmt --all -- --check
PASS

git diff --check
PASS

repository pre-commit hook
PASS

focused Blocker/High production review
0 Blocker; 0 High
```

## ADR-087 benchmark disposition

Evaluated at PR head `8ef720c124c5b97901c962c3d19f4a4163d1913a` against the 25-target `lattice-inference` benchmark surface at base `fa48e9e4974dfcd672b761069c1c40142a449046`; this proof is void if either ref moves.

The diff changes no manifest, dependency or lockfile version, feature set, profile, build script, generated source, benchmark definition, or harness input. The reached `model/bert.rs` hunk adds only one private dormant module item and modifies no existing item. Recursively, the new module contains only new private fixed-size enums, inherent/derived implementations, one borrowed-string classifier, and `cfg(test)` tests: no production caller, heap allocation, global/static initializer, linker/codegen attribute, exported symbol, unsafe/extern code, macro registration/export, allocator hook, or trait implementation on an existing type.

Ungated targets inspected: `differential_attention_bench`, `native_sparse_attention_bench`, `gated_attention_bench`, `inference_bench`, `tokenizer_bench`, `e2e_bench`, `inference_perf`, `topk_readback`, `quarot_hadamard_bench`, `lm_head_bench`, `elementwise_cpu_bench`, `grammar_mask_bench`, `elementwise_bench`, `attn_opt_bench`, `metrics_bench`, `pruning_bench`, `kv_cache_f16_bench`, and `attention_dispatch_bench`.

Feature-gated targets inspected: `decode_attn_bench` (`f16`), `kv_cache_layout_bench` (`bench-internals`), `metal_decode_bench` (`metal-gpu`, `f16`), `cross_turn_prefix_cache_bench` (`metal-gpu`, `f16`), `mtp_decode` (`metal-gpu`, `f16`), `backward_stage0` (`train-backward`), and `f16_convert_bench` (`bench-internals`).

None of the 25 targets imports or calls the new module. This slice is unmeasured, not performance-neutral. Any future bytes parser, tokenizer constructor, or prepared-mode callsite must re-evaluate reachability and, if reachable, provide targeted measurement.

## Explicit exclusions

- JSON bytes parsing, bounded content validation, vocab/cardinality/special-ID facts, or tokenizer construction
- lower-priority layout fallback, config/sequence-cap integration, or final descriptor fields
- filesystem inventory, handles, snapshots, copy, or TOCTOU closure
- attestation, model loading, publication, or serving
- public API, legacy behavior changes, Qwen, Metal, or remote providers

## Child draft

- #1432 — dormant prepared config sequence-cap candidate extraction
