### PR TITLE
fix(inference): reject unsupported MoE prefill on every request-facing path

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -6694,14 +6694,19 @@ mod inner {
         /// aborting; the assert stays as the internal invariant for direct callers of
         /// the batched chunk schedulers.
         ///
-        /// Wired into [`Self::try_forward_prefill`], which is the entry point every
-        /// request-facing generation path prefills through.
-        /// [`Self::forward_prefill_with_hidden`] and
-        /// [`Self::forward_prefill_all_logits`] enter the batched schedulers without
-        /// this check and still abort on an MoE model; their callers are the
-        /// perplexity/profiling paths rather than request handling. Extending the check
-        /// to them would change those paths from abort to `Err`, which is a separate
-        /// behaviour change from this rejection.
+        /// Wired into all three public entry points that can reach the batched
+        /// schedulers: [`Self::try_forward_prefill`],
+        /// [`Self::forward_prefill_with_hidden`], and
+        /// [`Self::forward_prefill_all_logits`]. Every request-facing caller prefills
+        /// through one of them — `generate`, `generate_streaming`, and
+        /// `generate_streaming_with_cancel` through the first, `embed_tokens` through
+        /// the first, `compute_token_nlls` through the last — so an MoE model reports
+        /// this input instead of aborting the process.
+        ///
+        /// [`Self::forward_prefill`] is the exception, by construction: it unwraps
+        /// [`Self::try_forward_prefill`]'s result, so it still aborts. Its remaining
+        /// callers are the bench and profiling examples, which treat an unsupported
+        /// checkpoint as a contract violation.
         fn check_prefill_moe_batched_unsupported(
             &self,
             entry_point: &str,
@@ -7201,11 +7206,12 @@ mod inner {
         /// # Cross-turn cache invalidation (#516)
         ///
         /// Public raw-forward entry point — see [`Self::forward_step`]'s doc
-        /// comment for the invariant this enforces. `generate`/`generate_streaming`/
-        /// `generate_multimodal`/`compute_token_nlls` all call this after their own
-        /// `reset_state()`, which has already cleared the cache, so this clear is a
-        /// no-op on those paths; it only matters for a consumer calling this
-        /// entry point directly against a state with a live retained entry.
+        /// comment for the invariant this enforces. The clear happens inside
+        /// [`Self::try_forward_prefill`], which this wraps. No production caller in
+        /// this crate remains — the generation entry points prefill through the
+        /// fallible route directly — so this wrapper's callers are this module's own
+        /// tests, the bench and profiling examples, and any external consumer that
+        /// wants the panicking form.
         pub fn forward_prefill(&mut self, token_ids: &[u32]) -> Vec<f32> {
             match self.try_forward_prefill(token_ids) {
                 Ok(logits) => logits,
@@ -7237,15 +7243,12 @@ mod inner {
         /// Returns [`crate::error::InferenceError::InvalidInput`] before GPU
         /// dispatch for an empty prompt, an out-of-vocabulary token, a prompt
         /// whose token range exceeds the session capacity, or a session that is
-        /// not fresh (see above). On rejection, session state (KV cache, GDN
-        /// state, hidden-readback counters) is left unchanged.
-        ///
-        /// # Panics
-        ///
-        /// Aborts before dispatch on a multi-token prompt against a model with MoE
-        /// layers and no active LoRA adapter, which takes the batched schedulers.
-        /// Unlike [`Self::try_forward_prefill`], this entry point does not convert
-        /// that case into an error.
+        /// not fresh (see above). Returns
+        /// [`crate::error::InferenceError::UnsupportedModel`] for a multi-token
+        /// prompt against a model with MoE layers and no active LoRA adapter: that
+        /// input takes the batched schedulers, which have no MoE schedule. On
+        /// rejection, session state (KV cache, GDN state, hidden-readback counters)
+        /// is left unchanged.
         pub fn forward_prefill_with_hidden(
             &mut self,
             token_ids: &[u32],
@@ -7260,6 +7263,10 @@ mod inner {
             self.check_forward_token_ids("forward_prefill_with_hidden", token_ids)?;
             self.check_hidden_prefill_fresh_session()?;
             self.check_forward_range_capacity(0, token_ids.len(), false)?;
+            self.check_prefill_moe_batched_unsupported(
+                "forward_prefill_with_hidden",
+                token_ids.len(),
+            )?;
             self.cross_turn_prefix_cache.clear();
 
             if token_ids.len() == 1 {
@@ -7316,14 +7323,10 @@ mod inner {
         /// dispatch when the session is not fresh (see above). Returns an error
         /// when more than one position is requested while a LoRA adapter is active,
         /// because the batched all-position path does not apply LoRA projections.
-        ///
-        /// # Panics
-        ///
-        /// Aborts before dispatch on a multi-token prompt against a model with MoE
-        /// layers: the all-position path is batched by construction and the batched
-        /// schedulers have no MoE schedule. Unlike
-        /// [`Self::try_forward_prefill`], this entry point does not convert that
-        /// case into an error.
+        /// Returns [`crate::error::InferenceError::UnsupportedModel`] for a
+        /// multi-token prompt against a model with MoE layers: the all-position
+        /// path is batched by construction and the batched schedulers have no MoE
+        /// schedule.
         ///
         /// # Cross-turn cache invalidation (#516)
         ///
@@ -7341,6 +7344,10 @@ mod inner {
                         .into(),
                 ));
             }
+            self.check_prefill_moe_batched_unsupported(
+                "forward_prefill_all_logits",
+                token_ids.len(),
+            )?;
             self.cross_turn_prefix_cache.clear();
             Ok(self.forward_prefill_impl(token_ids, true))
         }
@@ -9246,6 +9253,9 @@ mod inner {
         /// `generate` contract (#611).
         /// Returns `InferenceError::Inference` when the prompt plus requested decode
         /// cap exceeds [`Self::max_context`].
+        /// Returns `InferenceError::UnsupportedModel` for a multi-token prompt on a
+        /// model with MoE layers and no active LoRA adapter: prefill for that input
+        /// is batched and the batched schedulers have no MoE schedule.
         pub fn generate(
             &mut self,
             prompt: &str,
@@ -9278,8 +9288,14 @@ mod inner {
             // Initialise grammar state for grammar-constrained decoding (ADR-046).
             let mut grammar_state = gen_cfg.grammar.as_ref().map(|g| g.initial_state());
 
-            // Batch prefill: process all prompt tokens at once (GEMM)
-            let mut prefill_logits = self.forward_prefill(&prompt_ids);
+            // Batch prefill: process all prompt tokens at once (GEMM). Through the
+            // fallible entry point, not the unwrapping wrapper: a multi-token prompt
+            // on an MoE model has no batched schedule, and this is a request-facing
+            // call, so it must come back as `UnsupportedModel` rather than aborting
+            // the process. `try_forward_prefill` rejects before any state mutation,
+            // and every generation entry point calls `reset_state()` at its top, so
+            // returning here leaves nothing for this call to unwind.
+            let mut prefill_logits = self.try_forward_prefill(&prompt_ids)?;
 
             // Apply grammar masking to prefill logits before sampling.
             if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
@@ -11100,6 +11116,10 @@ mod inner {
         /// `generate_streaming` contract (#611).
         /// Returns `InferenceError::Inference` when the prompt plus effective decode
         /// cap exceeds [`Self::max_context`].
+        /// Returns `InferenceError::UnsupportedModel` for a multi-token prompt on a
+        /// model with MoE layers and no active LoRA adapter, for the reason given on
+        /// [`Self::generate`]. `generate_streaming` shares this implementation and so
+        /// reports the same error.
         pub fn generate_streaming_with_cancel<F, C>(
             &mut self,
             prompt: &str,
@@ -11176,8 +11196,10 @@ mod inner {
                 });
             }
 
-            // Batch prefill
-            let mut prefill_logits = self.forward_prefill(&prompt_ids);
+            // Batch prefill, through the fallible entry point for the same reason
+            // `generate` does: an MoE model has no batched prefill schedule, and a
+            // streaming request must see that as an error rather than an abort.
+            let mut prefill_logits = self.try_forward_prefill(&prompt_ids)?;
 
             // The prefill call itself cannot be interrupted mid-flight (it is one
             // GPU dispatch), so this is the earliest point a disconnect that
@@ -13045,6 +13067,9 @@ mod inner {
         ///
         /// - `tokens` empty, longer than the session's context, or containing
         ///   an id at or above `vocab_size`.
+        /// - More than one token against a model with MoE layers: the prefill this
+        ///   runs to produce the hidden state is batched, and the batched schedulers
+        ///   have no MoE schedule.
         /// - [`HiddenPooling::Mean`], which this path does not implement. Mean
         ///   pooling needs every position's *post-norm* hidden state, and the
         ///   Metal prefill normalizes only the rows it is about to project to
@@ -13103,8 +13128,12 @@ mod inner {
             self.session
                 .final_hidden_captured
                 .store(false, std::sync::atomic::Ordering::Relaxed);
-            let _ = self.forward_prefill(tokens);
+            // Fallible route: a multi-token prompt on an MoE model has no batched
+            // prefill schedule. Restore the capture flag before propagating, so a
+            // rejected call leaves the session exactly as it found it.
+            let prefill = self.try_forward_prefill(tokens);
             self.session.capture_final_hidden = previous;
+            prefill?;
 
             if !self
                 .session
@@ -28676,6 +28705,254 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             }
             crate::tokenizer::bpe::BpeTokenizer::from_vocab_and_merges(vocab, Vec::new())
                 .expect("single-char vocab tokenizer build")
+        }
+
+        /// Shared assertion for the #1448 entry-point sweep. Every public prefill
+        /// route that can reach the batched schedulers must REPORT an unsupported
+        /// (MoE) multi-token prefill as `UnsupportedModel`, never abort the process.
+        ///
+        /// Each caller does its own `catch_unwind` around its own entry point and
+        /// hands the outcome here, because a panic is the exact failure under guard:
+        /// it has to be observed as a caught unwind, not allowed to propagate. The
+        /// variant is asserted rather than just "an error", and "did not panic" is
+        /// deliberately not the assertion — a test that only checks for the absence
+        /// of a crash passes against a route that rejects for some unrelated reason,
+        /// and so would pass without the guard under test ever running.
+        fn assert_moe_prefill_rejected<T: std::fmt::Debug>(
+            outcome: std::thread::Result<Result<T, crate::error::InferenceError>>,
+            entry_point: &str,
+        ) {
+            let Ok(returned) = outcome else {
+                panic!(
+                    "{entry_point}: an unsupported-MoE prefill must come back as Err; it \
+                     unwound as a panic instead, which in a release build is the process \
+                     abort this guard exists to remove"
+                )
+            };
+            let error = match returned {
+                Err(error) => error,
+                Ok(value) => panic!(
+                    "{entry_point}: an unsupported-MoE prefill must not succeed; got {value:?}"
+                ),
+            };
+            let message = match &error {
+                crate::error::InferenceError::UnsupportedModel(message) => message.clone(),
+                other => panic!(
+                    "{entry_point}: the documented contract is \
+                     InferenceError::UnsupportedModel; got {other:?}. Any other variant \
+                     means a different rejection fired first and this test would pass \
+                     without the guard under test having run at all"
+                ),
+            };
+            assert!(
+                message.contains("MoE"),
+                "{entry_point}: the rejection must name the MoE batched-prefill \
+                 limitation so a caller can act on it; got {message:?}"
+            );
+        }
+
+        /// Regression (#1448): `forward_prefill_with_hidden` takes the batched
+        /// schedulers for a multi-token prompt with no active LoRA adapter, and those
+        /// have no MoE schedule. Until the check was wired in here it aborted on that
+        /// input. Three tokens, one more than the two-token minimum, so the assertion
+        /// is not resting on the smallest possible batch.
+        #[test]
+        fn forward_prefill_with_hidden_reports_moe_prefill_rejection() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _guard = gpu_test_lock();
+            let (cfg, weights) = tiny_moe_prefill_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 16)
+                .expect("moe prefill fixture must construct");
+            let position_before = state.session.position;
+
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                state.forward_prefill_with_hidden(&[1u32, 3, 5])
+            }));
+            assert_moe_prefill_rejected(outcome, "forward_prefill_with_hidden");
+            assert_eq!(
+                state.session.position, position_before,
+                "the rejection runs before any dispatch, so session position must be \
+                 untouched"
+            );
+        }
+
+        /// Regression (#1448): `forward_prefill_all_logits` is batched by
+        /// construction — it has no per-token fallback at all — so an MoE checkpoint
+        /// reached it and aborted. Its production caller is perplexity evaluation,
+        /// which now gets an error it can report.
+        #[test]
+        fn forward_prefill_all_logits_reports_moe_prefill_rejection() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _guard = gpu_test_lock();
+            let (cfg, weights) = tiny_moe_prefill_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 16)
+                .expect("moe prefill fixture must construct");
+            let position_before = state.session.position;
+
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                state.forward_prefill_all_logits(&[1u32, 3, 5])
+            }));
+            assert_moe_prefill_rejected(outcome, "forward_prefill_all_logits");
+            assert_eq!(
+                state.session.position, position_before,
+                "the rejection runs before any dispatch, so session position must be \
+                 untouched"
+            );
+        }
+
+        /// Regression (#1448): `generate` prefilled through the panicking
+        /// `forward_prefill` wrapper, so the typed rejection that already existed one
+        /// level down was turned straight back into an abort on the request-facing
+        /// path. This is the one that matters for a server: an ordinary valid prompt
+        /// against an MoE checkpoint took the host down.
+        #[test]
+        fn generate_reports_moe_prefill_rejection_without_panicking() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _guard = gpu_test_lock();
+            use crate::tokenizer::common::Tokenizer;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let prompt = "abc";
+            let tokenized = tokenizer.tokenize(prompt);
+            assert!(
+                tokenized.real_length > 1,
+                "test construction: the prompt must tokenize to more than one token \
+                 (got {}), or prefill never reaches the batched path under guard",
+                tokenized.real_length
+            );
+
+            let (cfg, weights) = tiny_moe_prefill_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32)
+                .expect("moe prefill fixture must construct");
+            let gen_cfg = moe_rejection_gen_cfg();
+
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                state.generate(prompt, &tokenizer, &gen_cfg)
+            }));
+            assert_moe_prefill_rejected(outcome, "generate");
+        }
+
+        /// Regression (#1448): `generate_streaming` shares
+        /// `generate_streaming_with_cancel`'s one implementation, which prefilled
+        /// through the same panicking wrapper `generate` did. Covered separately
+        /// rather than assumed from `generate`, because the two build their prefill
+        /// call independently — the sibling-invocation-path case this fix's own
+        /// review has to answer for.
+        #[test]
+        fn generate_streaming_reports_moe_prefill_rejection_without_panicking() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _guard = gpu_test_lock();
+            use crate::tokenizer::common::Tokenizer;
+
+            let tokenizer = single_char_vocab_tokenizer();
+            let prompt = "abc";
+            let tokenized = tokenizer.tokenize(prompt);
+            assert!(
+                tokenized.real_length > 1,
+                "test construction: the prompt must tokenize to more than one token \
+                 (got {}), or prefill never reaches the batched path under guard",
+                tokenized.real_length
+            );
+
+            let (cfg, weights) = tiny_moe_prefill_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 32)
+                .expect("moe prefill fixture must construct");
+            let gen_cfg = moe_rejection_gen_cfg();
+
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                state.generate_streaming(prompt, &tokenizer, &gen_cfg, |_, _| true)
+            }));
+            assert_moe_prefill_rejected(outcome, "generate_streaming");
+        }
+
+        /// Regression (#1448): `embed_tokens` is the third caller of the panicking
+        /// wrapper and is not named in the issue — found by grepping the wrapper's
+        /// call sites rather than by working the reported list. It is request-facing
+        /// (it backs Metal embedding), so it had the same abort. It also sets
+        /// `capture_final_hidden` around the prefill, so the rejection has to restore
+        /// that flag on the way out; the second assertion is what makes the early
+        /// return distinguishable from one that leaks session state.
+        #[test]
+        fn embed_tokens_reports_moe_prefill_rejection_without_panicking() {
+            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
+            let Some(_) = metal::Device::system_default() else {
+                assert!(
+                    !enforce,
+                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                );
+                return;
+            };
+            let _guard = gpu_test_lock();
+            let (cfg, weights) = tiny_moe_prefill_fixture();
+            let mut state = MetalQwen35State::new(&weights, &cfg, 16)
+                .expect("moe prefill fixture must construct");
+            let capture_before = state.session.capture_final_hidden;
+
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                state.embed_tokens(
+                    &[1u32, 3, 5],
+                    crate::model::qwen35::HiddenPooling::LastToken,
+                )
+            }));
+            assert_moe_prefill_rejected(outcome, "embed_tokens");
+            assert_eq!(
+                state.session.capture_final_hidden, capture_before,
+                "a rejected embed must restore capture_final_hidden; leaving it set \
+                 would make the next unrelated forward pass capture a hidden row it \
+                 was never asked for"
+            );
+        }
+
+        /// Minimal decode config for the #1448 rejection tests. Every field is set
+        /// so that nothing but the MoE prefill can reject: no grammar, no logprobs,
+        /// no MTP, no stop tokens, and a decode budget the tiny fixture's context
+        /// comfortably admits. If one of those guards fired first,
+        /// `assert_moe_prefill_rejected` would see the wrong error variant and fail
+        /// rather than pass on the wrong evidence.
+        fn moe_rejection_gen_cfg() -> crate::model::qwen35_config::GenerateConfig {
+            crate::model::qwen35_config::GenerateConfig {
+                max_new_tokens: 4,
+                temperature: 0.0,
+                top_k: 1,
+                top_p: 1.0,
+                repetition_penalty: 1.0,
+                seed: Some(42),
+                stop_token_ids: vec![],
+                enable_thinking: false,
+                enable_mtp: Some(false),
+                grammar: None,
+                stop_strings: vec![],
+                reasoning_budget: None,
+                logprobs: None,
+            }
         }
 
         fn assert_context_budget_error<T: std::fmt::Debug>(

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -2511,6 +2511,18 @@ mod inner {
     /// empirically by PPL regression when using head_dim). The partial-RoPE
     /// frequency spectrum is compressed into the first `rope_dim` dimensions
     /// rather than sliced from a wider head_dim spectrum.
+    /// Single derivation point for the engine's `has_moe_layer` flag. Both
+    /// state constructors (f16 and Q4) build the flag from this same layer
+    /// scan, so a change to layer classification cannot update one
+    /// constructor and silently leave the other inconsistent.
+    fn derive_has_moe_layer(
+        layer_weights: &[(MetalLayerAttnWeights, MetalCommonLayerWeights)],
+    ) -> bool {
+        layer_weights
+            .iter()
+            .any(|(_, common_w)| matches!(common_w.ffn, MetalFfnWeights::Moe(_)))
+    }
+
     fn build_rope_interleaved(rope_dim: usize, max_pos: usize, theta: f64) -> (Vec<f32>, Vec<f32>) {
         let half = rope_dim / 2;
         let mut cos_data = Vec::with_capacity(max_pos * half);
@@ -3211,9 +3223,7 @@ mod inner {
             let rope_cos = make_buffer(&device, &cos_data, "rope_cos");
             let rope_sin = make_buffer(&device, &sin_data, "rope_sin");
 
-            let has_moe_layer = layer_weights
-                .iter()
-                .any(|(_, common_w)| matches!(common_w.ffn, MetalFfnWeights::Moe(_)));
+            let has_moe_layer = derive_has_moe_layer(&layer_weights);
 
             Ok(Self {
                 device,
@@ -12940,9 +12950,7 @@ mod inner {
                 None
             };
 
-            let has_moe_layer = layer_weights
-                .iter()
-                .any(|(_, common_w)| matches!(common_w.ffn, MetalFfnWeights::Moe(_)));
+            let has_moe_layer = derive_has_moe_layer(&layer_weights);
             Ok(Self {
                 engine: MetalQwen35Engine {
                     device,
@@ -13922,9 +13930,12 @@ mod inner {
         ///
         /// Returns the shared context-budget error before cache restore or eviction
         /// when the prompt plus effective decode cap exceeds [`Self::max_context`].
-        /// Returns `InferenceError::UnsupportedModel` on a model with MoE layers:
-        /// the suffix prefill this path runs is batched in every branch, and the
-        /// batched schedulers have no MoE schedule.
+        /// Returns `InferenceError::UnsupportedModel` when a model with MoE
+        /// layers reaches a batched prefill — a multi-token suffix (or full
+        /// fallback prefill) with no active LoRA adapter. Single-token
+        /// suffixes and LoRA-active prefills run per-token forward steps,
+        /// which support MoE (see [`Self::reject_moe_batched`] and the gated
+        /// [`Self::check_prefill_moe_batched_unsupported`]).
         pub fn generate_streaming_with_prefix_cache<F>(
             &mut self,
             slot_id: crate::kv_cache::CrossTurnSlotId,

--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -1590,6 +1590,11 @@ mod inner {
         /// Used by mtp_forward_one to apply R^T to embed and pre-final-hidden before
         /// the O-space MTP forward, and R to mtp_h_out before the logits GEMV.
         pub(crate) quarot_rotation: Option<crate::quant::quarot::hadamard::RandomizedHadamard>,
+        /// Whether any active layer's FFN is `MetalFfnWeights::Moe`. Computed once at
+        /// construction — layer FFN kinds never change after load (LoRA attaches to
+        /// attention projections, MTP weights are separate) — so the batched-prefill
+        /// MoE guards read this instead of rescanning `layer_weights` per call.
+        pub(crate) has_moe_layer: bool,
     }
 
     /// Per-request mutable inference state.
@@ -3206,6 +3211,10 @@ mod inner {
             let rope_cos = make_buffer(&device, &cos_data, "rope_cos");
             let rope_sin = make_buffer(&device, &sin_data, "rope_sin");
 
+            let has_moe_layer = layer_weights
+                .iter()
+                .any(|(_, common_w)| matches!(common_w.ffn, MetalFfnWeights::Moe(_)));
+
             Ok(Self {
                 device,
                 queue,
@@ -3220,6 +3229,7 @@ mod inner {
                 quant_format,
                 mtp_weights: None,
                 quarot_rotation: None,
+                has_moe_layer,
             })
         }
 
@@ -6687,26 +6697,54 @@ mod inner {
             Ok(())
         }
 
-        /// Batched (M>1) prefill has no MoE schedule: `assert_batched_prefill_dense_only`
-        /// panics on it, and `forward_prefill_impl` reaches that path for any prompt
-        /// longer than one token with no active LoRA adapter. Reported here as a typed
-        /// error so a request-facing caller sees a rejection instead of the process
-        /// aborting; the assert stays as the internal invariant for direct callers of
-        /// the batched chunk schedulers.
+        /// Batched prefill has no MoE schedule: `assert_batched_prefill_dense_only`
+        /// panics on it. Reported here as a typed error so a caller sees a rejection
+        /// instead of the process aborting; the assert stays as the internal
+        /// invariant for direct callers of the batched chunk schedulers.
         ///
-        /// Wired into all three public entry points that can reach the batched
-        /// schedulers: [`Self::try_forward_prefill`],
-        /// [`Self::forward_prefill_with_hidden`], and
-        /// [`Self::forward_prefill_all_logits`]. Every request-facing caller prefills
-        /// through one of them — `generate`, `generate_streaming`, and
+        /// This is the unconditional form: it rejects whenever the model has an MoE
+        /// layer, for call sites every remaining branch of which is batched.
+        /// [`Self::forward_prefill_from`] calls it after its single-token and LoRA
+        /// fast paths have already returned via per-token forward steps (which
+        /// support MoE). Entry points whose per-token routing is expressible as a
+        /// predicate on the input use
+        /// [`Self::check_prefill_moe_batched_unsupported`], which applies the
+        /// token-count/LoRA gate before delegating here.
+        fn reject_moe_batched(
+            &self,
+            entry_point: &str,
+        ) -> Result<(), crate::error::InferenceError> {
+            if self.engine.has_moe_layer {
+                return Err(crate::error::InferenceError::UnsupportedModel(format!(
+                    "{entry_point}: batched prefill (GEMM path) does not support MoE \
+                     layers. Decode one token at a time via forward_step for MoE \
+                     models."
+                )));
+            }
+            Ok(())
+        }
+
+        /// Gated form of [`Self::reject_moe_batched`] for entry points that route a
+        /// single-token or LoRA-active input to the per-token path, where MoE is
+        /// supported: only a multi-token, no-LoRA input reaches the batched
+        /// schedulers, so only that shape is rejected.
+        ///
+        /// Wired into the public entry points that can reach the batched schedulers
+        /// through `forward_prefill_impl` or the with-hidden chunk loop:
+        /// [`Self::try_forward_prefill`], [`Self::forward_prefill_with_hidden`], and
+        /// [`Self::forward_prefill_all_logits`]. The suffix primitive
+        /// [`Self::forward_prefill_from`] — reached by the prefix-cache generation
+        /// path — uses the unconditional form above. Every request-facing caller
+        /// prefills through one of the four: `generate`, `generate_streaming`, and
         /// `generate_streaming_with_cancel` through the first, `embed_tokens` through
-        /// the first, `compute_token_nlls` through the last — so an MoE model reports
-        /// this input instead of aborting the process.
+        /// the first, `compute_token_nlls` through the third,
+        /// `generate_streaming_with_prefix_cache*` through the fourth — so an MoE
+        /// model reports this input instead of aborting the process.
         ///
         /// [`Self::forward_prefill`] is the exception, by construction: it unwraps
         /// [`Self::try_forward_prefill`]'s result, so it still aborts. Its remaining
-        /// callers are the bench and profiling examples, which treat an unsupported
-        /// checkpoint as a contract violation.
+        /// callers are this module's tests, the bench and profiling examples, and any
+        /// external consumer that wants the panicking form.
         fn check_prefill_moe_batched_unsupported(
             &self,
             entry_point: &str,
@@ -6715,19 +6753,7 @@ mod inner {
             if token_count <= 1 || self.lora.is_some() {
                 return Ok(());
             }
-            let has_moe_layer = self
-                .engine
-                .layer_weights
-                .iter()
-                .any(|(_, common_w)| matches!(common_w.ffn, MetalFfnWeights::Moe(_)));
-            if has_moe_layer {
-                return Err(crate::error::InferenceError::UnsupportedModel(format!(
-                    "{entry_point}: batched prefill (M>1 GEMM path) does not support MoE \
-                     layers; prompt has {token_count} tokens. Prefill one token at a time \
-                     via forward_step for MoE models."
-                )));
-            }
-            Ok(())
+            self.reject_moe_batched(entry_point)
         }
 
         /// Pure capacity precondition for a Metal dispatch spanning `token_count` positions
@@ -7905,13 +7931,8 @@ mod inner {
         /// GDN/KV work has already been recorded (or, for schedulers that split
         /// encoding across multiple command buffers, already committed to the GPU).
         fn assert_batched_prefill_dense_only(&self) {
-            let has_moe_layer = self
-                .engine
-                .layer_weights
-                .iter()
-                .any(|(_, common_w)| matches!(common_w.ffn, MetalFfnWeights::Moe(_)));
             assert!(
-                !has_moe_layer,
+                !self.engine.has_moe_layer,
                 "batched prefill does not support MoE layers (M>1 GEMM path); \
                  use decode-mode forward_step for MoE models instead"
             );
@@ -9242,6 +9263,20 @@ mod inner {
             )
         }
 
+        /// Disengage the compact sampling route engaged by
+        /// [`Self::configure_sampling_route`] when a generation is abandoned after
+        /// route configuration but before its decode loop — the same two clears the
+        /// cancellation paths perform. Without this, a prefill that fails after the
+        /// route was engaged (e.g. the MoE batched-prefill rejection) returns `Err`
+        /// with `compact_route`/`compact_topk` still set, and a subsequent raw
+        /// `forward_step` on the same session takes the compact branch and returns
+        /// empty logits plus a stale one-candidate `compact_result` instead of the
+        /// full `[vocab_size]` logits the caller expects.
+        fn clear_compact_route_after_failed_prefill(&mut self) {
+            self.session.compact_topk = 0;
+            self.session.compact_route = GpuTopkRoute::CpuFallback;
+        }
+
         /// **Unstable**: generate text from a prompt; sampling parameters and output format may change.
         ///
         /// Generate text from a prompt.
@@ -9292,10 +9327,19 @@ mod inner {
             // fallible entry point, not the unwrapping wrapper: a multi-token prompt
             // on an MoE model has no batched schedule, and this is a request-facing
             // call, so it must come back as `UnsupportedModel` rather than aborting
-            // the process. `try_forward_prefill` rejects before any state mutation,
-            // and every generation entry point calls `reset_state()` at its top, so
-            // returning here leaves nothing for this call to unwind.
-            let mut prefill_logits = self.try_forward_prefill(&prompt_ids)?;
+            // the process. `try_forward_prefill` rejects before any state mutation;
+            // the error arm disengages the compact route configured above, exactly
+            // as the cancellation paths do, so the session is left clean for a raw
+            // `forward_step` caller.
+            let mut prefill_logits = match self.try_forward_prefill(&prompt_ids) {
+                Ok(logits) => logits,
+                Err(error) => {
+                    if use_compact {
+                        self.clear_compact_route_after_failed_prefill();
+                    }
+                    return Err(error);
+                }
+            };
 
             // Apply grammar masking to prefill logits before sampling.
             if let (Some(engine), Some(gs)) = (&gen_cfg.grammar, &mut grammar_state) {
@@ -11198,8 +11242,17 @@ mod inner {
 
             // Batch prefill, through the fallible entry point for the same reason
             // `generate` does: an MoE model has no batched prefill schedule, and a
-            // streaming request must see that as an error rather than an abort.
-            let mut prefill_logits = self.try_forward_prefill(&prompt_ids)?;
+            // streaming request must see that as an error rather than an abort. The
+            // error arm disengages the compact route, mirroring the cancel paths.
+            let mut prefill_logits = match self.try_forward_prefill(&prompt_ids) {
+                Ok(logits) => logits,
+                Err(error) => {
+                    if use_compact {
+                        self.clear_compact_route_after_failed_prefill();
+                    }
+                    return Err(error);
+                }
+            };
 
             // The prefill call itself cannot be interrupted mid-flight (it is one
             // GPU dispatch), so this is the earliest point a disconnect that
@@ -12887,6 +12940,9 @@ mod inner {
                 None
             };
 
+            let has_moe_layer = layer_weights
+                .iter()
+                .any(|(_, common_w)| matches!(common_w.ffn, MetalFfnWeights::Moe(_)));
             Ok(Self {
                 engine: MetalQwen35Engine {
                     device,
@@ -12902,6 +12958,7 @@ mod inner {
                     quant_format,
                     mtp_weights: mtp_weights_opt,
                     quarot_rotation,
+                    has_moe_layer,
                 },
                 session: InferenceSession {
                     activations,
@@ -13672,6 +13729,10 @@ mod inner {
                 }
                 return Ok(last_logits);
             }
+            // Every branch below is batched (the single-token and LoRA fast paths
+            // returned above via per-token forward steps, which support MoE), so the
+            // MoE rejection applies unconditionally from here (#1448).
+            self.reject_moe_batched("forward_prefill_from")?;
             let max_prefill = self.session.max_prefill;
             if token_ids.len() <= max_prefill {
                 // Only/last chunk — its logits are always the caller's answer.
@@ -13861,6 +13922,9 @@ mod inner {
         ///
         /// Returns the shared context-budget error before cache restore or eviction
         /// when the prompt plus effective decode cap exceeds [`Self::max_context`].
+        /// Returns `InferenceError::UnsupportedModel` on a model with MoE layers:
+        /// the suffix prefill this path runs is batched in every branch, and the
+        /// batched schedulers have no MoE schedule.
         pub fn generate_streaming_with_prefix_cache<F>(
             &mut self,
             slot_id: crate::kv_cache::CrossTurnSlotId,
@@ -14173,7 +14237,16 @@ mod inner {
             // The one line that differs structurally from `generate_streaming`:
             // prefill only the divergent suffix, at its true absolute position.
             let suffix = &prompt_ids[plan.suffix_start..];
-            let mut prefill_logits = self.forward_prefill_from(suffix, plan.suffix_start, false)?;
+            let mut prefill_logits =
+                match self.forward_prefill_from(suffix, plan.suffix_start, false) {
+                    Ok(logits) => logits,
+                    Err(error) => {
+                        if use_compact {
+                            self.clear_compact_route_after_failed_prefill();
+                        }
+                        return Err(error);
+                    }
+                };
 
             // The suffix prefill itself cannot be interrupted mid-flight (one
             // GPU dispatch), so this is the earliest point a disconnect that
@@ -28751,13 +28824,15 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             );
         }
 
-        /// Regression (#1448): `forward_prefill_with_hidden` takes the batched
-        /// schedulers for a multi-token prompt with no active LoRA adapter, and those
-        /// have no MoE schedule. Until the check was wired in here it aborted on that
-        /// input. Three tokens, one more than the two-token minimum, so the assertion
-        /// is not resting on the smallest possible batch.
-        #[test]
-        fn forward_prefill_with_hidden_reports_moe_prefill_rejection() {
+        /// Shared setup for the #1448 rejection tests: the `LATTICE_METAL_TEST_ENFORCE`
+        /// device contract, the machine-wide GPU lock, the MoE fixture, and state
+        /// construction, in one place so an entry-point addition or a setup change is
+        /// one edit instead of one per test. Runs `test` while the lock is held; on a
+        /// device-less machine it asserts the enforce contract and runs nothing.
+        fn with_moe_prefill_state(
+            max_cache_len: usize,
+            test: impl FnOnce(&Qwen35Config, &mut MetalQwen35State),
+        ) {
             let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
             let Some(_) = metal::Device::system_default() else {
                 assert!(
@@ -28768,19 +28843,30 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
             };
             let _guard = gpu_test_lock();
             let (cfg, weights) = tiny_moe_prefill_fixture();
-            let mut state = MetalQwen35State::new(&weights, &cfg, 16)
+            let mut state = MetalQwen35State::new(&weights, &cfg, max_cache_len)
                 .expect("moe prefill fixture must construct");
-            let position_before = state.session.position;
+            test(&cfg, &mut state);
+        }
 
-            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                state.forward_prefill_with_hidden(&[1u32, 3, 5])
-            }));
-            assert_moe_prefill_rejected(outcome, "forward_prefill_with_hidden");
-            assert_eq!(
-                state.session.position, position_before,
-                "the rejection runs before any dispatch, so session position must be \
-                 untouched"
-            );
+        /// Regression (#1448): `forward_prefill_with_hidden` takes the batched
+        /// schedulers for a multi-token prompt with no active LoRA adapter, and those
+        /// have no MoE schedule. Until the check was wired in here it aborted on that
+        /// input. Three tokens, one more than the two-token minimum, so the assertion
+        /// is not resting on the smallest possible batch.
+        #[test]
+        fn forward_prefill_with_hidden_reports_moe_prefill_rejection() {
+            with_moe_prefill_state(16, |_cfg, state| {
+                let position_before = state.session.position;
+                let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    state.forward_prefill_with_hidden(&[1u32, 3, 5])
+                }));
+                assert_moe_prefill_rejected(outcome, "forward_prefill_with_hidden");
+                assert_eq!(
+                    state.session.position, position_before,
+                    "the rejection runs before any dispatch, so session position must \
+                     be untouched"
+                );
+            });
         }
 
         /// Regression (#1448): `forward_prefill_all_logits` is batched by
@@ -28789,29 +28875,18 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// which now gets an error it can report.
         #[test]
         fn forward_prefill_all_logits_reports_moe_prefill_rejection() {
-            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
-            let Some(_) = metal::Device::system_default() else {
-                assert!(
-                    !enforce,
-                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+            with_moe_prefill_state(16, |_cfg, state| {
+                let position_before = state.session.position;
+                let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    state.forward_prefill_all_logits(&[1u32, 3, 5])
+                }));
+                assert_moe_prefill_rejected(outcome, "forward_prefill_all_logits");
+                assert_eq!(
+                    state.session.position, position_before,
+                    "the rejection runs before any dispatch, so session position must \
+                     be untouched"
                 );
-                return;
-            };
-            let _guard = gpu_test_lock();
-            let (cfg, weights) = tiny_moe_prefill_fixture();
-            let mut state = MetalQwen35State::new(&weights, &cfg, 16)
-                .expect("moe prefill fixture must construct");
-            let position_before = state.session.position;
-
-            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                state.forward_prefill_all_logits(&[1u32, 3, 5])
-            }));
-            assert_moe_prefill_rejected(outcome, "forward_prefill_all_logits");
-            assert_eq!(
-                state.session.position, position_before,
-                "the rejection runs before any dispatch, so session position must be \
-                 untouched"
-            );
+            });
         }
 
         /// Regression (#1448): `generate` prefilled through the panicking
@@ -28821,36 +28896,25 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// against an MoE checkpoint took the host down.
         #[test]
         fn generate_reports_moe_prefill_rejection_without_panicking() {
-            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
-            let Some(_) = metal::Device::system_default() else {
+            with_moe_prefill_state(32, |_cfg, state| {
+                use crate::tokenizer::common::Tokenizer;
+
+                let tokenizer = single_char_vocab_tokenizer();
+                let prompt = "abc";
+                let tokenized = tokenizer.tokenize(prompt);
                 assert!(
-                    !enforce,
-                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                    tokenized.real_length > 1,
+                    "test construction: the prompt must tokenize to more than one \
+                     token (got {}), or prefill never reaches the batched path under \
+                     guard",
+                    tokenized.real_length
                 );
-                return;
-            };
-            let _guard = gpu_test_lock();
-            use crate::tokenizer::common::Tokenizer;
-
-            let tokenizer = single_char_vocab_tokenizer();
-            let prompt = "abc";
-            let tokenized = tokenizer.tokenize(prompt);
-            assert!(
-                tokenized.real_length > 1,
-                "test construction: the prompt must tokenize to more than one token \
-                 (got {}), or prefill never reaches the batched path under guard",
-                tokenized.real_length
-            );
-
-            let (cfg, weights) = tiny_moe_prefill_fixture();
-            let mut state = MetalQwen35State::new(&weights, &cfg, 32)
-                .expect("moe prefill fixture must construct");
-            let gen_cfg = moe_rejection_gen_cfg();
-
-            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                state.generate(prompt, &tokenizer, &gen_cfg)
-            }));
-            assert_moe_prefill_rejected(outcome, "generate");
+                let gen_cfg = moe_rejection_gen_cfg();
+                let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    state.generate(prompt, &tokenizer, &gen_cfg)
+                }));
+                assert_moe_prefill_rejected(outcome, "generate");
+            });
         }
 
         /// Regression (#1448): `generate_streaming` shares
@@ -28861,36 +28925,128 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// review has to answer for.
         #[test]
         fn generate_streaming_reports_moe_prefill_rejection_without_panicking() {
-            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
-            let Some(_) = metal::Device::system_default() else {
+            with_moe_prefill_state(32, |_cfg, state| {
+                use crate::tokenizer::common::Tokenizer;
+
+                let tokenizer = single_char_vocab_tokenizer();
+                let prompt = "abc";
+                let tokenized = tokenizer.tokenize(prompt);
                 assert!(
-                    !enforce,
-                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+                    tokenized.real_length > 1,
+                    "test construction: the prompt must tokenize to more than one \
+                     token (got {}), or prefill never reaches the batched path under \
+                     guard",
+                    tokenized.real_length
                 );
-                return;
-            };
-            let _guard = gpu_test_lock();
-            use crate::tokenizer::common::Tokenizer;
+                let gen_cfg = moe_rejection_gen_cfg();
+                let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    state.generate_streaming(prompt, &tokenizer, &gen_cfg, |_, _| true)
+                }));
+                assert_moe_prefill_rejected(outcome, "generate_streaming");
+            });
+        }
 
-            let tokenizer = single_char_vocab_tokenizer();
-            let prompt = "abc";
-            let tokenized = tokenizer.tokenize(prompt);
-            assert!(
-                tokenized.real_length > 1,
-                "test construction: the prompt must tokenize to more than one token \
-                 (got {}), or prefill never reaches the batched path under guard",
-                tokenized.real_length
-            );
+        /// Regression (#1448 follow-up): the prefix-cache generation path reaches the
+        /// batched schedulers through `forward_prefill_from`, not through
+        /// `try_forward_prefill`, so the first fix left it able to abort — the
+        /// exact sibling-invocation-path miss the original test comment warned about,
+        /// found by the review rather than by the grep. The serve worker calls this
+        /// entry point directly, so this abort was remotely reachable.
+        #[test]
+        fn generate_streaming_with_prefix_cache_reports_moe_prefill_rejection() {
+            with_moe_prefill_state(32, |_cfg, state| {
+                use crate::tokenizer::common::Tokenizer;
 
-            let (cfg, weights) = tiny_moe_prefill_fixture();
-            let mut state = MetalQwen35State::new(&weights, &cfg, 32)
-                .expect("moe prefill fixture must construct");
-            let gen_cfg = moe_rejection_gen_cfg();
+                let tokenizer = single_char_vocab_tokenizer();
+                let prompt = "abc";
+                let tokenized = tokenizer.tokenize(prompt);
+                assert!(
+                    tokenized.real_length > 1,
+                    "test construction: the prompt must tokenize to more than one \
+                     token (got {}), or the suffix prefill never spans multiple \
+                     tokens",
+                    tokenized.real_length
+                );
+                let gen_cfg = moe_rejection_gen_cfg();
+                let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    state
+                        .generate_streaming_with_prefix_cache(
+                            crate::kv_cache::CrossTurnSlotId::DEFAULT,
+                            prompt,
+                            &tokenizer,
+                            &gen_cfg,
+                            |_, _| true,
+                        )
+                        .map(|cached| cached.output)
+                }));
+                assert_moe_prefill_rejected(outcome, "generate_streaming_with_prefix_cache");
+            });
+        }
 
-            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                state.generate_streaming(prompt, &tokenizer, &gen_cfg, |_, _| true)
-            }));
-            assert_moe_prefill_rejected(outcome, "generate_streaming");
+        /// Rule-separating pair for `forward_prefill_from` on an MoE model (#1448
+        /// follow-up): a single-token suffix takes the per-token `try_forward_step`
+        /// fast path, which supports MoE, and must SUCCEED with full-vocabulary
+        /// logits; a multi-token suffix has only batched branches left and must be
+        /// rejected as `UnsupportedModel`. Asserting both on one fixture is what
+        /// pins the rejection to the batched routing rather than to the model kind —
+        /// a rejection keyed on "is MoE" alone would fail the first arm.
+        #[test]
+        fn forward_prefill_from_separates_single_token_success_from_batched_rejection() {
+            with_moe_prefill_state(16, |cfg, state| {
+                let logits = state
+                    .forward_prefill_from(&[2u32], 0, false)
+                    .expect("a single-token suffix takes the per-token path, which supports MoE");
+                assert_eq!(
+                    logits.len(),
+                    cfg.vocab_size,
+                    "the single-token fast path must return full-vocabulary logits"
+                );
+
+                state.reset_state();
+                let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    state.forward_prefill_from(&[1u32, 3, 5], 0, false)
+                }));
+                assert_moe_prefill_rejected(outcome, "forward_prefill_from");
+            });
+        }
+
+        /// Regression (#1448 follow-up): a prefill that fails after
+        /// `configure_sampling_route` engaged the compact route must not leave that
+        /// route on the session — a raw `forward_step` afterward would take the
+        /// compact branch and return empty logits. Engages the route by direct field
+        /// assignment (the #171 pattern: route *selection* is env-keyed and
+        /// process-global, so an end-to-end engagement through `generate` is not
+        /// testable under parallel test execution), calls the cleanup the error arms
+        /// call, and asserts the outcome the contract names: `forward_step` returns
+        /// full-vocabulary logits. The wiring of the cleanup into all three
+        /// generation entry points' error arms is pinned by the source-consistency
+        /// rows in `public_scheduling_entry_points_route_through_their_preflights`.
+        #[test]
+        fn failed_prefill_compact_cleanup_restores_full_vocab_forward_step() {
+            with_moe_prefill_state(16, |cfg, state| {
+                state.session.compact_route = GpuTopkRoute::BlockArgmax;
+                state.session.compact_topk = 1;
+
+                state.clear_compact_route_after_failed_prefill();
+
+                assert_eq!(
+                    state.session.compact_route,
+                    GpuTopkRoute::CpuFallback,
+                    "the cleanup must disengage the compact route"
+                );
+                assert_eq!(
+                    state.session.compact_topk, 0,
+                    "the cleanup must clear compact_topk"
+                );
+                let logits = state.forward_step(3, 0);
+                assert_eq!(
+                    logits.len(),
+                    cfg.vocab_size,
+                    "after cleanup, a raw forward_step must return full [vocab_size] \
+                     logits via the exact path — a shorter/empty result means the \
+                     compact route survived the failed prefill"
+                );
+            });
         }
 
         /// Regression (#1448): `embed_tokens` is the third caller of the panicking
