### PR TITLE
feat(inference): match prepared WordPiece vocab facts

### DIFF
--- a/crates/inference/src/model/bert.rs
+++ b/crates/inference/src/model/bert.rs
@@ -53,6 +53,9 @@ mod prepared_tokenizer_json_model;
 #[cfg_attr(not(test), allow(dead_code))]
 mod prepared_vocab_txt;
 
+#[cfg_attr(not(test), allow(dead_code))]
+mod prepared_wordpiece_vocab_match;
+
 /// Per-layer fused Q/K/V weight+bias, built once at model-load time from a
 /// `TransformerLayerWeights` layer's separate `query`/`key`/`value` tensors.
 ///

--- a/crates/inference/src/model/bert/prepared_wordpiece_vocab_match.rs
+++ b/crates/inference/src/model/bert/prepared_wordpiece_vocab_match.rs
@@ -1,0 +1,180 @@
+//! Dormant prepared-BERT WordPiece vocabulary/cardinality agreement.
+//!
+//! The tensor matcher proves that the prepared geometry's vocabulary size is
+//! both the strict `config.json` value and the first dimension of the required
+//! word-embedding tensor. This module adds the selected WordPiece `vocab.txt`
+//! dense-cardinality proof without accepting a caller-supplied row count.
+
+use super::prepared_tensor_inventory::MatchedBertInventoryFacts;
+use super::prepared_vocab_txt::PreparedBertWordPieceVocabTxtFacts;
+use std::num::NonZeroU64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PreparedBertWordPieceVocabMatchError {
+    TokenizerCardinalityPlatformUnrepresentable {
+        cardinality: NonZeroU64,
+    },
+    VocabularyCardinalityMismatch {
+        tokenizer_cardinality: NonZeroU64,
+        validated_config_and_embedding_rows: usize,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct MatchedPreparedBertWordPieceVocabFacts {
+    wordpiece_vocab: PreparedBertWordPieceVocabTxtFacts,
+    model_inventory: MatchedBertInventoryFacts,
+}
+
+impl MatchedPreparedBertWordPieceVocabFacts {
+    pub(super) fn wordpiece_vocab(self) -> PreparedBertWordPieceVocabTxtFacts {
+        self.wordpiece_vocab
+    }
+
+    pub(super) fn model_inventory(self) -> MatchedBertInventoryFacts {
+        self.model_inventory
+    }
+}
+
+pub(super) fn match_prepared_bert_wordpiece_vocab(
+    wordpiece_vocab: PreparedBertWordPieceVocabTxtFacts,
+    model_inventory: MatchedBertInventoryFacts,
+) -> Result<MatchedPreparedBertWordPieceVocabFacts, PreparedBertWordPieceVocabMatchError> {
+    validate_cardinality(wordpiece_vocab, model_inventory.geometry().vocab_size())?;
+    Ok(MatchedPreparedBertWordPieceVocabFacts {
+        wordpiece_vocab,
+        model_inventory,
+    })
+}
+
+fn validate_cardinality(
+    wordpiece_vocab: PreparedBertWordPieceVocabTxtFacts,
+    validated_config_and_embedding_rows: usize,
+) -> Result<(), PreparedBertWordPieceVocabMatchError> {
+    let tokenizer_cardinality = wordpiece_vocab.vocab_txt().vocabulary_cardinality();
+    validate_cardinality_with_platform_max(
+        tokenizer_cardinality,
+        validated_config_and_embedding_rows,
+        usize::MAX as u64,
+    )
+}
+
+fn validate_cardinality_with_platform_max(
+    tokenizer_cardinality: NonZeroU64,
+    validated_config_and_embedding_rows: usize,
+    platform_max: u64,
+) -> Result<(), PreparedBertWordPieceVocabMatchError> {
+    if tokenizer_cardinality.get() > platform_max {
+        return Err(
+            PreparedBertWordPieceVocabMatchError::TokenizerCardinalityPlatformUnrepresentable {
+                cardinality: tokenizer_cardinality,
+            },
+        );
+    }
+    let tokenizer_cardinality_usize =
+        usize::try_from(tokenizer_cardinality.get()).map_err(|_| {
+            PreparedBertWordPieceVocabMatchError::TokenizerCardinalityPlatformUnrepresentable {
+                cardinality: tokenizer_cardinality,
+            }
+        })?;
+    if tokenizer_cardinality_usize != validated_config_and_embedding_rows {
+        return Err(
+            PreparedBertWordPieceVocabMatchError::VocabularyCardinalityMismatch {
+                tokenizer_cardinality,
+                validated_config_and_embedding_rows,
+            },
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::bert::prepared_vocab_txt::{
+        PreparedBertVocabTxtLimits, parse_prepared_bert_vocab_txt,
+        validate_prepared_bert_wordpiece_vocab_txt,
+    };
+    use std::num::NonZeroU64;
+
+    fn nz(value: u64) -> NonZeroU64 {
+        match NonZeroU64::new(value) {
+            Some(value) => value,
+            None => panic!("test limit must be nonzero"),
+        }
+    }
+
+    fn wordpiece() -> PreparedBertWordPieceVocabTxtFacts {
+        let limits =
+            match PreparedBertVocabTxtLimits::try_new(nz(256), nz(16), nz(1024), nz(16_384)) {
+                Ok(limits) => limits,
+                Err(error) => panic!("valid limits: {error:?}"),
+            };
+        let generic = match parse_prepared_bert_vocab_txt(
+            b"[CLS]\n[SEP]\n[PAD]\n[UNK]\n[MASK]\nordinary",
+            &limits,
+        ) {
+            Ok(facts) => facts,
+            Err(error) => panic!("valid vocab: {error:?}"),
+        };
+        match validate_prepared_bert_wordpiece_vocab_txt(generic) {
+            Ok(facts) => facts,
+            Err(error) => panic!("valid WordPiece vocab: {error:?}"),
+        }
+    }
+
+    #[test]
+    fn dense_cardinality_must_equal_validated_config_and_embedding_rows() {
+        let wordpiece = wordpiece();
+        assert_eq!(validate_cardinality(wordpiece, 6), Ok(()));
+        for rows in [5, 7] {
+            assert_eq!(
+                validate_cardinality(wordpiece, rows),
+                Err(
+                    PreparedBertWordPieceVocabMatchError::VocabularyCardinalityMismatch {
+                        tokenizer_cardinality: nz(6),
+                        validated_config_and_embedding_rows: rows,
+                    }
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn matching_does_not_rewrite_wordpiece_ids_or_generic_facts() {
+        let wordpiece = wordpiece();
+        assert_eq!(wordpiece.cls_id(), 0);
+        assert_eq!(wordpiece.sep_id(), 1);
+        assert_eq!(wordpiece.pad_id(), 2);
+        assert_eq!(wordpiece.unk_id(), 3);
+        assert_eq!(wordpiece.mask_id(), 4);
+        assert_eq!(wordpiece.vocab_txt().vocabulary_cardinality().get(), 6);
+        assert_eq!(validate_cardinality(wordpiece, 6), Ok(()));
+        assert_eq!(
+            validate_cardinality_with_platform_max(nz(6), 6, 5),
+            Err(
+                PreparedBertWordPieceVocabMatchError::TokenizerCardinalityPlatformUnrepresentable {
+                    cardinality: nz(6),
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn entrypoint_requires_and_retains_the_matched_inventory_capability() {
+        let _entrypoint: fn(
+            PreparedBertWordPieceVocabTxtFacts,
+            MatchedBertInventoryFacts,
+        ) -> Result<
+            MatchedPreparedBertWordPieceVocabFacts,
+            PreparedBertWordPieceVocabMatchError,
+        > = match_prepared_bert_wordpiece_vocab;
+        let _wordpiece_accessor: fn(
+            MatchedPreparedBertWordPieceVocabFacts,
+        ) -> PreparedBertWordPieceVocabTxtFacts =
+            MatchedPreparedBertWordPieceVocabFacts::wordpiece_vocab;
+        let _inventory_accessor: fn(
+            MatchedPreparedBertWordPieceVocabFacts,
+        ) -> MatchedBertInventoryFacts = MatchedPreparedBertWordPieceVocabFacts::model_inventory;
+    }
+}


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Governance and stack

Draft implementation work for proposed Lattice ADR-088 and Khive ADR-160. Do not merge until the governing specification is accepted and the parent stack is ready.

Stacked on #1437. This slice is private, dormant, and has no production caller.

## What this adds

- a pure evidence-composition finalizer that accepts the prepared WordPiece dense-vocabulary facts and the exact `MatchedBertInventoryFacts` capability
- exact equality between tokenizer cardinality and the geometry vocabulary size already proven against both strict `config.json` and `word_embeddings.weight` rows
- checked tokenizer `u64 → usize` conversion with a typed platform failure
- an owned success wrapper retaining both original proof inputs without reinspection or relabeling

Because the `vocab.txt` parser proves dense IDs and #1437 proves the five required WordPiece tokens come from that ID space, successful equality also proves those IDs are below validated model `V`. This does not generalize to other tokenizer layouts.

There is no free caller-supplied row count at the private entrypoint, allocation, parsing, filesystem access, tensor reinspection, loader integration, publication, serving callsite, or legacy behavior change.

## TDD evidence

Mutation RED: weakening exact equality to a one-sided comparison made the exact/±1 cardinality test fail 1/1; the restored implementation passed the full focused module.

## Verification

```text
Focused prepared_wordpiece_vocab_match tests
3 passed; 0 failed

RUSTC_WRAPPER= cargo clippy -p lattice-inference --lib --tests -j4 -- -D warnings
PASS

cargo fmt --all -- --check
PASS

git diff --check
PASS

repository pre-commit hook
PASS

focused Blocker/High production review
0 Blocker; 0 High
```

## ADR-087 benchmark disposition

Evaluated at PR head `4ada9d83d36abd7d3d78a885c7b883116c5849f3` against the 25-target `lattice-inference` benchmark surface at base `2a24d6697ca93d7f3feacc07959cc212738daa49`; this proof is void if either ref moves.

The diff adds only one private dormant module and its private declaration in `model/bert.rs`, outside ADR-087's corrected file surface. It changes no manifest, dependency or lockfile version, feature set, profile, build script, generated source, benchmark definition, or harness input. The module has no production caller and no declared default benchmark path imports or calls it.

Ungated targets inspected: `differential_attention_bench`, `native_sparse_attention_bench`, `gated_attention_bench`, `inference_bench`, `tokenizer_bench`, `e2e_bench`, `inference_perf`, `topk_readback`, `quarot_hadamard_bench`, `lm_head_bench`, `elementwise_cpu_bench`, `grammar_mask_bench`, `elementwise_bench`, `attn_opt_bench`, `metrics_bench`, `pruning_bench`, `kv_cache_f16_bench`, and `attention_dispatch_bench`.

Feature-gated targets inspected: `decode_attn_bench` (`f16`), `kv_cache_layout_bench` (`bench-internals`), `metal_decode_bench` (`metal-gpu`, `f16`), `cross_turn_prefix_cache_bench` (`metal-gpu`, `f16`), `mtp_decode` (`metal-gpu`, `f16`), `backward_stage0` (`train-backward`), and `f16_convert_bench` (`bench-internals`).

This is a pinned ADR-087 D3-A Step-1 file-level unreachability disposition. A compiled-artifact residual remains. This slice is unmeasured, not performance-neutral. Any live prepared-mode callsite must re-evaluate reachability and provide targeted measurement when required.

## Explicit exclusions

- BPE, tokenizer JSON/vocab JSON, SentencePiece, and added-token ID spaces
- tokenizer layout selection or tokenizer construction
- sequence-cap, token-type-ID, or special-token runtime routing
- filesystem inventory, handles, snapshots, copy, or TOCTOU closure
- attestation, model loading, publication, serving, or public API

## Child draft

- #1439 — raw BPE `vocab.txt` control-ID facts
