### PR TITLE
feat(inference): match prepared BPE vocab facts

### DIFF
--- a/crates/inference/src/model/bert.rs
+++ b/crates/inference/src/model/bert.rs
@@ -59,6 +59,9 @@ mod prepared_wordpiece_vocab_match;
 #[cfg_attr(not(test), allow(dead_code))]
 mod prepared_merges_txt;
 
+#[cfg_attr(not(test), allow(dead_code))]
+mod prepared_bpe_vocab_match;
+
 /// Per-layer fused Q/K/V weight+bias, built once at model-load time from a
 /// `TransformerLayerWeights` layer's separate `query`/`key`/`value` tensors.
 ///

--- a/crates/inference/src/model/bert/prepared_bpe_vocab_match.rs
+++ b/crates/inference/src/model/bert/prepared_bpe_vocab_match.rs
@@ -1,0 +1,195 @@
+//! Dormant prepared-BERT raw-BPE lexical vocabulary agreement.
+//!
+//! This module composes the selected dense `vocab.txt` facts, bounded lexical
+//! `merges.txt` census, and the matched config/tensor inventory capability. It
+//! proves only vocabulary-cardinality agreement for `VocabTxtMerges`; it does
+//! not claim retained merge operands, an effective rank map, emitted-token
+//! closure, tokenizer construction, or a live prepared path.
+
+use super::prepared_merges_txt::PreparedBertBpeMergesTxtLexicalFacts;
+use super::prepared_tensor_inventory::MatchedBertInventoryFacts;
+use super::prepared_vocab_txt::PreparedBertBpeVocabTxtFacts;
+use std::num::NonZeroU64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum PreparedBertBpeVocabMatchError {
+    TokenizerCardinalityPlatformUnrepresentable {
+        cardinality: NonZeroU64,
+    },
+    VocabularyCardinalityMismatch {
+        tokenizer_cardinality: NonZeroU64,
+        validated_config_and_embedding_rows: usize,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct MatchedPreparedBertBpeVocabTxtMergesLexicalFacts {
+    bpe_vocab: PreparedBertBpeVocabTxtFacts,
+    merges_lexical: PreparedBertBpeMergesTxtLexicalFacts,
+    model_inventory: MatchedBertInventoryFacts,
+}
+
+impl MatchedPreparedBertBpeVocabTxtMergesLexicalFacts {
+    pub(super) fn bpe_vocab(self) -> PreparedBertBpeVocabTxtFacts {
+        self.bpe_vocab
+    }
+
+    pub(super) fn merges_lexical(self) -> PreparedBertBpeMergesTxtLexicalFacts {
+        self.merges_lexical
+    }
+
+    pub(super) fn model_inventory(self) -> MatchedBertInventoryFacts {
+        self.model_inventory
+    }
+}
+
+pub(super) fn match_prepared_bert_bpe_vocab_txt_merges_lexical(
+    bpe_vocab: PreparedBertBpeVocabTxtFacts,
+    merges_lexical: PreparedBertBpeMergesTxtLexicalFacts,
+    model_inventory: MatchedBertInventoryFacts,
+) -> Result<MatchedPreparedBertBpeVocabTxtMergesLexicalFacts, PreparedBertBpeVocabMatchError> {
+    validate_cardinality(bpe_vocab, model_inventory.geometry().vocab_size())?;
+    Ok(MatchedPreparedBertBpeVocabTxtMergesLexicalFacts {
+        bpe_vocab,
+        merges_lexical,
+        model_inventory,
+    })
+}
+
+fn validate_cardinality(
+    bpe_vocab: PreparedBertBpeVocabTxtFacts,
+    validated_config_and_embedding_rows: usize,
+) -> Result<(), PreparedBertBpeVocabMatchError> {
+    let tokenizer_cardinality = bpe_vocab.vocab_txt().vocabulary_cardinality();
+    validate_cardinality_with_platform_max(
+        tokenizer_cardinality,
+        validated_config_and_embedding_rows,
+        usize::MAX as u64,
+    )
+}
+
+fn validate_cardinality_with_platform_max(
+    tokenizer_cardinality: NonZeroU64,
+    validated_config_and_embedding_rows: usize,
+    platform_max: u64,
+) -> Result<(), PreparedBertBpeVocabMatchError> {
+    if tokenizer_cardinality.get() > platform_max {
+        return Err(
+            PreparedBertBpeVocabMatchError::TokenizerCardinalityPlatformUnrepresentable {
+                cardinality: tokenizer_cardinality,
+            },
+        );
+    }
+    let tokenizer_cardinality_usize =
+        usize::try_from(tokenizer_cardinality.get()).map_err(|_| {
+            PreparedBertBpeVocabMatchError::TokenizerCardinalityPlatformUnrepresentable {
+                cardinality: tokenizer_cardinality,
+            }
+        })?;
+    if tokenizer_cardinality_usize != validated_config_and_embedding_rows {
+        return Err(
+            PreparedBertBpeVocabMatchError::VocabularyCardinalityMismatch {
+                tokenizer_cardinality,
+                validated_config_and_embedding_rows,
+            },
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::bert::prepared_merges_txt::{
+        PreparedBertBpeMergesTxtLimits, census_prepared_bert_bpe_merges_txt,
+    };
+    use crate::model::bert::prepared_vocab_txt::{
+        PreparedBertVocabTxtLimits, parse_prepared_bert_vocab_txt,
+        resolve_prepared_bert_bpe_vocab_txt,
+    };
+    use std::num::NonZeroU64;
+
+    fn nz(value: u64) -> NonZeroU64 {
+        match NonZeroU64::new(value) {
+            Some(value) => value,
+            None => panic!("test value must be nonzero"),
+        }
+    }
+
+    fn bpe_vocab() -> PreparedBertBpeVocabTxtFacts {
+        let limits = match PreparedBertVocabTxtLimits::try_new(nz(64), nz(8), nz(512), nz(4096)) {
+            Ok(limits) => limits,
+            Err(error) => panic!("valid limits: {error:?}"),
+        };
+        let vocab = match parse_prepared_bert_vocab_txt(b"a\nb\nc", &limits) {
+            Ok(vocab) => vocab,
+            Err(error) => panic!("valid vocab: {error:?}"),
+        };
+        resolve_prepared_bert_bpe_vocab_txt(vocab)
+    }
+
+    #[test]
+    fn dense_bpe_cardinality_must_equal_validated_config_and_embedding_rows() {
+        let bpe_vocab = bpe_vocab();
+        assert_eq!(validate_cardinality(bpe_vocab, 3), Ok(()));
+        for rows in [2, 4] {
+            assert_eq!(
+                validate_cardinality(bpe_vocab, rows),
+                Err(
+                    PreparedBertBpeVocabMatchError::VocabularyCardinalityMismatch {
+                        tokenizer_cardinality: nz(3),
+                        validated_config_and_embedding_rows: rows,
+                    }
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn platform_failure_precedes_cardinality_mismatch_and_empty_merges_are_valid() {
+        let bpe_vocab = bpe_vocab();
+        assert_eq!(
+            validate_cardinality_with_platform_max(nz(3), 2, 2),
+            Err(
+                PreparedBertBpeVocabMatchError::TokenizerCardinalityPlatformUnrepresentable {
+                    cardinality: nz(3),
+                }
+            )
+        );
+
+        let limits = match PreparedBertBpeMergesTxtLimits::try_new(nz(1), nz(1), nz(8)) {
+            Ok(limits) => limits,
+            Err(error) => panic!("valid limits: {error:?}"),
+        };
+        let merges = match census_prepared_bert_bpe_merges_txt(b"", &limits) {
+            Ok(merges) => merges,
+            Err(error) => panic!("empty merge list is valid: {error:?}"),
+        };
+        assert_eq!(merges.merge_entry_count(), 0);
+        assert_eq!(validate_cardinality(bpe_vocab, 3), Ok(()));
+    }
+
+    #[test]
+    fn entrypoint_requires_and_retains_all_three_evidence_capabilities() {
+        let _entrypoint: fn(
+            PreparedBertBpeVocabTxtFacts,
+            PreparedBertBpeMergesTxtLexicalFacts,
+            MatchedBertInventoryFacts,
+        ) -> Result<
+            MatchedPreparedBertBpeVocabTxtMergesLexicalFacts,
+            PreparedBertBpeVocabMatchError,
+        > = match_prepared_bert_bpe_vocab_txt_merges_lexical;
+        let _vocab_accessor: fn(
+            MatchedPreparedBertBpeVocabTxtMergesLexicalFacts,
+        ) -> PreparedBertBpeVocabTxtFacts =
+            MatchedPreparedBertBpeVocabTxtMergesLexicalFacts::bpe_vocab;
+        let _merges_accessor: fn(
+            MatchedPreparedBertBpeVocabTxtMergesLexicalFacts,
+        ) -> PreparedBertBpeMergesTxtLexicalFacts =
+            MatchedPreparedBertBpeVocabTxtMergesLexicalFacts::merges_lexical;
+        let _inventory_accessor: fn(
+            MatchedPreparedBertBpeVocabTxtMergesLexicalFacts,
+        ) -> MatchedBertInventoryFacts =
+            MatchedPreparedBertBpeVocabTxtMergesLexicalFacts::model_inventory;
+    }
+}


### PR DESCRIPTION
> _PR description authored by Codex (OpenAI agent) on behalf of @ohdearquant._

## Governance and stack

Draft implementation work for proposed Lattice ADR-088 and Khive ADR-160. Do not merge until the governing specification is accepted and the parent stack is ready.

Stacked on #1440. Continued by #1442. This slice is private, dormant, and has no production caller.

## What this adds

- a pure evidence-composition matcher for the selected raw `VocabTxtMerges` BPE layout
- exact equality between the dense `vocab.txt` cardinality and the vocabulary size already proven by `MatchedBertInventoryFacts` to equal both strict config V and word-embedding rows
- checked `u64` to `usize` conversion with a typed platform error before mismatch comparison
- a Copy success capability retaining the exact BPE vocab facts, bounded lexical `merges.txt` census, and matched config/tensor inventory

This proves only raw-BPE lexical vocabulary cardinality agreement. Empty merge lists remain valid. Retained operands, effective ranks, emitted-token closure, and tokenizer construction remain separate work.

## TDD evidence

Compile-first RED failed with 22 missing production-symbol errors and one expected unused-import warning.

Mutation RED: weakening equality to a one-sided comparison made the V-1 mismatch case fail 1/1; restoring exact equality returned the focused module to GREEN.

## Verification

```text
Focused prepared_bpe_vocab_match tests
3 passed; 0 failed

RUSTC_WRAPPER= cargo clippy -p lattice-inference --lib --tests -j4 -- -D warnings
PASS

cargo fmt --all -- --check
PASS

git diff --check
PASS

repository pre-commit hook
PASS

focused Blocker/High production reviews
0 Blocker; 0 High
```

## ADR-087 benchmark disposition

Evaluated at PR head `964656280c0877fc5821aaa050bb69922e8fa000` against the 25-target `lattice-inference` benchmark surface at base `f05be09040ee7d51e50d3c3f20708ff906514900`; this proof is void if either ref moves.

The diff changes only `crates/inference/src/model/bert.rs` and the new private dormant `crates/inference/src/model/bert/prepared_bpe_vocab_match.rs`, both outside ADR-087's corrected five-entry file surface. It changes no manifest, dependency or lockfile version, feature set, profile, build script, generated source, benchmark definition, or harness input. The new module contains only private new types, derives on those types, inherent methods, ordinary free functions, and cfg(test) tests. It has no global initializer, registration, allocator hook, linker/codegen attribute, macro side effect, unsafe code, or production caller.

Ungated targets inspected: `differential_attention_bench`, `native_sparse_attention_bench`, `gated_attention_bench`, `inference_bench`, `tokenizer_bench`, `e2e_bench`, `inference_perf`, `topk_readback`, `quarot_hadamard_bench`, `lm_head_bench`, `elementwise_cpu_bench`, `grammar_mask_bench`, `elementwise_bench`, `attn_opt_bench`, `metrics_bench`, `pruning_bench`, `kv_cache_f16_bench`, and `attention_dispatch_bench`.

Feature-gated targets inspected: `decode_attn_bench` (`f16`), `kv_cache_layout_bench` (`bench-internals`), `metal_decode_bench` (`metal-gpu`, `f16`), `cross_turn_prefix_cache_bench` (`metal-gpu`, `f16`), `mtp_decode` (`metal-gpu`, `f16`), `backward_stage0` (`train-backward`), and `f16_convert_bench` (`bench-internals`).

This is a pinned ADR-087 D3-A Step-1 file-level unreachability disposition. A compiled-artifact residual remains. This slice is unmeasured, not performance-neutral. Any live prepared-mode callsite must re-evaluate reachability and provide targeted measurement when required.

## Explicit exclusions

- retained merge operands, owned strings, unique-pair count, or effective first-wins rank map
- vocabulary membership, concatenated-token validity, emitted-ID closure, or tokenizer construction
- `vocab.json + merges.txt` and tokenizer.json layouts
- filesystem reads, recognized inventory, handles, snapshots, copy, or TOCTOU closure
- attestation, model loading, publication, serving, or public API