@@ -28902,33 +29058,22 @@ kernel void per_head_rms_norm_batch_pre_854_oracle(
         /// return distinguishable from one that leaks session state.
         #[test]
         fn embed_tokens_reports_moe_prefill_rejection_without_panicking() {
-            let enforce = std::env::var_os("LATTICE_METAL_TEST_ENFORCE").is_some();
-            let Some(_) = metal::Device::system_default() else {
-                assert!(
-                    !enforce,
-                    "LATTICE_METAL_TEST_ENFORCE=1 but no Metal device present"
+            with_moe_prefill_state(16, |_cfg, state| {
+                let capture_before = state.session.capture_final_hidden;
+                let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    state.embed_tokens(
+                        &[1u32, 3, 5],
+                        crate::model::qwen35::HiddenPooling::LastToken,
+                    )
+                }));
+                assert_moe_prefill_rejected(outcome, "embed_tokens");
+                assert_eq!(
+                    state.session.capture_final_hidden, capture_before,
+                    "a rejected embed must restore capture_final_hidden; leaving it \
+                     set would make the next unrelated forward pass capture a hidden \
+                     row it was never asked for"
                 );
-                return;
-            };
-            let _guard = gpu_test_lock();
-            let (cfg, weights) = tiny_moe_prefill_fixture();
-            let mut state = MetalQwen35State::new(&weights, &cfg, 16)
-                .expect("moe prefill fixture must construct");
-            let capture_before = state.session.capture_final_hidden;
-
-            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                state.embed_tokens(
-                    &[1u32, 3, 5],
-                    crate::model::qwen35::HiddenPooling::LastToken,
-                )
-            }));
-            assert_moe_prefill_rejected(outcome, "embed_tokens");
-            assert_eq!(
-                state.session.capture_final_hidden, capture_before,
-                "a rejected embed must restore capture_final_hidden; leaving it set \
-                 would make the next unrelated forward pass capture a hidden row it \
-                 was never asked for"
-            );
+            });
         }
 
         /// Minimal decode config for the #1448 rejection tests. Every field is set
