### PR TITLE
feat(inference): add dormant BERT CPU policy contract

### DIFF
--- a/crates/inference/src/forward/cpu/bert_policy.rs
+++ b/crates/inference/src/forward/cpu/bert_policy.rs
@@ -1,0 +1,134 @@
+//! Dormant BERT CPU policy value contracts for sealed native preparation.
+
+use super::simd::{SimdConfig, simd_config};
+
+/// Frozen CPU capability facts captured for a future pinned BERT execution policy.
+///
+/// This value is metadata only. Possessing it does not prove that a
+/// [`crate::model::BertModel`] was loaded or executed with pinned kernels. No model constructor
+/// accepts this profile yet.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct BertCpuKernelProfile {
+    target_architecture: &'static str,
+    avx2_enabled: bool,
+    fma_enabled: bool,
+    avx512f_enabled: bool,
+    neon_enabled: bool,
+}
+
+impl BertCpuKernelProfile {
+    /// Captures the process-wide CPU capability set without reading environment variables.
+    ///
+    /// The captured facts are immutable and repeatable for the process lifetime. This method
+    /// does not select kernels or make an existing model a pinned model.
+    pub fn capture() -> Self {
+        Self::from_detected(std::env::consts::ARCH, simd_config())
+    }
+
+    fn from_detected(target_architecture: &'static str, simd: SimdConfig) -> Self {
+        Self {
+            target_architecture,
+            avx2_enabled: simd.avx2_enabled,
+            fma_enabled: simd.fma_enabled,
+            avx512f_enabled: simd.avx512f_enabled,
+            neon_enabled: simd.neon_enabled,
+        }
+    }
+
+    /// Returns the Rust target architecture captured by this profile.
+    pub const fn target_architecture(&self) -> &'static str {
+        self.target_architecture
+    }
+
+    /// Reports that the Lattice-owned scalar fallback is part of every capability set.
+    pub const fn scalar_enabled(&self) -> bool {
+        true
+    }
+
+    /// Reports the captured AVX2 capability.
+    pub const fn avx2_enabled(&self) -> bool {
+        self.avx2_enabled
+    }
+
+    /// Reports the captured FMA capability.
+    pub const fn fma_enabled(&self) -> bool {
+        self.fma_enabled
+    }
+
+    /// Reports the captured AVX-512F capability.
+    pub const fn avx512f_enabled(&self) -> bool {
+        self.avx512f_enabled
+    }
+
+    /// Reports the captured NEON capability.
+    pub const fn neon_enabled(&self) -> bool {
+        self.neon_enabled
+    }
+}
+
+/// BERT CPU execution-policy request.
+///
+/// This is a dormant contract: existing BERT constructors and forward paths remain `Auto`, and
+/// no constructor accepts `Pinned` yet. A later implementation must thread the frozen profile
+/// through every output-affecting kernel before the policy can be treated as enforcement proof.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum BertCpuKernelPolicy {
+    /// Preserve the existing ambient platform dispatcher.
+    Auto,
+    /// Request the future pinned path with one immutable captured capability profile.
+    Pinned(BertCpuKernelProfile),
+}
+
+impl BertCpuKernelPolicy {
+    /// Borrows the captured profile only when the pinned policy was requested.
+    pub const fn pinned_profile(&self) -> Option<&BertCpuKernelProfile> {
+        match self {
+            Self::Auto => None,
+            Self::Pinned(profile) => Some(profile),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn detected(
+        avx2_enabled: bool,
+        fma_enabled: bool,
+        avx512f_enabled: bool,
+        neon_enabled: bool,
+    ) -> SimdConfig {
+        SimdConfig {
+            avx2_enabled,
+            fma_enabled,
+            avx512f_enabled,
+            neon_enabled,
+        }
+    }
+
+    #[test]
+    fn synthetic_capability_rows_are_copied_without_aliasing_fields() {
+        let rows = [
+            ("scalar", detected(false, false, false, false)),
+            ("x86-avx2", detected(true, false, false, false)),
+            ("x86-avx2-fma", detected(true, true, false, false)),
+            ("x86-avx512", detected(true, true, true, false)),
+            ("aarch64-neon", detected(false, false, false, true)),
+        ];
+
+        for (target, capabilities) in rows {
+            let profile = BertCpuKernelProfile::from_detected(target, capabilities);
+            assert_eq!(profile.target_architecture(), target);
+            assert!(profile.scalar_enabled());
+            assert_eq!(profile.avx2_enabled(), capabilities.avx2_enabled);
+            assert_eq!(profile.fma_enabled(), capabilities.fma_enabled);
+            assert_eq!(profile.avx512f_enabled(), capabilities.avx512f_enabled);
+            assert_eq!(profile.neon_enabled(), capabilities.neon_enabled);
+        }
+    }
+}

--- a/crates/inference/src/forward/cpu/mod.rs
+++ b/crates/inference/src/forward/cpu/mod.rs
@@ -1,6 +1,7 @@
 //! CPU forward-kernel module index.
 mod activation;
 mod arch_kernels;
+mod bert_policy;
 mod blas;
 mod elementwise;
 mod gemm_validate;
@@ -20,6 +21,8 @@ pub use activation::{add_bias, add_bias_gelu, gelu};
 pub use arch_kernels::matmul_neon;
 #[cfg(target_arch = "x86_64")]
 pub use arch_kernels::{matmul_avx2, matmul_avx512};
+#[doc(hidden)]
+pub use bert_policy::{BertCpuKernelPolicy, BertCpuKernelProfile};
 pub use blas::{sgemm_bt_strided, sgemm_nn_ab, sgemm_nn_strided};
 pub use elementwise::{elementwise_mul, rms_norm, silu_inplace};
 pub(crate) use gemm_validate::{validate_gemm_bt, validate_gemm_nn, validate_ternary_matvec_args};

--- a/crates/inference/src/lib.rs
+++ b/crates/inference/src/lib.rs
@@ -140,6 +140,12 @@ pub(crate) fn default_cache_dir() -> Result<PathBuf, error::InferenceError> {
 // Re-exports for public API backward compatibility
 /// Root error type for inference, tokenizer, model loading, and runtime failures. See [`error`].
 pub use crate::error::InferenceError;
+/// Dormant BERT CPU policy contract for sealed native preparation.
+#[doc(hidden)]
+pub use crate::forward::cpu::BertCpuKernelPolicy;
+/// Frozen CPU capability facts for the dormant BERT pinned-policy contract.
+#[doc(hidden)]
+pub use crate::forward::cpu::BertCpuKernelProfile;
 /// BERT encoder configuration. See [`BertModel`] and [`model`].
 pub use crate::model::BertConfig;
 /// BERT/BGE encoder model. See [`BertConfig`], [`Tokenizer`], and [`BertPooling`].

--- a/crates/inference/tests/bert_cpu_kernel_policy_api.rs
+++ b/crates/inference/tests/bert_cpu_kernel_policy_api.rs
@@ -1,0 +1,48 @@
+use lattice_inference::{BertCpuKernelPolicy, BertCpuKernelProfile};
+
+#[test]
+fn captured_profile_is_stable_and_policy_retains_it_exactly() {
+    let first = BertCpuKernelProfile::capture();
+    let second = BertCpuKernelProfile::capture();
+    assert_eq!(first, second);
+
+    let automatic = BertCpuKernelPolicy::Auto;
+    assert_eq!(automatic.pinned_profile(), None);
+
+    let pinned = BertCpuKernelPolicy::Pinned(first);
+    assert_eq!(pinned.pinned_profile(), Some(&first));
+}
+
+#[test]
+fn captured_profile_reports_the_closed_host_capability_set() {
+    let profile = BertCpuKernelProfile::capture();
+    assert_eq!(profile.target_architecture(), std::env::consts::ARCH);
+    assert!(profile.scalar_enabled());
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        assert_eq!(profile.avx2_enabled(), is_x86_feature_detected!("avx2"));
+        assert_eq!(profile.fma_enabled(), is_x86_feature_detected!("fma"));
+        assert_eq!(
+            profile.avx512f_enabled(),
+            is_x86_feature_detected!("avx512f")
+        );
+        assert!(!profile.neon_enabled());
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        assert!(!profile.avx2_enabled());
+        assert!(!profile.fma_enabled());
+        assert!(!profile.avx512f_enabled());
+        assert!(profile.neon_enabled());
+    }
+
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    {
+        assert!(!profile.avx2_enabled());
+        assert!(!profile.fma_enabled());
+        assert!(!profile.avx512f_enabled());
+        assert!(!profile.neon_enabled());
+    }
+}


### PR DESCRIPTION
## Summary

Adds a dormant BERT CPU execution-policy contract. Nothing calls it: no model
constructor accepts a policy, and both the value and the enum are
`#[doc(hidden)]` and `#[non_exhaustive]`, so this change adds vocabulary for a
later pinned-kernel path rather than behaviour.

- `BertCpuKernelProfile` freezes the process-wide CPU capability set
  (architecture plus AVX2, FMA, AVX-512F and NEON) by reading the existing
  `simd_config()` once. It reads no environment variables, and its doc comment
  states plainly that holding one proves nothing about how a model was loaded or
  executed.
- `BertCpuKernelPolicy` is `Auto` or `Pinned(profile)`, with `pinned_profile()`
  returning `None` for `Auto`. `Auto` is what every existing path continues to
  do.
- `scalar_enabled()` returns `true` unconditionally, because the crate's own
  scalar fallback is part of every capability set.

Tests cover five synthetic capability rows and assert each accessor reports the
value it was constructed from, so a field-aliasing mistake in the constructor
fails rather than passing by coincidence.

## Provenance

This is #1417's commit, unchanged, on a branch cut from current `main`. #1417
branched off the same base as #1418 rather than continuing the ADR-088 series,
so it was not carried by #1467, and because #1467 landed as a squash the series
commits are not ancestors of `main`. Retargeting the old branch would have
reverted `main`'s ADR-088 text to the series' earlier draft, so the commit was
cherry-picked onto `main` instead. #1417 is closed in favour of this.

## bench-compare disposition

Structural waiver. No declared bench target in `crates/inference` or
`crates/embed` reaches this code, because no non-test caller exists: the module
is reachable only through the two new public re-exports and the one integration
test, and nothing in the crate constructs a `BertCpuKernelPolicy`. The existing
files it touches gain a module declaration and two re-exports, neither of which
alters an executed path, and no manifest, feature, profile, lockfile or bench
target definition differs from `main`.

Stated rather than argued away: an unreachable change is unmeasured, not proven
free. The change that threads a frozen profile through the kernels is the one
that needs an A/B, and it will be measurable because it will finally sit on a
path a benchmark executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
