### PR TITLE
test(inference): assert the clamp fixture's layout, not just its pieces

### DIFF
--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -2602,6 +2602,50 @@ mod tests {
             "both continuations are used as the max_draft, so they must be the same length"
         );
 
+        // The assertions above constrain the pieces. These constrain their PLACEMENT,
+        // which is what the tests actually rest on, and which a layout edit walks
+        // straight through: both of the mutations below left every assertion above and
+        // all 12 `speculate_` tests passing.
+        let c_short_at = b.len();
+        let hb_first_at = c_short_at + c_short.len();
+        let c_long_at = hb_first_at + hb.len();
+        let hb_last_at = c_long_at + c_long.len();
+
+        assert_eq!(
+            prompt.len(),
+            hb_last_at + hb.len(),
+            "the prompt must be exactly b | c_short | hb | c_long | hb; another length means a \
+             piece was added, dropped or resized, and every offset below is then reading \
+             something other than what it names"
+        );
+        assert_eq!(
+            &prompt[..b.len()],
+            b.as_slice(),
+            "the prompt must OPEN with the bare {MAX_NGRAM_LIMIT}-token block. Opening with the \
+             long block instead still contains a copy of it, so a clamped search still matches \
+             and still drafts c_short: the test keeps passing while no longer exercising a \
+             distinct shorter match"
+        );
+        assert_eq!(
+            &prompt[c_short_at..c_short_at + c_short.len()],
+            c_short.as_slice(),
+            "the short block must be followed by c_short, or a clamped search drafts something \
+             the clamp assertion does not name"
+        );
+        assert_eq!(
+            &prompt[hb_first_at..hb_first_at + hb.len()],
+            hb.as_slice(),
+            "the long block must sit between the two continuations, or the unclamped search has \
+             no earlier long match to find"
+        );
+        assert_eq!(
+            &prompt[c_long_at..c_long_at + c_long.len()],
+            c_long.as_slice(),
+            "the long block must be followed by c_long. With c_short here instead, a clamped and \
+             an unclamped search draft the SAME tokens, so removing the clamp stops changing the \
+             outcome and the regression test can no longer fail"
+        );
+
         (prompt, c_short, c_long)
     }
 

--- a/crates/inference/src/speculative.rs
+++ b/crates/inference/src/speculative.rs
@@ -2603,9 +2603,9 @@ mod tests {
         );
 
         // The assertions above constrain the pieces. These constrain their PLACEMENT,
-        // which is what the tests actually rest on, and which a layout edit walks
-        // straight through: both of the mutations below left every assertion above and
-        // all 12 `speculate_` tests passing.
+        // which is what the tests actually rest on: a layout edit that swaps or moves
+        // a piece can leave every piece-level assertion and every `speculate_` test
+        // passing while the fixture no longer exercises a distinct shorter match.
         let c_short_at = b.len();
         let hb_first_at = c_short_at + c_short.len();
         let c_long_at = hb_first_at + hb.len();


### PR DESCRIPTION
#1451 gave `clamp_fixture` assertions covering the sizes and distinctness of its
parts. Those constrain the pieces. They do not constrain where the pieces sit,
and placement is what both clamp tests actually rest on.

Two layout edits pass straight through the existing assertions with all 12
`speculate_` tests still green:

- **Opening the prompt with `hb` instead of `b`.** `hb` contains a copy of `b`,
  so a clamped search still matches and still drafts `c_short`. The test passes
  while no longer exercising a distinct shorter match, which is the whole thing
  it is for.
- **Inserting `c_short` where `c_long` belongs.** A clamped and an unclamped
  search then draft the same tokens, so removing the clamp stops changing the
  outcome and the regression test can no longer fail.

That is the same failure mode #1450 was opened about — an assertion set that
looks like a guard and is not one — one level up from where it was fixed.

## What changed

A length assertion plus four slice assertions at computed offsets, so
`b | c_short | hb | c_long | hb` is checked as a layout rather than implied by
the four `extend_from_slice` calls directly above it.

Each message names the property that dies if that piece moves. A layout
assertion whose failure text does not say what it was protecting is the next
one to get edited away.

Test-only. One hunk, inside `mod tests`, 44 lines added, no production code
touched.

## Reverse-apply results

Reproduced on this branch's parent (`9b04c4dde4`), then re-run after the fix.
Each mutation was restored to a byte-identical copy of the pre-mutation file
before the next ran.

| mutation | before this PR | after this PR |
|---|---|---|
| open with `hb` instead of `b` | 12 passed | fails on the length assertion |
| open with `hb[..b.len()]` (same length) | — | fails on the opening-block assertion |
| `c_short` in place of `c_long` | 12 passed | fails on the `c_long` placement assertion |
| remove `max_ngram.min(MAX_NGRAM_LIMIT)` | 2 failed | 2 failed |

The same-length row is there because the first mutation changes the prompt's
length and so trips the length assertion first, which says nothing about
whether the opening-block assertion does any work. Substituting a same-length
different block isolates it: it fails on the opening-block assertion, with
`the prompt must OPEN with the bare 64-token block`.

The last row is the control. The clamp mutation these tests exist to catch
still reddens exactly the two clamp tests and leaves the other ten green, so
the added assertions did not displace what was already being detected.

Honest note on the length assertion: it is a precondition for the offset reads
below it rather than an independently exercised guard, and no mutation here
isolates it. It is stated that way rather than listed as though it had its own
arm.

## bench-compare disposition

**Not owed, and no bench group is involved.** The change is a single hunk inside
`mod tests`, so it is absent from every non-test build.

Independently of that: of the 25 `[[bench]]` targets declared in
`crates/inference/Cargo.toml` — enumerated by parsing the manifest, not read off
a list — none references `NgramSpeculator`, `speculative::` or
`generate_with_speculation`, so no declared target executes this code either
way. Build inputs are identical between base and head: one `.rs` file, no
manifest, lockfile, feature, profile, build-script, bench-definition or harness
change.

Stated rather than implied: unmeasured, not waived. Nothing here claims a
performance property.

Follow-up to #1451, which closed #1450.
