### PR TITLE
feat(inference): compose prepared sequence cap facts

### DIFF
--- a/crates/inference/src/model/bert.rs
+++ b/crates/inference/src/model/bert.rs
@@ -42,6 +42,9 @@ mod prepared_tokenizer_config;
 mod prepared_sequence_cap;
 
 #[cfg_attr(not(test), allow(dead_code))]
+mod prepared_sequence_cap_adapter;
+
+#[cfg_attr(not(test), allow(dead_code))]
 mod prepared_tokenizer_json_model;
 
 /// Per-layer fused Q/K/V weight+bias, built once at model-load time from a

--- a/crates/inference/src/model/bert/prepared_sequence_cap_adapter.rs
+++ b/crates/inference/src/model/bert/prepared_sequence_cap_adapter.rs
@@ -1,0 +1,212 @@
+//! Dormant adapter from parsed prepared-BERT config facts to sequence-cap resolution.
+
+use super::prepared_config::{ParsedBertConfigFacts, PreparedBertConfigSequenceCandidateError};
+use super::prepared_sequence_cap::{
+    PreparedBertSequenceCap, PreparedBertSequenceCapError, PreparedBertSequenceCapKey,
+    RawPreparedBertSequenceCapCandidate, RawPreparedBertSequenceCapCandidates,
+    resolve_prepared_bert_sequence_cap,
+};
+use super::prepared_tokenizer_config::{
+    ParsedBertTokenizerConfigFacts, PreparedBertTokenizerConfigCandidateKey,
+    PreparedBertTokenizerMaxLengthCandidate,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PreparedBertParsedSequenceCapError {
+    ConfigJsonCandidate(PreparedBertConfigSequenceCandidateError),
+    Resolver(PreparedBertSequenceCapError),
+}
+
+pub(super) fn resolve_prepared_bert_sequence_cap_from_facts(
+    tokenizer_config: ParsedBertTokenizerConfigFacts,
+    config: ParsedBertConfigFacts,
+) -> Result<Option<PreparedBertSequenceCap>, PreparedBertParsedSequenceCapError> {
+    let tokenizer_config_json = tokenizer_config.candidate().map(map_tokenizer_candidate);
+    let config_json = if tokenizer_config_json.is_some() {
+        None
+    } else {
+        Some(
+            config
+                .sequence_cap_candidate()
+                .map_err(PreparedBertParsedSequenceCapError::ConfigJsonCandidate)?,
+        )
+    };
+    resolve_prepared_bert_sequence_cap(RawPreparedBertSequenceCapCandidates::new(
+        tokenizer_config_json,
+        config_json,
+    ))
+    .map_err(PreparedBertParsedSequenceCapError::Resolver)
+}
+
+fn map_tokenizer_candidate(
+    candidate: PreparedBertTokenizerMaxLengthCandidate,
+) -> RawPreparedBertSequenceCapCandidate {
+    let key = match candidate.key() {
+        PreparedBertTokenizerConfigCandidateKey::ModelMaxLength => {
+            PreparedBertSequenceCapKey::ModelMaxLength
+        }
+        PreparedBertTokenizerConfigCandidateKey::MaxPositionEmbeddings => {
+            PreparedBertSequenceCapKey::MaxPositionEmbeddings
+        }
+        PreparedBertTokenizerConfigCandidateKey::NPositions => {
+            PreparedBertSequenceCapKey::NPositions
+        }
+        PreparedBertTokenizerConfigCandidateKey::MaxSeqLen => PreparedBertSequenceCapKey::MaxSeqLen,
+        PreparedBertTokenizerConfigCandidateKey::TruncationMaxLength => {
+            PreparedBertSequenceCapKey::TruncationMaxLength
+        }
+    };
+    RawPreparedBertSequenceCapCandidate::new(key, candidate.raw_value())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::bert::prepared_config::{
+        PreparedBertConfigLimits, PreparedBertConfigValueKind, parse_prepared_bert_config_json,
+    };
+    use crate::model::bert::prepared_sequence_cap::PreparedBertSequenceCapSource;
+    use crate::model::bert::prepared_tokenizer_config::{
+        PreparedBertTokenizerConfigLimits, parse_prepared_bert_tokenizer_config_json,
+    };
+    use std::num::NonZeroU64;
+
+    const CONFIG: &str = concat!(
+        "{\"vocab_size\":11,",
+        "\"hidden_size\":12,",
+        "\"num_hidden_layers\":3,",
+        "\"num_attention_heads\":3,",
+        "\"intermediate_size\":17,",
+        "\"max_position_embeddings\":19,",
+        "\"type_vocab_size\":5,",
+        "\"layer_norm_eps\":1e-12}"
+    );
+
+    fn nz(value: u64) -> NonZeroU64 {
+        NonZeroU64::new(value).unwrap()
+    }
+
+    fn parse_config(bytes: &[u8]) -> ParsedBertConfigFacts {
+        let len = u64::try_from(bytes.len()).unwrap();
+        let limits = PreparedBertConfigLimits::try_new(nz(len), nz(len * 2)).unwrap();
+        parse_prepared_bert_config_json(bytes, &limits).unwrap()
+    }
+
+    fn parse_tokenizer_config(bytes: &[u8]) -> ParsedBertTokenizerConfigFacts {
+        let len = u64::try_from(bytes.len()).unwrap();
+        let limits = PreparedBertTokenizerConfigLimits::try_new(nz(len), nz(len * 2)).unwrap();
+        parse_prepared_bert_tokenizer_config_json(bytes, &limits).unwrap()
+    }
+
+    fn config_with_model_max_length(value: &str) -> String {
+        CONFIG.replacen(
+            "\"type_vocab_size\"",
+            &format!("\"model_max_length\":{value},\"type_vocab_size\""),
+            1,
+        )
+    }
+
+    #[test]
+    fn every_tokenizer_key_maps_exhaustively_and_shadows_deferred_config_failure() {
+        use PreparedBertSequenceCapKey::{
+            MaxPositionEmbeddings, MaxSeqLen, ModelMaxLength, NPositions, TruncationMaxLength,
+        };
+
+        let invalid_config = parse_config(config_with_model_max_length("\"bad\"").as_bytes());
+        for (json, expected_key) in [
+            (br#"{"model_max_length":3000}"#.as_slice(), ModelMaxLength),
+            (
+                br#"{"max_position_embeddings":3000}"#.as_slice(),
+                MaxPositionEmbeddings,
+            ),
+            (br#"{"n_positions":3000}"#.as_slice(), NPositions),
+            (br#"{"max_seq_len":3000}"#.as_slice(), MaxSeqLen),
+            (
+                br#"{"truncation":{"max_length":3000}}"#.as_slice(),
+                TruncationMaxLength,
+            ),
+        ] {
+            let resolved = resolve_prepared_bert_sequence_cap_from_facts(
+                parse_tokenizer_config(json),
+                invalid_config,
+            )
+            .unwrap()
+            .unwrap();
+            assert_eq!(
+                (
+                    resolved.source(),
+                    resolved.key(),
+                    resolved.raw_value().get(),
+                    resolved.capped_value().get(),
+                ),
+                (
+                    PreparedBertSequenceCapSource::TokenizerConfigJson,
+                    expected_key,
+                    3000,
+                    2048,
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn missing_tokenizer_candidate_uses_config_model_max_length_or_position_fallback() {
+        let no_tokenizer_candidate = parse_tokenizer_config(br#"{}"#);
+        for (config, expected_key, raw_value, capped_value) in [
+            (
+                parse_config(config_with_model_max_length("4096").as_bytes()),
+                PreparedBertSequenceCapKey::ModelMaxLength,
+                4096,
+                2048,
+            ),
+            (
+                parse_config(CONFIG.as_bytes()),
+                PreparedBertSequenceCapKey::MaxPositionEmbeddings,
+                19,
+                19,
+            ),
+        ] {
+            let resolved =
+                resolve_prepared_bert_sequence_cap_from_facts(no_tokenizer_candidate, config)
+                    .unwrap()
+                    .unwrap();
+            assert_eq!(resolved.source(), PreparedBertSequenceCapSource::ConfigJson);
+            assert_eq!(resolved.key(), expected_key);
+            assert_eq!(resolved.raw_value().get(), raw_value);
+            assert_eq!(resolved.capped_value().get(), capped_value);
+        }
+    }
+
+    #[test]
+    fn missing_tokenizer_candidate_surfaces_deferred_config_and_resolver_errors() {
+        let no_tokenizer_candidate = parse_tokenizer_config(br#"{}"#);
+        let invalid_config = parse_config(config_with_model_max_length("\"bad\"").as_bytes());
+        assert!(matches!(
+            resolve_prepared_bert_sequence_cap_from_facts(no_tokenizer_candidate, invalid_config,),
+            Err(PreparedBertParsedSequenceCapError::ConfigJsonCandidate(
+                PreparedBertConfigSequenceCandidateError::InvalidType {
+                    key: PreparedBertSequenceCapKey::ModelMaxLength,
+                    actual: PreparedBertConfigValueKind::String,
+                    ..
+                }
+            ))
+        ));
+
+        let zero_positions = CONFIG.replace(
+            "\"max_position_embeddings\":19",
+            "\"max_position_embeddings\":0",
+        );
+        assert_eq!(
+            resolve_prepared_bert_sequence_cap_from_facts(
+                no_tokenizer_candidate,
+                parse_config(zero_positions.as_bytes()),
+            ),
+            Err(PreparedBertParsedSequenceCapError::Resolver(
+                PreparedBertSequenceCapError::Zero {
+                    source: PreparedBertSequenceCapSource::ConfigJson,
+                    key: PreparedBertSequenceCapKey::MaxPositionEmbeddings,
+                }
+            ))
+        );
+    }
+}


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Governance and stack

Draft implementation work for proposed Lattice ADR-088 and Khive ADR-160. Do not merge until the governing specification is accepted and the parent stack is ready.

Stacked on #1432. This slice is private, dormant, and has no production caller.

## What this adds

- composition from parsed `tokenizer_config.json` and `config.json` facts into #1430's canonical two-slot sequence-cap resolver
- exhaustive mapping of all five tokenizer-config candidate keys
- whole-file short-circuiting: a selected tokenizer-config candidate shadows the config-side candidate and its deferred fault
- typed propagation of a deferred config-side candidate fault only when tokenizer config provides no candidate
- reuse of the existing source/key/raw/`min(raw, 2048)` facts without duplicating precedence or cap logic

This slice does not parse bytes, validate the capped value against geometry or position rows, construct a descriptor, or make the prepared path live.

There is no filesystem/path access, allocation, attestation, loader integration, publication, serving callsite, or legacy behavior change.

## TDD evidence

Compile-first RED exited 101 with six missing API/type errors and one expected unused-import warning. GREEN locks all five key mappings, tokenizer-file short-circuiting over a deferred config fault, config `model_max_length`/position fallback, and distinct deferred-candidate versus resolver errors.

## Verification

```text
Focused prepared_sequence_cap_adapter tests
3 passed; 0 failed

RUSTC_WRAPPER= cargo clippy -p lattice-inference --lib --tests -j4 -- -D warnings
PASS

cargo fmt --all -- --check
PASS

git diff --check
PASS

repository pre-commit hook
PASS

focused Blocker/High production review
0 Blocker; 0 High
```

## ADR-087 benchmark disposition

Evaluated at PR head `219c110acfef43e23de9801ee08114af31b9c445` against the 25-target `lattice-inference` benchmark surface at base `b94de84ec861b9e5de83b7482c17bceb9d54619a`; this proof is void if either ref moves.

The diff changes no manifest, dependency or lockfile version, feature set, profile, build script, generated source, benchmark definition, or harness input. The reached `model/bert.rs` hunk adds only one private dormant module item and modifies no existing item. Recursively, the new module contains only new private fixed-size error plumbing, exhaustive key conversion, composition functions, and `cfg(test)` tests: no production caller, heap allocation, global/static initializer, linker/codegen attribute, exported symbol, unsafe/extern code, macro registration/export, allocator hook, or trait implementation on an existing type.

Ungated targets inspected: `differential_attention_bench`, `native_sparse_attention_bench`, `gated_attention_bench`, `inference_bench`, `tokenizer_bench`, `e2e_bench`, `inference_perf`, `topk_readback`, `quarot_hadamard_bench`, `lm_head_bench`, `elementwise_cpu_bench`, `grammar_mask_bench`, `elementwise_bench`, `attn_opt_bench`, `metrics_bench`, `pruning_bench`, `kv_cache_f16_bench`, and `attention_dispatch_bench`.

Feature-gated targets inspected: `decode_attn_bench` (`f16`), `kv_cache_layout_bench` (`bench-internals`), `metal_decode_bench` (`metal-gpu`, `f16`), `cross_turn_prefix_cache_bench` (`metal-gpu`, `f16`), `mtp_decode` (`metal-gpu`, `f16`), `backward_stage0` (`train-backward`), and `f16_convert_bench` (`bench-internals`).

None of the 25 targets imports or calls the new module. A compiled-artifact residual remains. This slice is unmeasured, not performance-neutral. Any live prepared-mode callsite must re-evaluate reachability and provide targeted measurement when required.

## Explicit exclusions

- JSON parsing or source-file discovery
- sequence-cap vs geometry/position-row validation or final descriptor fields
- filesystem inventory, handles, snapshots, copy, or TOCTOU closure
- tokenizer content validation, attestation, model loading, publication, or serving
- public API, legacy behavior changes, Qwen, Metal, or remote providers

## Child draft

- #1434 — dormant sequence-cap finalization against validated position rows