@@ -37889,6 +38034,19 @@ mod public_scheduling_entry_point_tests {
             (
                 "pub fn forward_prefill_all_logits(",
                 "check_raw_prefill_fresh_session",
+            ),
+            ("fn forward_prefill_from(", "reject_moe_batched"),
+            (
+                "pub fn generate(",
+                "clear_compact_route_after_failed_prefill",
+            ),
+            (
+                "pub fn generate_streaming_with_cancel<F, C>(",
+                "clear_compact_route_after_failed_prefill",
+            ),
+            (
+                "fn generate_streaming_with_prefix_cache_and_cancel_inner<F, C>(",
+                "clear_compact_route_after_failed_prefill",
             ),
             ("fn verify_tokens(", "check_live_cursor"),
             ("fn rollback_cache_to(", "rollback_speculative_state_to"),


### PR DESCRIPTION
`generate_with_speculation` already rejected a multi-token prompt on an MoE
model with a typed `UnsupportedModel` error. The other routes into the same
batched prefill schedulers still aborted the process on that input, so an
ordinary valid prompt against an MoE checkpoint took the host down.

`forward_prefill` unwraps `try_forward_prefill` and panics on its error, which
is the whole problem: the check existed and produced a correct error, and the
wrapper turned it straight back into an abort for everything that prefilled
through it.

## What changed

**Three production callers now prefill through the fallible route.** None of
them needed a signature change — all three already return
`Result<_, InferenceError>`, so this is `self.try_forward_prefill(..)?` in place
of `self.forward_prefill(..)`:

- `generate`
- `generate_streaming_with_cancel` (and so `generate_streaming`, which is the
  `should_cancel = || false` form over the same implementation)
- `embed_tokens`

`embed_tokens` was not in the issue. It turned up by grepping the wrapper's call
sites rather than working the reported list, and it is request-facing in the
same way the other two are. It also sets `capture_final_hidden` around the
prefill, so the rejection restores that flag before propagating; otherwise a
refused embed would leave the next unrelated forward pass capturing a hidden row
nobody asked for.

**Two entry points now run the check.** `forward_prefill_with_hidden` and
`forward_prefill_all_logits` enter the batched schedulers directly. Both already
return `Result`, so the check is additive for them. This does change perplexity
evaluation on an MoE model from abort to `Err`, which is the point.

The check sits before `cross_turn_prefix_cache.clear()` in both, so a rejection
leaves session state exactly as it found it — the same guarantee the
surrounding preflight checks already give.

`forward_prefill` itself is unchanged and still panics. That is now stated as
its purpose rather than as an accident: it has no production caller left in the
crate, and its remaining users are this module's tests and the bench and
profiling examples, which treat an unsupported checkpoint as a contract
violation.

## Docs corrected in the same change

Three doc comments asserted things this change makes false, and one was already
false before it:

- the `# Panics` sections on `forward_prefill_with_hidden` and
  `forward_prefill_all_logits` documented the abort; they are now `# Errors`
  entries naming `UnsupportedModel`. `forward_prefill_all_logits` had two
  separate `# Panics` sections as a result; it now has one.
- `check_prefill_moe_batched_unsupported`'s own comment said the other two entry
  points deliberately went unchecked. It now names all three, and says why
  `forward_prefill` is the exception.
- `forward_prefill`'s cross-turn-cache paragraph listed
  `generate`/`generate_streaming`/`generate_multimodal`/`compute_token_nlls` as
  its callers. `generate_multimodal` and `compute_token_nlls` had already stopped
  calling it; the other two stop here.

## Tests

Five, one per entry point, each asserting the returned error variant and that
the message names the limitation — not that the call "did not panic". A
did-not-panic assertion passes against a route that rejects for some unrelated
reason, so it can pass without the guard under test ever running. Each wraps its
own entry point in `catch_unwind`, because the panic is the failure being
guarded and has to be observed rather than allowed to propagate.

The `generate` and `generate_streaming` tests assert their prompt tokenizes to
more than one token before doing anything else. A single-token prompt never
reaches the batched path, so without that check the test could pass while
measuring nothing.

## Reverse-apply results

Six properties, each checked separately, each reverse-applied and restored:

| what was reverted | test that failed | others |
|---|---|---|
| `generate` fallible prefill | `generate_reports_moe_prefill_rejection_without_panicking` | 5 pass |
| `generate_streaming` fallible prefill | `generate_streaming_reports_moe_prefill_rejection_without_panicking` | 5 pass |
| `embed_tokens` fallible prefill | `embed_tokens_reports_moe_prefill_rejection_without_panicking` | 5 pass |
| `embed_tokens` flag restore ordering | same test, on the `capture_final_hidden` assertion | 5 pass |
| check in `forward_prefill_with_hidden` | `forward_prefill_with_hidden_reports_moe_prefill_rejection` | 5 pass |
| check in `forward_prefill_all_logits` | `forward_prefill_all_logits_reports_moe_prefill_rejection` | 5 pass |

The flag-ordering row is listed separately on purpose: reverting the
`embed_tokens` prefill alone fails on the error-variant assertion, which says
nothing about whether the second assertion is load-bearing. Moving the restore
after the propagation instead leaves the variant assertion passing and fails on
`capture_final_hidden`.

Each revert restored the file to a byte-identical copy of the pre-mutation
snapshot before the next one ran, and the suite is green afterwards: 6 passed,
0 failed.

## bench-compare disposition

**Measurement is owed and has not been run. This is not a waiver.**

*Population searched.* All 25 `[[bench]]` targets declared in
`crates/inference/Cargo.toml`, enumerated by parsing the manifest rather than
read off a list, plus `lattice-embed`'s `simd`. The two targets
`make bench-compare` drives by default are not the population and a clean
default A/B here would be a statement about coverage, not about the change.

*Compiled-out under default features, but that is the wrong predicate.* The
changed code lives in `metal_qwen35::inner`, gated
`#[cfg(all(target_os = "macos", feature = "metal-gpu"))]`. The default feature
set is `std, download, serve`, so the diff is absent from a default-feature
bench build and the default A/B pair is built from identical effective source.

*Three targets declare `required-features = ["metal-gpu", "f16"]`, and two of
them reach a changed line:*

- `mtp_decode` → `chat_completion` → `generate` → the changed prefill call.
- `cross_turn_prefix_cache_bench` → `chat_completion_streaming` →
  `generate_streaming_with_cancel` → the changed prefill call.
- `metal_decode_bench` calls `forward_prefill`, whose body this PR does not
  touch, so it does not reach a changed line.

Both reachable targets are Criterion (`criterion_group!` / `criterion_main!`)
and live in `lattice-inference`, so they sit inside `bench-compare`'s paired
machinery rather than outside it. The invocation is

```
BENCHES_INFERENCE=mtp_decode CARGO_FEATURES_INFERENCE=metal-gpu,f16 make bench-compare
BENCHES_INFERENCE=cross_turn_prefix_cache_bench CARGO_FEATURES_INFERENCE=metal-gpu,f16 make bench-compare
```

(`scripts/lib/bench-compare-impl.sh:447-448` reads both as overridable.)

*Build inputs are identical between base and head* — one `.rs` file changed, no
manifest, lockfile, feature, profile, build-script, bench-definition or harness
change — so the only open question is the runtime one above, and that question
has a reachable target, which is exactly the case where the structural argument
does not apply.

*Why it is not run here.* The host these measurements are taken on is offline,
so no A/B can be produced at the moment. Running it on an arbitrary machine
would produce a number that records nothing about the conditions that made it,
which is worse than saying it is missing.

*Residual risk, stated rather than implied.* On the two reachable paths the
change replaces `self.forward_prefill(x)` with `self.try_forward_prefill(x)?`,
and `forward_prefill`'s entire body is a match on `try_forward_prefill`'s
result — so the executed work per prefill differs by one call frame and one
match, once per iteration, against a GPU prefill. That is an argument about
what the change is, not a measurement of what it costs, and it is not offered
as a substitute for one. The genuinely new work is the added
`check_prefill_moe_batched_unsupported` call in `forward_prefill_with_hidden`
and `forward_prefill_all_logits`, which scans the layer list once per
multi-token prefill; no declared bench target reaches either of those two
functions.

Closes #1448.


---

## Follow-up: two gaps in the first version of this change

The first version's claim of universal coverage was false: the prefix-cache
generation path reaches the batched schedulers through `forward_prefill_from`,
not through `try_forward_prefill`, so it could still abort — and the serve
worker calls that entry point directly, which made the abort remotely
reachable. That is the exact sibling-invocation-path class the original test
comment warned about. Separately, a prefill that failed after
`configure_sampling_route` had engaged the compact sampling route returned
`Err` with the route still set, so a subsequent raw `forward_step` on the same
session would take the compact branch and return empty logits.

### What changed

- **`forward_prefill_from` now rejects MoE** before its batched branches. Its
  single-token and LoRA fast paths return earlier via per-token forward steps,
  which support MoE — so a one-token suffix on an MoE model still works, and
  only the genuinely batched shapes are rejected. A rule-separating test pins
  that: same fixture, single-token arm must succeed with full-vocab logits,
  multi-token arm must be rejected. `generate_streaming_with_prefix_cache` gets
  a request-path regression test and an `# Errors` entry.
- **All three generation entry points clear the compact route on prefill
  failure** (`clear_compact_route_after_failed_prefill`, the same two clears
  the cancellation paths perform). The wiring into each entry point's error arm
  is pinned by new rows in the source-consistency test; the helper's outcome is
  pinned by a test asserting `forward_step` returns full-vocabulary logits
  after cleanup. Stated honestly: the route is engaged in that test by direct
  field assignment (the #171 pattern), because route *selection* is keyed on a
  process-global environment variable and cannot be engaged end-to-end under
  parallel test execution.
- **The per-call `O(layer_count)` scans are gone**: `has_moe_layer` is computed
  once at engine construction (layer FFN kinds never change after load) and
  both the rejection helpers and `assert_batched_prefill_dense_only` read the
  cached flag.
- **The five earlier tests share one setup helper** (`with_moe_prefill_state`):
  device gate, enforce contract, GPU lock, fixture, and state construction in
  one place.

### Follow-up reverse-apply results

| mutation | tests that failed | others |
|---|---|---|
| remove the `forward_prefill_from` rejection | prefix-cache test, rule-separating pair, consistency row | 7 pass |
| no-op the compact cleanup helper | cleanup-outcome test | 9 pass |
| revert `generate`'s error arm to plain `?` | consistency row | 9 pass |

Each restore was byte-identical to the pre-mutation snapshot; the post-restore
control ran all 10 tests green. One measurement here was voided and re-run: the
first mutation pass filtered on an unsplit shell variable, matched zero tests,
and reported clean exits that measured nothing — caught by running the control
first on the re-run.

One claim from the first version corrected here in the open: I initially wrote
that `forward_prefill_from` batch-chunks even a single token. It does not — it
has a single-token `try_forward_step` fast path — and the first draft of the
new test asserted rejection for that arm and failed against correct behavior.
The shipped test asserts the true contract (single-token succeeds, multi-token
rejects).


**Follow-up (a21ee9d5):** scoped the `generate_streaming_with_prefix_cache` error doc to the actually-rejected shape (batched multi-token, no-LoRA — single-token and LoRA-active suffixes run per-token, which supports MoE), and deduplicated the `has_moe_layer` derivation into a single shared helper used by both state constructors. Comment/refactor only; no behavior change.
