### PR TITLE
fix(inference): reject selected SentencePiece BERT tokenizer layouts and recognize all three candidates

### DIFF
--- a/crates/inference/src/model/bert/prepared_file_presence.rs
+++ b/crates/inference/src/model/bert/prepared_file_presence.rs
@@ -16,6 +16,8 @@ pub(super) struct RawPreparedBertFilePresence {
     merges_txt: bool,
     vocab_txt: bool,
     tokenizer_model: bool,
+    sentencepiece_bpe_model: bool,
+    spiece_model: bool,
 }
 
 impl RawPreparedBertFilePresence {
@@ -29,6 +31,8 @@ impl RawPreparedBertFilePresence {
         merges_txt: bool,
         vocab_txt: bool,
         tokenizer_model: bool,
+        sentencepiece_bpe_model: bool,
+        spiece_model: bool,
     ) -> Self {
         Self {
             model_safetensors,
@@ -39,18 +43,28 @@ impl RawPreparedBertFilePresence {
             merges_txt,
             vocab_txt,
             tokenizer_model,
+            sentencepiece_bpe_model,
+            spiece_model,
         }
     }
 
-    pub(super) fn mask(self) -> u8 {
-        u8::from(self.model_safetensors) << 7
-            | u8::from(self.config_json) << 6
-            | u8::from(self.tokenizer_config_json) << 5
-            | u8::from(self.tokenizer_json) << 4
-            | u8::from(self.vocab_json) << 3
-            | u8::from(self.merges_txt) << 2
-            | u8::from(self.vocab_txt) << 1
-            | u8::from(self.tokenizer_model)
+    /// Bit layout, MSB to LSB: `model_safetensors`(9), `config_json`(8),
+    /// `tokenizer_config_json`(7), `tokenizer_json`(6), `vocab_json`(5),
+    /// `merges_txt`(4), `vocab_txt`(3), `tokenizer_model`(2),
+    /// `sentencepiece_bpe_model`(1), `spiece_model`(0). Ten recognized-file facts
+    /// no longer fit a `u8`; this mask widened to `u16` to keep every candidate
+    /// individually addressable.
+    pub(super) fn mask(self) -> u16 {
+        u16::from(self.model_safetensors) << 9
+            | u16::from(self.config_json) << 8
+            | u16::from(self.tokenizer_config_json) << 7
+            | u16::from(self.tokenizer_json) << 6
+            | u16::from(self.vocab_json) << 5
+            | u16::from(self.merges_txt) << 4
+            | u16::from(self.vocab_txt) << 3
+            | u16::from(self.tokenizer_model) << 2
+            | u16::from(self.sentencepiece_bpe_model) << 1
+            | u16::from(self.spiece_model)
     }
 
     fn tokenizer_candidates(self) -> RawBertTokenizerCandidatePresence {
@@ -60,6 +74,8 @@ impl RawPreparedBertFilePresence {
             self.merges_txt,
             self.vocab_txt,
             self.tokenizer_model,
+            self.sentencepiece_bpe_model,
+            self.spiece_model,
         )
     }
 }
@@ -113,20 +129,26 @@ pub(super) fn validate_prepared_bert_file_presence(
 #[cfg(test)]
 mod tests {
     use super::super::prepared_tokenizer_selection::{
-        PreparedBertTokenizerLayout, PreparedBertTokenizerSelectionError,
+        PreparedBertTokenizerLayout, PreparedBertTokenizerSelectionError, SentencePieceCandidate,
     };
     use super::*;
 
-    fn presence(mask: u8) -> RawPreparedBertFilePresence {
+    /// Bit order matches `RawPreparedBertFilePresence::mask()`: model_safetensors,
+    /// config_json, tokenizer_config_json, tokenizer_json, vocab_json, merges_txt,
+    /// vocab_txt, tokenizer_model, sentencepiece_bpe_model, spiece_model (MSB to
+    /// LSB, 10 bits).
+    fn presence(mask: u16) -> RawPreparedBertFilePresence {
         RawPreparedBertFilePresence::new(
-            mask & 0b1000_0000 != 0,
-            mask & 0b0100_0000 != 0,
-            mask & 0b0010_0000 != 0,
-            mask & 0b0001_0000 != 0,
-            mask & 0b0000_1000 != 0,
-            mask & 0b0000_0100 != 0,
-            mask & 0b0000_0010 != 0,
-            mask & 0b0000_0001 != 0,
+            mask & 0b10_0000_0000 != 0,
+            mask & 0b01_0000_0000 != 0,
+            mask & 0b00_1000_0000 != 0,
+            mask & 0b00_0100_0000 != 0,
+            mask & 0b00_0010_0000 != 0,
+            mask & 0b00_0001_0000 != 0,
+            mask & 0b00_0000_1000 != 0,
+            mask & 0b00_0000_0100 != 0,
+            mask & 0b00_0000_0010 != 0,
+            mask & 0b00_0000_0001 != 0,
         )
     }
 
@@ -134,15 +156,15 @@ mod tests {
     fn required_files_fail_in_model_config_tokenizer_config_order() {
         for (mask, expected) in [
             (
-                0b0001_0000,
+                0b00_0100_0000,
                 PreparedBertFilePresenceError::MissingModelSafetensors,
             ),
             (
-                0b1001_0000,
+                0b10_0100_0000,
                 PreparedBertFilePresenceError::MissingConfigJson,
             ),
             (
-                0b1101_0000,
+                0b11_0100_0000,
                 PreparedBertFilePresenceError::MissingTokenizerConfigJson,
             ),
         ] {
@@ -156,23 +178,46 @@ mod tests {
     #[test]
     fn tokenizer_validation_and_precedence_are_delegated_to_the_selector() {
         use PreparedBertTokenizerLayout::{
-            TokenizerJson, TokenizerModel, VocabJsonMerges, VocabTxt, VocabTxtMerges,
+            TokenizerJson, VocabJsonMerges, VocabTxt, VocabTxtMerges,
         };
 
         for (mask, expected) in [
-            (0b1111_1111, Ok(TokenizerJson)),
-            (0b1110_1101, Ok(VocabJsonMerges)),
-            (0b1110_0111, Ok(VocabTxtMerges)),
-            (0b1110_0011, Ok(VocabTxt)),
-            (0b1110_0001, Ok(TokenizerModel)),
+            (0b11_1111_1111, Ok(TokenizerJson)),
+            (0b11_1011_0000, Ok(VocabJsonMerges)),
+            (0b11_1001_1000, Ok(VocabTxtMerges)),
+            (0b11_1000_1000, Ok(VocabTxt)),
             (
-                0b1111_0100,
+                0b11_1000_0100,
+                Err(PreparedBertFilePresenceError::Tokenizer(
+                    PreparedBertTokenizerSelectionError::SentencePieceSelected(
+                        SentencePieceCandidate::TokenizerDotModel,
+                    ),
+                )),
+            ),
+            (
+                0b11_1000_0010,
+                Err(PreparedBertFilePresenceError::Tokenizer(
+                    PreparedBertTokenizerSelectionError::SentencePieceSelected(
+                        SentencePieceCandidate::SentencePieceBpe,
+                    ),
+                )),
+            ),
+            (
+                0b11_1000_0001,
+                Err(PreparedBertFilePresenceError::Tokenizer(
+                    PreparedBertTokenizerSelectionError::SentencePieceSelected(
+                        SentencePieceCandidate::Spiece,
+                    ),
+                )),
+            ),
+            (
+                0b11_1001_0000,
                 Err(PreparedBertFilePresenceError::Tokenizer(
                     PreparedBertTokenizerSelectionError::MergesWithoutVocab,
                 )),
             ),
             (
-                0b1111_1000,
+                0b11_1010_0000,
                 Err(PreparedBertFilePresenceError::Tokenizer(
                     PreparedBertTokenizerSelectionError::VocabJsonWithoutMerges,
                 )),
@@ -180,23 +225,42 @@ mod tests {
         ] {
             let actual = validate_prepared_bert_file_presence(presence(mask))
                 .map(PreparedBertFilePresence::tokenizer_layout);
-            assert_eq!(actual, expected, "recognized-file mask {mask:08b}");
+            assert_eq!(actual, expected, "recognized-file mask {mask:010b}");
         }
     }
 
     #[test]
-    fn validated_output_preserves_all_eight_raw_presence_facts() {
+    fn validated_output_preserves_all_ten_raw_presence_facts() {
         for mask in [
-            0b1111_1111,
-            0b1110_1101,
-            0b1110_0111,
-            0b1110_0011,
-            0b1110_0001,
+            0b11_1111_1111u16,
+            0b11_1011_0000,
+            0b11_1001_1000,
+            0b11_1000_1000,
         ] {
             let raw = presence(mask);
             let validated = validate_prepared_bert_file_presence(raw).unwrap();
             assert_eq!(validated.presence(), raw);
             assert_eq!(validated.presence().mask(), mask);
         }
+    }
+
+    /// Every present recognized SentencePiece candidate is still carried in the
+    /// raw presence facts even though selecting one is rejected: the inventory
+    /// evidence (this struct) and the selection outcome are independent.
+    #[test]
+    fn a_rejected_sentencepiece_selection_does_not_erase_the_original_presence_mask() {
+        let mask = 0b11_1000_0111u16; // required files + all three SentencePiece candidates
+        let raw = presence(mask);
+        assert_eq!(raw.mask(), mask);
+        assert_eq!(
+            validate_prepared_bert_file_presence(raw),
+            Err(PreparedBertFilePresenceError::Tokenizer(
+                PreparedBertTokenizerSelectionError::SentencePieceSelected(
+                    SentencePieceCandidate::TokenizerDotModel,
+                ),
+            ))
+        );
+        // The caller retains the original Copy value regardless of the error.
+        assert_eq!(raw.mask(), mask);
     }
 }

--- a/crates/inference/src/model/bert/prepared_tokenizer_selection.rs
+++ b/crates/inference/src/model/bert/prepared_tokenizer_selection.rs
@@ -7,15 +7,20 @@ pub(super) struct RawBertTokenizerCandidatePresence {
     merges_txt: bool,
     vocab_txt: bool,
     tokenizer_model: bool,
+    sentencepiece_bpe_model: bool,
+    spiece_model: bool,
 }
 
 impl RawBertTokenizerCandidatePresence {
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         tokenizer_json: bool,
         vocab_json: bool,
         merges_txt: bool,
         vocab_txt: bool,
         tokenizer_model: bool,
+        sentencepiece_bpe_model: bool,
+        spiece_model: bool,
     ) -> Self {
         Self {
             tokenizer_json,
@@ -23,15 +28,22 @@ impl RawBertTokenizerCandidatePresence {
             merges_txt,
             vocab_txt,
             tokenizer_model,
+            sentencepiece_bpe_model,
+            spiece_model,
         }
     }
 
+    /// Bit layout, MSB to LSB: `tokenizer_json`(6), `vocab_json`(5), `merges_txt`(4),
+    /// `vocab_txt`(3), `tokenizer_model`(2), `sentencepiece_bpe_model`(1),
+    /// `spiece_model`(0).
     pub(super) fn mask(self) -> u8 {
-        u8::from(self.tokenizer_json) << 4
-            | u8::from(self.vocab_json) << 3
-            | u8::from(self.merges_txt) << 2
-            | u8::from(self.vocab_txt) << 1
-            | u8::from(self.tokenizer_model)
+        u8::from(self.tokenizer_json) << 6
+            | u8::from(self.vocab_json) << 5
+            | u8::from(self.merges_txt) << 4
+            | u8::from(self.vocab_txt) << 3
+            | u8::from(self.tokenizer_model) << 2
+            | u8::from(self.sentencepiece_bpe_model) << 1
+            | u8::from(self.spiece_model)
     }
 }
 
@@ -41,7 +53,17 @@ pub(super) enum PreparedBertTokenizerLayout {
     VocabJsonMerges,
     VocabTxtMerges,
     VocabTxt,
-    TokenizerModel,
+}
+
+/// Which SentencePiece candidate file a rejected selection named. ADR-088 D4
+/// requires prepared BERT mode to reject a selected SentencePiece layout rather
+/// than fall through to it, since SentencePiece/Unigram is outside the supported
+/// tokenizer closure.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum SentencePieceCandidate {
+    TokenizerDotModel,
+    SentencePieceBpe,
+    Spiece,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -49,6 +71,7 @@ pub(super) enum PreparedBertTokenizerSelectionError {
     MissingRepresentation,
     VocabJsonWithoutMerges,
     MergesWithoutVocab,
+    SentencePieceSelected(SentencePieceCandidate),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -67,6 +90,13 @@ impl PreparedBertTokenizerSelection {
     }
 }
 
+/// ADR-088 D4 lists the three SentencePiece candidates (`tokenizer.model`,
+/// `sentencepiece.bpe.model`, `spiece.model`) without ordering them against each
+/// other; it only orders the SentencePiece tier as a whole below WordPiece/BPE.
+/// This selector breaks the tie in the order D4 itself lists the three names,
+/// both where it introduces the recognized-file set and where it states the
+/// tokenizer precedence: `tokenizer.model`, then `sentencepiece.bpe.model`, then
+/// `spiece.model`.
 pub(super) fn select_prepared_bert_tokenizer_layout(
     presence: RawBertTokenizerCandidatePresence,
 ) -> Result<PreparedBertTokenizerSelection, PreparedBertTokenizerSelectionError> {
@@ -86,7 +116,17 @@ pub(super) fn select_prepared_bert_tokenizer_layout(
     } else if presence.vocab_txt {
         PreparedBertTokenizerLayout::VocabTxt
     } else if presence.tokenizer_model {
-        PreparedBertTokenizerLayout::TokenizerModel
+        return Err(PreparedBertTokenizerSelectionError::SentencePieceSelected(
+            SentencePieceCandidate::TokenizerDotModel,
+        ));
+    } else if presence.sentencepiece_bpe_model {
+        return Err(PreparedBertTokenizerSelectionError::SentencePieceSelected(
+            SentencePieceCandidate::SentencePieceBpe,
+        ));
+    } else if presence.spiece_model {
+        return Err(PreparedBertTokenizerSelectionError::SentencePieceSelected(
+            SentencePieceCandidate::Spiece,
+        ));
     } else {
         return Err(PreparedBertTokenizerSelectionError::MissingRepresentation);
     };
@@ -104,54 +144,166 @@ mod tests {
         PreparedBertTokenizerSelectionError::VocabJsonWithoutMerges;
     const ORPHAN_MERGES: PreparedBertTokenizerSelectionError =
         PreparedBertTokenizerSelectionError::MergesWithoutVocab;
+    const SP_TOKENIZER_MODEL: PreparedBertTokenizerSelectionError =
+        PreparedBertTokenizerSelectionError::SentencePieceSelected(
+            SentencePieceCandidate::TokenizerDotModel,
+        );
+    const SP_SENTENCEPIECE_BPE: PreparedBertTokenizerSelectionError =
+        PreparedBertTokenizerSelectionError::SentencePieceSelected(
+            SentencePieceCandidate::SentencePieceBpe,
+        );
+    const SP_SPIECE: PreparedBertTokenizerSelectionError =
+        PreparedBertTokenizerSelectionError::SentencePieceSelected(SentencePieceCandidate::Spiece);
 
     const J: PreparedBertTokenizerLayout = PreparedBertTokenizerLayout::TokenizerJson;
     const VM: PreparedBertTokenizerLayout = PreparedBertTokenizerLayout::VocabJsonMerges;
     const TM: PreparedBertTokenizerLayout = PreparedBertTokenizerLayout::VocabTxtMerges;
     const T: PreparedBertTokenizerLayout = PreparedBertTokenizerLayout::VocabTxt;
-    const S: PreparedBertTokenizerLayout = PreparedBertTokenizerLayout::TokenizerModel;
 
     fn presence(mask: u8) -> RawBertTokenizerCandidatePresence {
         RawBertTokenizerCandidatePresence::new(
-            mask & 0b1_0000 != 0,
-            mask & 0b0_1000 != 0,
-            mask & 0b0_0100 != 0,
-            mask & 0b0_0010 != 0,
-            mask & 0b0_0001 != 0,
+            mask & 0b100_0000 != 0,
+            mask & 0b010_0000 != 0,
+            mask & 0b001_0000 != 0,
+            mask & 0b000_1000 != 0,
+            mask & 0b000_0100 != 0,
+            mask & 0b000_0010 != 0,
+            mask & 0b000_0001 != 0,
         )
     }
 
+    /// Every one of the 2^7 = 128 tokenizer-candidate presence states has exactly
+    /// one specified result. Bit order matches `presence()`: tokenizer_json,
+    /// vocab_json, merges_txt, vocab_txt, tokenizer_model, sentencepiece_bpe_model,
+    /// spiece_model (MSB to LSB). Generated from the precedence rules in ADR-088
+    /// D4, independent of the implementation under test.
     #[test]
-    fn all_32_presence_states_have_one_exact_result() {
+    fn all_128_presence_states_have_one_exact_result() {
         let expected = [
             Err(MISSING),
-            Ok(S),
+            Err(SP_SPIECE),
+            Err(SP_SENTENCEPIECE_BPE),
+            Err(SP_SENTENCEPIECE_BPE),
+            Err(SP_TOKENIZER_MODEL),
+            Err(SP_TOKENIZER_MODEL),
+            Err(SP_TOKENIZER_MODEL),
+            Err(SP_TOKENIZER_MODEL),
+            Ok(T),
+            Ok(T),
+            Ok(T),
+            Ok(T),
+            Ok(T),
+            Ok(T),
             Ok(T),
             Ok(T),
             Err(ORPHAN_MERGES),
             Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Ok(TM),
+            Ok(TM),
+            Ok(TM),
+            Ok(TM),
+            Ok(TM),
+            Ok(TM),
             Ok(TM),
             Ok(TM),
             Err(PARTIAL_VOCAB_JSON),
             Err(PARTIAL_VOCAB_JSON),
             Err(PARTIAL_VOCAB_JSON),
             Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
             Ok(VM),
             Ok(VM),
             Ok(VM),
             Ok(VM),
+            Ok(VM),
+            Ok(VM),
+            Ok(VM),
+            Ok(VM),
+            Ok(VM),
+            Ok(VM),
+            Ok(VM),
+            Ok(VM),
+            Ok(VM),
+            Ok(VM),
+            Ok(VM),
+            Ok(VM),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
             Ok(J),
             Ok(J),
             Ok(J),
             Ok(J),
             Err(ORPHAN_MERGES),
             Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Err(ORPHAN_MERGES),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
             Ok(J),
             Ok(J),
             Err(PARTIAL_VOCAB_JSON),
             Err(PARTIAL_VOCAB_JSON),
             Err(PARTIAL_VOCAB_JSON),
             Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Err(PARTIAL_VOCAB_JSON),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
+            Ok(J),
             Ok(J),
             Ok(J),
             Ok(J),
@@ -164,25 +316,25 @@ mod tests {
                 select_prepared_bert_tokenizer_layout(raw)
                     .map(PreparedBertTokenizerSelection::layout),
                 expected_layout,
-                "JVMTS mask {mask:05b}"
+                "JVMTSPS mask {mask:07b}"
             );
         }
     }
 
     #[test]
     fn global_partial_validation_precedes_even_tokenizer_json() {
-        for mask in [0b1_0100, 0b1_0101] {
+        for mask in [0b101_0000, 0b101_0001] {
             assert_eq!(
                 select_prepared_bert_tokenizer_layout(presence(mask)),
                 Err(ORPHAN_MERGES),
-                "orphan merges must fail under tokenizer.json for {mask:05b}"
+                "orphan merges must fail under tokenizer.json for {mask:07b}"
             );
         }
-        for mask in [0b1_1000, 0b1_1001, 0b1_1010, 0b1_1011] {
+        for mask in [0b110_0000, 0b110_0001, 0b110_0010, 0b110_0011] {
             assert_eq!(
                 select_prepared_bert_tokenizer_layout(presence(mask)),
                 Err(PARTIAL_VOCAB_JSON),
-                "partial vocab.json must fail under tokenizer.json for {mask:05b}"
+                "partial vocab.json must fail under tokenizer.json for {mask:07b}"
             );
         }
     }
@@ -190,11 +342,10 @@ mod tests {
     #[test]
     fn selected_layout_preserves_the_complete_raw_presence_fact() {
         for (mask, layout) in [
-            (0b1_1111, J),
-            (0b0_1111, VM),
-            (0b0_0111, TM),
-            (0b0_0011, T),
-            (0b0_0001, S),
+            (0b111_1111, J),
+            (0b011_1111, VM),
+            (0b001_1111, TM),
+            (0b000_1000, T),
         ] {
             let raw = presence(mask);
             let selected = select_prepared_bert_tokenizer_layout(raw).unwrap();
@@ -202,5 +353,39 @@ mod tests {
             assert_eq!(selected.presence(), raw);
             assert_eq!(selected.presence().mask(), mask);
         }
+    }
+
+    /// A selected SentencePiece candidate is rejected rather than accepted, and
+    /// the error names which of the three files was selected, per the
+    /// tokenizer.model > sentencepiece.bpe.model > spiece.model precedence this
+    /// module documents.
+    #[test]
+    fn sentencepiece_precedence_among_the_three_candidates_when_selected() {
+        for (mask, expected) in [
+            (0b000_0001, SP_SPIECE),
+            (0b000_0010, SP_SENTENCEPIECE_BPE),
+            (0b000_0011, SP_SENTENCEPIECE_BPE),
+            (0b000_0100, SP_TOKENIZER_MODEL),
+            (0b000_0101, SP_TOKENIZER_MODEL),
+            (0b000_0110, SP_TOKENIZER_MODEL),
+            (0b000_0111, SP_TOKENIZER_MODEL),
+        ] {
+            assert_eq!(
+                select_prepared_bert_tokenizer_layout(presence(mask)),
+                Err(expected),
+                "SentencePiece-only mask {mask:07b}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_higher_tier_candidate_shadows_a_present_sentencepiece_candidate() {
+        // tokenizer.json plus every SentencePiece candidate still selects
+        // TokenizerJson; the SentencePiece bits are shadowed, not consulted.
+        let raw = presence(0b111_0111);
+        assert_eq!(
+            select_prepared_bert_tokenizer_layout(raw).map(PreparedBertTokenizerSelection::layout),
+            Ok(J)
+        );
     }
 }


### PR DESCRIPTION
## Summary

The dormant prepared-BERT tokenizer contract disagreed with ADR-088 D4 in two
ways. Both are fixed here, in the same dormant code, with no production caller
added.

**Three SentencePiece files were one bit.** `RawPreparedBertFilePresence` and
`RawBertTokenizerCandidatePresence` carried a single `tokenizer_model: bool`
standing for `tokenizer.model`, `sentencepiece.bpe.model` and `spiece.model`
together. D4 names the three individually and requires every present recognized
candidate to be copied and attested, which one bit cannot record. Each file now
has its own field and its own bit; the file-presence mask widened from `u8` to
`u16` to hold ten booleans, with the bit layout documented on the method.

**A selected SentencePiece layout was accepted, not rejected.**
`select_prepared_bert_tokenizer_layout` returned
`Ok(PreparedBertTokenizerLayout::TokenizerModel)` when a SentencePiece candidate
was the last one standing. D4 requires a typed rejection naming the unsupported
tokenizer model, with no fall-through to a lower-priority WordPiece or BPE
candidate. Selection now returns
`PreparedBertTokenizerSelectionError::SentencePieceSelected(SentencePieceCandidate)`
naming which of the three was selected. `PreparedBertTokenizerLayout::TokenizerModel`
is removed, because after this change no path can construct it and the whole-tree
grep finds no other reference.

The four supported layouts, the two partial-layout errors, and the order in which
they are checked are unchanged.

### One place the ADR does not decide

D4 lists the three SentencePiece candidates as a single precedence tier and never
orders them against each other. It does list them in the same order twice, at the
inventory description and at tier 5 of the precedence list, so that order is what
the rejection uses: `tokenizer.model`, then `sentencepiece.bpe.model`, then
`spiece.model`. This is a choice made under an ADR gap rather than a requirement
read out of it, and it is recorded as such in a doc comment on the selector.
Filed separately so the ADR can settle it.

## Tests

- The exhaustive selector test enumerates all 128 states of the widened candidate
  mask, not a sample. Its expected results are a literal table written from D4's
  precedence rules rather than derived from the implementation, so it can disagree
  with the code.
- New: precedence among the three SentencePiece candidates across all eight
  combinations; a higher-tier candidate shadows a present SentencePiece file; a
  rejected SentencePiece selection leaves the original presence facts intact.
- The file-presence delegation test gained one case per SentencePiece candidate,
  each asserting the specific named-candidate error.

Three mutation probes, each with its reddening arm predicted before the run and
reconciled after: collapsing the three fields back into one bit reddens only the
two non-`tokenizer.model` delegation cases; accepting instead of rejecting reddens
four tests and leaves the shadowing test green because it returns at a higher
tier; and reversing the order within the SentencePiece tier reddens the
precedence test and the exhaustive table while leaving the other three green.
Each restore was verified by an empty diff and a re-run.

## bench-compare disposition

Structural waiver. Both files are dormant: their modules are declared
`#[cfg_attr(not(test), allow(dead_code))]`, every item is `pub(super)`, and a
whole-tree grep finds no caller outside the two files and their own tests. No
declared bench target in `crates/inference` or `crates/embed` can reach this
code, and no manifest, feature, profile, lockfile or bench-target definition
differs from `main`.

Stated rather than argued away: unreachable is unmeasured, not proven free. The
change that wires these facts into the prepared-checkpoint load path is the one
that needs an A/B, and it will be measurable because it will sit on a path a
benchmark executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
