### PR TITLE
feat(inference): extract prepared config sequence caps

### DIFF
--- a/crates/inference/src/model/bert/prepared_config.rs
+++ b/crates/inference/src/model/bert/prepared_config.rs
@@ -1,6 +1,9 @@
 //! Dormant checked parsing contract for prepared BERT `config.json` bytes.
 
 use super::prepared_facts::RawBertConfigFacts;
+use super::prepared_sequence_cap::{
+    PreparedBertSequenceCapKey, RawPreparedBertSequenceCapCandidate,
+};
 use std::num::NonZeroU64;
 use std::ops::Range;
 
@@ -16,10 +19,23 @@ pub(super) enum PreparedBertConfigField {
     MaxPositionEmbeddings,
     TypeVocabSize,
     LayerNormEps,
+    ModelMaxLength,
 }
 
 impl PreparedBertConfigField {
-    const ALL: [Self; 8] = [
+    const ALL: [Self; 9] = [
+        Self::VocabSize,
+        Self::HiddenSize,
+        Self::NumHiddenLayers,
+        Self::NumAttentionHeads,
+        Self::IntermediateSize,
+        Self::MaxPositionEmbeddings,
+        Self::TypeVocabSize,
+        Self::LayerNormEps,
+        Self::ModelMaxLength,
+    ];
+
+    const REQUIRED: [Self; 8] = [
         Self::VocabSize,
         Self::HiddenSize,
         Self::NumHiddenLayers,
@@ -40,6 +56,7 @@ impl PreparedBertConfigField {
             Self::MaxPositionEmbeddings => 5,
             Self::TypeVocabSize => 6,
             Self::LayerNormEps => 7,
+            Self::ModelMaxLength => 8,
         }
     }
 
@@ -53,6 +70,7 @@ impl PreparedBertConfigField {
             Self::MaxPositionEmbeddings => b"max_position_embeddings",
             Self::TypeVocabSize => b"type_vocab_size",
             Self::LayerNormEps => b"layer_norm_eps",
+            Self::ModelMaxLength => b"model_max_length",
         }
     }
 
@@ -94,10 +112,25 @@ pub(super) enum PreparedBertConfigExpectedType {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum PreparedBertConfigUnsignedFault {
+    Zero,
     Negative,
     Fractional,
     Exponent,
     Overflow,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PreparedBertConfigSequenceCandidateError {
+    InvalidType {
+        key: PreparedBertSequenceCapKey,
+        actual: PreparedBertConfigValueKind,
+        at: usize,
+    },
+    InvalidPositiveInteger {
+        key: PreparedBertSequenceCapKey,
+        fault: PreparedBertConfigUnsignedFault,
+        at: usize,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -212,6 +245,8 @@ impl PreparedBertConfigLimits {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) struct ParsedBertConfigFacts {
     raw: RawBertConfigFacts,
+    sequence_cap_candidate:
+        Result<RawPreparedBertSequenceCapCandidate, PreparedBertConfigSequenceCandidateError>,
     config_bytes: u64,
     logical_config_parse_work_bytes: u64,
 }
@@ -219,6 +254,12 @@ pub(super) struct ParsedBertConfigFacts {
 impl ParsedBertConfigFacts {
     pub(super) fn raw(self) -> RawBertConfigFacts {
         self.raw
+    }
+
+    pub(super) fn sequence_cap_candidate(
+        self,
+    ) -> Result<RawPreparedBertSequenceCapCandidate, PreparedBertConfigSequenceCandidateError> {
+        self.sequence_cap_candidate
     }
 
     pub(super) fn config_bytes(self) -> u64 {
@@ -261,9 +302,10 @@ pub(super) fn parse_prepared_bert_config_json(
     }
 
     JsonCursor::new(bytes).validate_document()?;
-    let raw = SemanticParser::new(bytes).parse()?;
+    let (raw, sequence_cap_candidate) = SemanticParser::new(bytes).parse()?;
     Ok(ParsedBertConfigFacts {
         raw,
+        sequence_cap_candidate,
         config_bytes,
         logical_config_parse_work_bytes,
     })
@@ -725,22 +767,31 @@ impl<'a> JsonCursor<'a> {
 
 struct SemanticParser<'a> {
     cursor: JsonCursor<'a>,
-    seen_at: [Option<usize>; 8],
+    seen_at: [Option<usize>; 9],
     unsigned: [u64; 7],
     epsilon: f64,
+    model_max_length_candidate: Option<
+        Result<RawPreparedBertSequenceCapCandidate, PreparedBertConfigSequenceCandidateError>,
+    >,
 }
 
 impl<'a> SemanticParser<'a> {
     fn new(bytes: &'a [u8]) -> Self {
         Self {
             cursor: JsonCursor::new(bytes),
-            seen_at: [None; 8],
+            seen_at: [None; 9],
             unsigned: [0; 7],
             epsilon: 0.0,
+            model_max_length_candidate: None,
         }
     }
 
-    fn parse(mut self) -> ConfigResult<RawBertConfigFacts> {
+    fn parse(
+        mut self,
+    ) -> ConfigResult<(
+        RawBertConfigFacts,
+        Result<RawPreparedBertSequenceCapCandidate, PreparedBertConfigSequenceCandidateError>,
+    )> {
         self.cursor.skip_whitespace();
         self.cursor.pos += 1;
         self.cursor.skip_whitespace();
@@ -768,21 +819,41 @@ impl<'a> SemanticParser<'a> {
                     }
                     self.seen_at[index] = Some(key_at);
                     let actual = self.cursor.peek_value_kind()?;
-                    if actual != PreparedBertConfigValueKind::Number {
-                        return Err(PreparedBertConfigError::InvalidFieldType {
-                            field,
-                            expected: field.expected_type(),
-                            actual,
-                            at: value_at,
-                        });
-                    }
-                    let token = self.cursor.scan_number()?;
-                    if field == PreparedBertConfigField::LayerNormEps {
-                        self.epsilon =
-                            parse_float(self.cursor.bytes, token.range, field, value_at)?;
+                    if field == PreparedBertConfigField::ModelMaxLength {
+                        if actual == PreparedBertConfigValueKind::Number {
+                            let token = self.cursor.scan_number()?;
+                            self.model_max_length_candidate =
+                                Some(parse_model_max_length_candidate(
+                                    self.cursor.bytes,
+                                    &token,
+                                    value_at,
+                                ));
+                        } else {
+                            self.cursor.skip_value()?;
+                            self.model_max_length_candidate =
+                                Some(Err(PreparedBertConfigSequenceCandidateError::InvalidType {
+                                    key: PreparedBertSequenceCapKey::ModelMaxLength,
+                                    actual,
+                                    at: value_at,
+                                }));
+                        }
                     } else {
-                        self.unsigned[index] =
-                            parse_unsigned(self.cursor.bytes, token, field, value_at)?;
+                        if actual != PreparedBertConfigValueKind::Number {
+                            return Err(PreparedBertConfigError::InvalidFieldType {
+                                field,
+                                expected: field.expected_type(),
+                                actual,
+                                at: value_at,
+                            });
+                        }
+                        let token = self.cursor.scan_number()?;
+                        if field == PreparedBertConfigField::LayerNormEps {
+                            self.epsilon =
+                                parse_float(self.cursor.bytes, token.range, field, value_at)?;
+                        } else {
+                            let value = parse_unsigned(self.cursor.bytes, &token, field, value_at)?;
+                            self.unsigned[index] = value;
+                        }
                     }
                 } else {
                     self.cursor.skip_value()?;
@@ -805,20 +876,30 @@ impl<'a> SemanticParser<'a> {
             }
         }
 
-        for field in PreparedBertConfigField::ALL {
+        for field in PreparedBertConfigField::REQUIRED {
             if self.seen_at[field.index()].is_none() {
                 return Err(PreparedBertConfigError::MissingField { field });
             }
         }
-        Ok(RawBertConfigFacts::new(
-            self.unsigned[0],
-            self.unsigned[1],
-            self.unsigned[2],
-            self.unsigned[3],
-            self.unsigned[4],
-            self.unsigned[5],
-            self.unsigned[6],
-            self.epsilon,
+        let sequence_cap_candidate = match self.model_max_length_candidate {
+            Some(candidate) => candidate,
+            None => Ok(RawPreparedBertSequenceCapCandidate::new(
+                PreparedBertSequenceCapKey::MaxPositionEmbeddings,
+                self.unsigned[PreparedBertConfigField::MaxPositionEmbeddings.index()],
+            )),
+        };
+        Ok((
+            RawBertConfigFacts::new(
+                self.unsigned[0],
+                self.unsigned[1],
+                self.unsigned[2],
+                self.unsigned[3],
+                self.unsigned[4],
+                self.unsigned[5],
+                self.unsigned[6],
+                self.epsilon,
+            ),
+            sequence_cap_candidate,
         ))
     }
 }
@@ -849,41 +930,54 @@ impl JsonCursor<'_> {
 
 fn parse_unsigned(
     bytes: &[u8],
-    token: NumberToken,
+    token: &NumberToken,
     field: PreparedBertConfigField,
     at: usize,
 ) -> ConfigResult<u64> {
+    parse_unsigned_value(bytes, token)
+        .map_err(|fault| PreparedBertConfigError::InvalidUnsignedInteger { field, fault, at })
+}
+
+fn parse_model_max_length_candidate(
+    bytes: &[u8],
+    token: &NumberToken,
+    at: usize,
+) -> Result<RawPreparedBertSequenceCapCandidate, PreparedBertConfigSequenceCandidateError> {
+    let key = PreparedBertSequenceCapKey::ModelMaxLength;
+    let value = parse_unsigned_value(bytes, token).map_err(|fault| {
+        PreparedBertConfigSequenceCandidateError::InvalidPositiveInteger { key, fault, at }
+    })?;
+    if value == 0 {
+        return Err(
+            PreparedBertConfigSequenceCandidateError::InvalidPositiveInteger {
+                key,
+                fault: PreparedBertConfigUnsignedFault::Zero,
+                at,
+            },
+        );
+    }
+    Ok(RawPreparedBertSequenceCapCandidate::new(key, value))
+}
+
+fn parse_unsigned_value(
+    bytes: &[u8],
+    token: &NumberToken,
+) -> Result<u64, PreparedBertConfigUnsignedFault> {
     if token.negative {
-        return Err(PreparedBertConfigError::InvalidUnsignedInteger {
-            field,
-            fault: PreparedBertConfigUnsignedFault::Negative,
-            at,
-        });
+        return Err(PreparedBertConfigUnsignedFault::Negative);
     }
     if token.fractional {
-        return Err(PreparedBertConfigError::InvalidUnsignedInteger {
-            field,
-            fault: PreparedBertConfigUnsignedFault::Fractional,
-            at,
-        });
+        return Err(PreparedBertConfigUnsignedFault::Fractional);
     }
     if token.exponent {
-        return Err(PreparedBertConfigError::InvalidUnsignedInteger {
-            field,
-            fault: PreparedBertConfigUnsignedFault::Exponent,
-            at,
-        });
+        return Err(PreparedBertConfigUnsignedFault::Exponent);
     }
     let mut value = 0_u64;
-    for digit in &bytes[token.range] {
+    for digit in &bytes[token.range.clone()] {
         value = value
             .checked_mul(10)
             .and_then(|value| value.checked_add(u64::from(*digit - b'0')))
-            .ok_or(PreparedBertConfigError::InvalidUnsignedInteger {
-                field,
-                fault: PreparedBertConfigUnsignedFault::Overflow,
-                at,
-            })?;
+            .ok_or(PreparedBertConfigUnsignedFault::Overflow)?;
     }
     Ok(value)
 }
@@ -985,6 +1079,9 @@ mod tests {
     use crate::model::bert::prepared_facts::{
         BertGeometryLimits, BertPoolerMembers, PreparedBertFactError, RawBertConfigFacts,
         analyze_prepared_geometry,
+    };
+    use crate::model::bert::prepared_sequence_cap::{
+        PreparedBertSequenceCapKey, RawPreparedBertSequenceCapCandidate,
     };
     use std::num::NonZeroU64;
 
@@ -1526,5 +1623,85 @@ mod tests {
             parse(&bytes).unwrap()
         };
         assert_eq!(parsed.raw(), expected_raw(1e-12));
+    }
+
+    #[test]
+    fn model_max_length_wins_and_absence_falls_back_to_position_embeddings() {
+        assert_eq!(
+            parse(CANONICAL.as_bytes())
+                .unwrap()
+                .sequence_cap_candidate(),
+            Ok(RawPreparedBertSequenceCapCandidate::new(
+                PreparedBertSequenceCapKey::MaxPositionEmbeddings,
+                19,
+            ))
+        );
+
+        let present = document_with(None, None, &[("model_max_length", "128")]);
+        assert_eq!(
+            parse(present.as_bytes()).unwrap().sequence_cap_candidate(),
+            Ok(RawPreparedBertSequenceCapCandidate::new(
+                PreparedBertSequenceCapKey::ModelMaxLength,
+                128,
+            ))
+        );
+    }
+
+    #[test]
+    fn present_model_max_length_rejects_non_positive_or_inexact_u64_without_fallback() {
+        let string = document_with(None, None, &[("model_max_length", "\"128\"")]);
+        assert!(matches!(
+            parse(string.as_bytes()).unwrap().sequence_cap_candidate(),
+            Err(PreparedBertConfigSequenceCandidateError::InvalidType {
+                key: PreparedBertSequenceCapKey::ModelMaxLength,
+                actual: PreparedBertConfigValueKind::String,
+                ..
+            })
+        ));
+
+        for (value, fault) in [
+            ("0", PreparedBertConfigUnsignedFault::Zero),
+            ("-1", PreparedBertConfigUnsignedFault::Negative),
+            ("1.0", PreparedBertConfigUnsignedFault::Fractional),
+            ("1e0", PreparedBertConfigUnsignedFault::Exponent),
+            (
+                "18446744073709551616",
+                PreparedBertConfigUnsignedFault::Overflow,
+            ),
+        ] {
+            let document = document_with(None, None, &[("model_max_length", value)]);
+            assert!(matches!(
+                parse(document.as_bytes())
+                    .unwrap()
+                    .sequence_cap_candidate(),
+                Err(PreparedBertConfigSequenceCandidateError::InvalidPositiveInteger {
+                    key: PreparedBertSequenceCapKey::ModelMaxLength,
+                    fault: actual,
+                    ..
+                }) if actual == fault
+            ));
+        }
+    }
+
+    #[test]
+    fn decoded_model_max_length_duplicates_are_rejected() {
+        let duplicate = document_with(
+            None,
+            None,
+            &[
+                ("model_max_length", "128"),
+                ("model_max_\\u006cength", "64"),
+            ],
+        );
+        let first_at = duplicate.find("\"model_max_length\"").unwrap();
+        let duplicate_at = duplicate.rfind("\"model_max_\\u006cength\"").unwrap();
+        assert_eq!(
+            parse(duplicate.as_bytes()),
+            Err(PreparedBertConfigError::DuplicateField {
+                field: PreparedBertConfigField::ModelMaxLength,
+                first_at,
+                duplicate_at,
+            })
+        );
     }
 }


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Governance and stack

Draft implementation work for proposed Lattice ADR-088 and Khive ADR-160. Do not merge until the governing specification is accepted and the parent stack is ready.

Stacked on #1431. This slice is private, dormant, and has no production caller.

## What this adds

- prepared `config.json` sequence-candidate facts for `model_max_length` and the already-required `max_position_embeddings`
- exact in-file precedence: a present `model_max_length` wins; absence selects `max_position_embeddings`
- an owned deferred typed fault for a present string, zero, negative, fractional, exponent, or overflowing `model_max_length`, with no fallback to `max_position_embeddings`
- decoded-key duplicate detection, including literal/escaped aliases

Candidate-value faults are retained in the parsed facts instead of failing the outer geometry parse. This preserves whole-file precedence: a later valid `tokenizer_config.json` candidate may shadow the config candidate without observing its deferred fault. A literal/escaped duplicate remains a document-level config parser error.

This slice does not parse tokenizer configuration, cap at 2048, resolve cross-file precedence, compare against geometry/position rows, or construct a descriptor.

There is no filesystem/path access, allocation, attestation, loader integration, publication, serving callsite, or legacy behavior change.

## TDD evidence

Final-contract compile-first RED exited 101 with six missing production-symbol errors: four for `sequence_cap_candidate` and two for the deferred candidate error type. GREEN locks valid/absent precedence, deferred invalid-value faults without fallback, and literal/escaped duplicate rejection.

## Verification

```text
Focused prepared_config tests
16 passed; 0 failed

RUSTC_WRAPPER= cargo clippy -p lattice-inference --lib --tests -j4 -- -D warnings
PASS

cargo fmt --all -- --check
PASS

git diff --check
PASS

repository pre-commit hook
PASS

focused Blocker/High production review
0 Blocker; 0 High
```

## ADR-087 benchmark disposition

Evaluated at PR head `b94de84ec861b9e5de83b7482c17bceb9d54619a` against the 25-target `lattice-inference` benchmark surface at base `8ef720c124c5b97901c962c3d19f4a4163d1913a`; this proof is void if either ref moves.

The diff changes no manifest, dependency or lockfile version, feature set, profile, build script, generated source, benchmark definition, or harness input. It changes only the private dormant `prepared_config` module, which is outside ADR-087's corrected default A/B file surface, has no production caller, and is absent from every benchmark target's import and call surface. No reached benchmark file or symbol changes.

Ungated targets inspected: `differential_attention_bench`, `native_sparse_attention_bench`, `gated_attention_bench`, `inference_bench`, `tokenizer_bench`, `e2e_bench`, `inference_perf`, `topk_readback`, `quarot_hadamard_bench`, `lm_head_bench`, `elementwise_cpu_bench`, `grammar_mask_bench`, `elementwise_bench`, `attn_opt_bench`, `metrics_bench`, `pruning_bench`, `kv_cache_f16_bench`, and `attention_dispatch_bench`.

Feature-gated targets inspected: `decode_attn_bench` (`f16`), `kv_cache_layout_bench` (`bench-internals`), `metal_decode_bench` (`metal-gpu`, `f16`), `cross_turn_prefix_cache_bench` (`metal-gpu`, `f16`), `mtp_decode` (`metal-gpu`, `f16`), `backward_stage0` (`train-backward`), and `f16_convert_bench` (`bench-internals`).

This is a pinned D3-A Step-1 unreachability disposition, not a Form-1 item-addition proof: existing dormant parser items change. The compiled crate still carries binary/codegen residual risk. This slice is unmeasured, not performance-neutral. Any live prepared-mode callsite must re-evaluate reachability and provide targeted measurement when required.

## Explicit exclusions

- tokenizer-config parsing or tokenizer-config-to-config cross-file precedence
- the 2048 cap, geometry/position-row validation, or realized descriptor fields
- filesystem inventory, handles, snapshots, copy, or TOCTOU closure
- attestation, model loading, publication, or serving
- public API, legacy behavior changes, Qwen, Metal, or remote providers

## Child draft

- #1433 — dormant parsed-facts sequence-cap adapter
