### PR TITLE
feat(inference): finalize prepared sequence cap facts

### DIFF
--- a/crates/inference/src/model/bert.rs
+++ b/crates/inference/src/model/bert.rs
@@ -45,6 +45,9 @@ mod prepared_sequence_cap;
 mod prepared_sequence_cap_adapter;
 
 #[cfg_attr(not(test), allow(dead_code))]
+mod prepared_sequence_cap_finalizer;
+
+#[cfg_attr(not(test), allow(dead_code))]
 mod prepared_tokenizer_json_model;
 
 /// Per-layer fused Q/K/V weight+bias, built once at model-load time from a

--- a/crates/inference/src/model/bert/prepared_sequence_cap_finalizer.rs
+++ b/crates/inference/src/model/bert/prepared_sequence_cap_finalizer.rs
@@ -1,0 +1,186 @@
+//! Dormant final validation of prepared-BERT sequence-cap facts against matched tensors.
+
+use super::prepared_sequence_cap::{
+    PreparedBertSequenceCap, PreparedBertSequenceCapKey, PreparedBertSequenceCapSource,
+};
+use super::prepared_tensor_inventory::MatchedBertInventoryFacts;
+use std::num::NonZeroU64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PreparedBertSequenceCapFinalizationError {
+    ExceedsValidatedPositionRows {
+        capped_value: NonZeroU64,
+        validated_position_rows: usize,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct RealizedPreparedBertSequenceCapFacts {
+    source: PreparedBertSequenceCapSource,
+    key: PreparedBertSequenceCapKey,
+    raw_value: NonZeroU64,
+    capped_value: NonZeroU64,
+    validated_position_rows: usize,
+}
+
+impl RealizedPreparedBertSequenceCapFacts {
+    pub(super) fn source(self) -> PreparedBertSequenceCapSource {
+        self.source
+    }
+
+    pub(super) fn key(self) -> PreparedBertSequenceCapKey {
+        self.key
+    }
+
+    pub(super) fn raw_value(self) -> NonZeroU64 {
+        self.raw_value
+    }
+
+    pub(super) fn capped_value(self) -> NonZeroU64 {
+        self.capped_value
+    }
+
+    pub(super) fn validated_position_rows(self) -> usize {
+        self.validated_position_rows
+    }
+}
+
+pub(super) fn finalize_prepared_bert_sequence_cap(
+    sequence_cap: PreparedBertSequenceCap,
+    matched_inventory: MatchedBertInventoryFacts,
+) -> Result<RealizedPreparedBertSequenceCapFacts, PreparedBertSequenceCapFinalizationError> {
+    finalize_prepared_bert_sequence_cap_with_position_rows(
+        sequence_cap,
+        matched_inventory.geometry().position_embeddings(),
+    )
+}
+
+fn finalize_prepared_bert_sequence_cap_with_position_rows(
+    sequence_cap: PreparedBertSequenceCap,
+    validated_position_rows: usize,
+) -> Result<RealizedPreparedBertSequenceCapFacts, PreparedBertSequenceCapFinalizationError> {
+    let capped_value = sequence_cap.capped_value();
+    if u64::try_from(validated_position_rows)
+        .is_ok_and(|validated_position_rows| capped_value.get() > validated_position_rows)
+    {
+        return Err(
+            PreparedBertSequenceCapFinalizationError::ExceedsValidatedPositionRows {
+                capped_value,
+                validated_position_rows,
+            },
+        );
+    }
+    Ok(RealizedPreparedBertSequenceCapFacts {
+        source: sequence_cap.source(),
+        key: sequence_cap.key(),
+        raw_value: sequence_cap.raw_value(),
+        capped_value,
+        validated_position_rows,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::bert::prepared_sequence_cap::{
+        RawPreparedBertSequenceCapCandidate, RawPreparedBertSequenceCapCandidates,
+        resolve_prepared_bert_sequence_cap,
+    };
+
+    fn nz(value: u64) -> NonZeroU64 {
+        NonZeroU64::new(value).unwrap()
+    }
+
+    fn sequence_cap(
+        source: PreparedBertSequenceCapSource,
+        key: PreparedBertSequenceCapKey,
+        raw_value: u64,
+    ) -> PreparedBertSequenceCap {
+        let candidate = RawPreparedBertSequenceCapCandidate::new(key, raw_value);
+        let candidates = match source {
+            PreparedBertSequenceCapSource::TokenizerConfigJson => {
+                RawPreparedBertSequenceCapCandidates::new(Some(candidate), None)
+            }
+            PreparedBertSequenceCapSource::ConfigJson => {
+                RawPreparedBertSequenceCapCandidates::new(None, Some(candidate))
+            }
+        };
+        resolve_prepared_bert_sequence_cap(candidates)
+            .unwrap()
+            .unwrap()
+    }
+
+    #[test]
+    fn exact_and_capped_values_fit_validated_position_rows_and_preserve_all_facts() {
+        let _entrypoint: fn(
+            PreparedBertSequenceCap,
+            MatchedBertInventoryFacts,
+        ) -> Result<
+            RealizedPreparedBertSequenceCapFacts,
+            PreparedBertSequenceCapFinalizationError,
+        > = finalize_prepared_bert_sequence_cap;
+
+        for (source, key, raw_value, capped_value) in [
+            (
+                PreparedBertSequenceCapSource::ConfigJson,
+                PreparedBertSequenceCapKey::ModelMaxLength,
+                2048,
+                2048,
+            ),
+            (
+                PreparedBertSequenceCapSource::TokenizerConfigJson,
+                PreparedBertSequenceCapKey::NPositions,
+                2049,
+                2048,
+            ),
+        ] {
+            let realized = finalize_prepared_bert_sequence_cap_with_position_rows(
+                sequence_cap(source, key, raw_value),
+                2048,
+            )
+            .unwrap();
+            assert_eq!(realized.source(), source);
+            assert_eq!(realized.key(), key);
+            assert_eq!(realized.raw_value(), nz(raw_value));
+            assert_eq!(realized.capped_value(), nz(capped_value));
+            assert_eq!(realized.validated_position_rows(), 2048);
+        }
+    }
+
+    #[test]
+    fn capped_values_above_validated_position_rows_fail_at_exact_boundaries() {
+        for (sequence_cap, validated_position_rows, capped_value) in [
+            (
+                sequence_cap(
+                    PreparedBertSequenceCapSource::ConfigJson,
+                    PreparedBertSequenceCapKey::MaxPositionEmbeddings,
+                    513,
+                ),
+                512,
+                513,
+            ),
+            (
+                sequence_cap(
+                    PreparedBertSequenceCapSource::TokenizerConfigJson,
+                    PreparedBertSequenceCapKey::TruncationMaxLength,
+                    4096,
+                ),
+                1024,
+                2048,
+            ),
+        ] {
+            assert_eq!(
+                finalize_prepared_bert_sequence_cap_with_position_rows(
+                    sequence_cap,
+                    validated_position_rows,
+                ),
+                Err(
+                    PreparedBertSequenceCapFinalizationError::ExceedsValidatedPositionRows {
+                        capped_value: nz(capped_value),
+                        validated_position_rows,
+                    }
+                )
+            );
+        }
+    }
+}


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Governance and stack

Draft implementation work for proposed Lattice ADR-088 and Khive ADR-160. Do not merge until the governing specification is accepted and the parent stack is ready.

Stacked on #1433. This slice is private, dormant, and has no production caller.

## What this adds

- finalization of an already-resolved sequence cap against `MatchedBertInventoryFacts`
- proof that the capped value does not exceed the position-embedding rows validated from the required tensor inventory
- realized facts preserving source, key, raw value, capped value, and validated position-row count
- a typed failure when the capped value exceeds validated rows

The API deliberately requires matched inventory facts rather than free geometry or a caller-supplied row count. This keeps actual tensor-shape validation in the authority chain.

This slice does not parse bytes, inspect files, build a tokenizer/model, construct a descriptor, or make the prepared path live.

There is no filesystem/path access, allocation, attestation, loader integration, publication, serving callsite, or legacy behavior change.

## TDD evidence

Compile-first RED exited 101 with four missing type/function errors and one expected unused-import warning. GREEN locks equality, cap-before-row comparison, exact overflow cases, and preservation of every resolved fact.

## Verification

```text
Focused prepared_sequence_cap_finalizer tests
2 passed; 0 failed

RUSTC_WRAPPER= cargo clippy -p lattice-inference --lib --tests -j4 -- -D warnings
PASS

cargo fmt --all -- --check
PASS

git diff --check
PASS

repository pre-commit hook
PASS

focused Blocker/High production review
0 Blocker; 0 High
```

## ADR-087 benchmark disposition

Evaluated at PR head `8f0afdd846ae26d58a2b3fb05ef0d17ac01a071a` against the 25-target `lattice-inference` benchmark surface at base `219c110acfef43e23de9801ee08114af31b9c445`; this proof is void if either ref moves.

The diff changes no manifest, dependency or lockfile version, feature set, profile, build script, generated source, benchmark definition, or harness input. The reached `model/bert.rs` hunk adds only one private dormant module item and modifies no existing item. Recursively, the new module contains only new private fixed-size facts/errors, ordinary accessors/finalization functions, and `cfg(test)` tests: no production caller, heap allocation, global/static initializer, linker/codegen attribute, exported symbol, unsafe/extern code, macro registration/export, allocator hook, or trait implementation on an existing type.

Ungated targets inspected: `differential_attention_bench`, `native_sparse_attention_bench`, `gated_attention_bench`, `inference_bench`, `tokenizer_bench`, `e2e_bench`, `inference_perf`, `topk_readback`, `quarot_hadamard_bench`, `lm_head_bench`, `elementwise_cpu_bench`, `grammar_mask_bench`, `elementwise_bench`, `attn_opt_bench`, `metrics_bench`, `pruning_bench`, `kv_cache_f16_bench`, and `attention_dispatch_bench`.

Feature-gated targets inspected: `decode_attn_bench` (`f16`), `kv_cache_layout_bench` (`bench-internals`), `metal_decode_bench` (`metal-gpu`, `f16`), `cross_turn_prefix_cache_bench` (`metal-gpu`, `f16`), `mtp_decode` (`metal-gpu`, `f16`), `backward_stage0` (`train-backward`), and `f16_convert_bench` (`bench-internals`).

None of the 25 targets imports or calls the new module. A compiled-artifact residual remains. This slice is unmeasured, not performance-neutral. Any live prepared-mode callsite must re-evaluate reachability and provide targeted measurement when required.

## Explicit exclusions

- JSON parsing, cross-file candidate composition, or source-file discovery
- descriptor canonicalization or tokenizer/model construction
- filesystem inventory, handles, snapshots, copy, or TOCTOU closure
- tokenizer content validation, attestation, model loading, publication, or serving
- public API, legacy behavior changes, Qwen, Metal, or remote providers

## Child draft

- #1435 — bounded prepared tokenizer JSON model-type parser
