### PR TITLE
bench(inference): add a packed-batch attention kernel group

### DIFF
--- a/crates/inference/benches/inference_bench.rs
+++ b/crates/inference/benches/inference_bench.rs
@@ -990,6 +990,141 @@ fn bench_attention_kernel(c: &mut Criterion) {
     group.finish();
 }
 
+// ---------------------------------------------------------------------------
+// Packed-batch attention kernel benchmark
+//
+// `bench_attention_kernel` above exercises `multi_head_attention`, the
+// single-sequence per-head path. No other declared bench target in this crate
+// calls `multi_head_attention_batched`, the packed-batch path that
+// `BertModel::forward_batch` uses: the only route that reaches it is
+// `e2e_bench`, transitively and only at that binary's own input sizes, which
+// top out around 100 tokens. The group below is the direct caller that closes
+// that gap, so a coverage audit reading this comment should count it as one.
+//
+// Sweep geometry: attention cost in this path is dominated by the score and
+// context products, both O(num_heads * seq_len^2 * head_dim) for a fixed model
+// shape, and by the per-`matmul_bt` dispatch cost, which scales with the
+// number of calls rather than their size. Those two terms move in opposite
+// directions as `seq_len` grows, so any change to how the per-head products
+// are issued has a crossover somewhere in `seq_len`, and a single point
+// measurement cannot locate it. `seq_len` in `[16, 128]` (bge-small's
+// HIDDEN_SIZE=384/NUM_HEADS=12/HEAD_DIM=32 shape) is the range
+// `attention_kernel` above and `e2e_bench` already cover; this sweep brackets
+// that known short end against the long end, up to 512, bge-small's
+// `max_position_embeddings` limit.
+//
+// Requires `--features bench-internals` to reach
+// `multi_head_attention_batched`, which stays `pub(crate)` otherwise; the
+// group itself is always registered (empty no-op body without the feature),
+// matching the `inference_perf` bench's convention for gated groups.
+// ---------------------------------------------------------------------------
+
+fn bench_attention_batched_kernel(c: &mut Criterion) {
+    #[cfg(feature = "bench-internals")]
+    {
+        use lattice_inference::attention::standard::bench_support::multi_head_attention_batched;
+
+        let (layer_weights, _layer_storage) =
+            synthetic_layer_weights(HIDDEN_SIZE, INTERMEDIATE_SIZE);
+        let layer = &layer_weights;
+        let fused_qkv_weight = random_vec_with_seed(3 * HIDDEN_SIZE * HIDDEN_SIZE, 0x4000_0001);
+        let fused_qkv_bias = random_bias_with_seed(3 * HIDDEN_SIZE, 0x4000_0002);
+
+        let mut group = c.benchmark_group("attention_batched_kernel");
+        group.sample_size(10);
+        group.warm_up_time(Duration::from_secs(1));
+        group.measurement_time(Duration::from_secs(4));
+
+        // Primary axis: sequence length, single packed segment (batch=1),
+        // sweeping the dispatch-bound short end through the arithmetic-bound
+        // long end (see geometry note above).
+        for seq_len in [16usize, 32, 64, 128, 256, 384, 512] {
+            let cu_seqlens = vec![0usize, seq_len];
+            let total = seq_len;
+            let hidden_states = random_vec(total * HIDDEN_SIZE);
+            let mut q = vec![0.0f32; total * HIDDEN_SIZE];
+            let mut k = vec![0.0f32; total * HIDDEN_SIZE];
+            let mut v = vec![0.0f32; total * HIDDEN_SIZE];
+            let mut qkv = vec![0.0f32; total * HIDDEN_SIZE * 3];
+            let mut concat = vec![0.0f32; total * HIDDEN_SIZE];
+            let mut output = vec![0.0f32; total * HIDDEN_SIZE];
+
+            group.throughput(Throughput::Elements((NUM_HEADS * seq_len * seq_len) as u64));
+            group.bench_function(BenchmarkId::new("seq_len", seq_len), |b| {
+                b.iter(|| {
+                    multi_head_attention_batched(
+                        black_box(hidden_states.as_slice()),
+                        layer,
+                        black_box(fused_qkv_weight.as_slice()),
+                        black_box(fused_qkv_bias.as_slice()),
+                        black_box(cu_seqlens.as_slice()),
+                        HIDDEN_SIZE,
+                        NUM_HEADS,
+                        HEAD_DIM,
+                        &mut q,
+                        &mut k,
+                        &mut v,
+                        &mut qkv,
+                        &mut concat,
+                        &mut output,
+                        &NoopLoraHook,
+                        0,
+                    );
+                    black_box(output.as_slice());
+                });
+            });
+        }
+
+        // Secondary axis: batch shape at a fixed representative seq_len
+        // (mirrors `bench_batch_encoding_throughput`'s batch_size sweep at
+        // seq_len=32), confirming a multi-segment `cu_seqlens` batch reaches
+        // the same code path real callers (`BertModel::forward_batch`) use.
+        let batch_seq_len = 32usize;
+        for batch_size in [1usize, 4, 8, 16] {
+            let cu_seqlens: Vec<usize> = (0..=batch_size).map(|i| i * batch_seq_len).collect();
+            let total = batch_size * batch_seq_len;
+            let hidden_states = random_vec(total * HIDDEN_SIZE);
+            let mut q = vec![0.0f32; total * HIDDEN_SIZE];
+            let mut k = vec![0.0f32; total * HIDDEN_SIZE];
+            let mut v = vec![0.0f32; total * HIDDEN_SIZE];
+            let mut qkv = vec![0.0f32; total * HIDDEN_SIZE * 3];
+            let mut concat = vec![0.0f32; total * HIDDEN_SIZE];
+            let mut output = vec![0.0f32; total * HIDDEN_SIZE];
+
+            group.throughput(Throughput::Elements(
+                (batch_size * NUM_HEADS * batch_seq_len * batch_seq_len) as u64,
+            ));
+            group.bench_function(BenchmarkId::new("batch_size", batch_size), |b| {
+                b.iter(|| {
+                    multi_head_attention_batched(
+                        black_box(hidden_states.as_slice()),
+                        layer,
+                        black_box(fused_qkv_weight.as_slice()),
+                        black_box(fused_qkv_bias.as_slice()),
+                        black_box(cu_seqlens.as_slice()),
+                        HIDDEN_SIZE,
+                        NUM_HEADS,
+                        HEAD_DIM,
+                        &mut q,
+                        &mut k,
+                        &mut v,
+                        &mut qkv,
+                        &mut concat,
+                        &mut output,
+                        &NoopLoraHook,
+                        0,
+                    );
+                    black_box(output.as_slice());
+                });
+            });
+        }
+
+        group.finish();
+    }
+    #[cfg(not(feature = "bench-internals"))]
+    let _ = c;
+}
+
 criterion_group!(
     name = benches;
     config = Criterion::default();
@@ -999,6 +1134,7 @@ criterion_group!(
         bench_tokenizer_throughput,
         bench_full_forward_pass,
         bench_batch_encoding_throughput,
-        bench_attention_kernel
+        bench_attention_kernel,
+        bench_attention_batched_kernel
 );
 criterion_main!(benches);

--- a/crates/inference/benches/inference_bench.rs
+++ b/crates/inference/benches/inference_bench.rs
@@ -999,7 +999,14 @@ fn bench_attention_kernel(c: &mut Criterion) {
 // `BertModel::forward_batch` uses: the only route that reaches it is
 // `e2e_bench`, transitively and only at that binary's own input sizes, which
 // top out around 100 tokens. The group below is the direct caller that closes
-// that gap, so a coverage audit reading this comment should count it as one.
+// that gap.
+//
+// It is not in any default bench workflow: `scripts/bench-ci.sh` and
+// `scripts/bench-gate.sh` both select `elementwise_cpu_bench` with no features,
+// so comparing this group requires naming the target
+// (`lattice-inference:inference_bench`) and enabling `bench-internals`
+// explicitly. Without both, this group's body is a no-op and the comparison is
+// silently empty.
 //
 // Sweep geometry: attention cost in this path is dominated by the score and
 // context products, both O(num_heads * seq_len^2 * head_dim) for a fixed model

--- a/crates/inference/src/attention/standard.rs
+++ b/crates/inference/src/attention/standard.rs
@@ -961,6 +961,60 @@ pub(crate) fn multi_head_attention_batched_padded_reference(
     );
 }
 
+// -----------------------------------------------------------------------
+// Bench-only support module
+// -----------------------------------------------------------------------
+
+/// Bench-only re-export of [`multi_head_attention_batched`], which stays
+/// `pub(crate)` outside `bench-internals` builds. Same visibility discipline
+/// as `weights::bench_support` and `forward::neon_forward::bench_support`:
+/// the default public API is unchanged, and only a `--features
+/// bench-internals` build can reach the packed-batch attention path directly
+/// from a Criterion bench.
+#[cfg(feature = "bench-internals")]
+pub mod bench_support {
+    use super::*;
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn multi_head_attention_batched(
+        hidden_states: &[f32],
+        layer_weights: &TransformerLayerWeights<'_>,
+        fused_qkv_weight: &[f32],
+        fused_qkv_bias: &[f32],
+        cu_seqlens: &[usize],
+        hidden_size: usize,
+        num_heads: usize,
+        head_dim: usize,
+        q: &mut [f32],
+        k: &mut [f32],
+        v: &mut [f32],
+        qkv: &mut [f32],
+        concat: &mut [f32],
+        output: &mut [f32],
+        lora: &dyn LoraHook,
+        layer_idx: usize,
+    ) {
+        super::multi_head_attention_batched(
+            hidden_states,
+            layer_weights,
+            fused_qkv_weight,
+            fused_qkv_bias,
+            cu_seqlens,
+            hidden_size,
+            num_heads,
+            head_dim,
+            q,
+            k,
+            v,
+            qkv,
+            concat,
+            output,
+            lora,
+            layer_idx,
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Why

`multi_head_attention_batched` is the packed-batch attention path `BertModel::forward_batch` runs for every multi-sequence embedding request, and no declared bench target in `lattice-inference` calls it. The closest existing group, `attention_kernel`, exercises `multi_head_attention`, the single-sequence per-head entry point, which is a different function. The only route that reaches the packed path at all is `e2e_bench`, transitively, at that binary's own input sizes of roughly 100 tokens.

The practical consequence is that a change to the packed path has nothing on the base side to compare against, so its A/B can only measure code the change did not touch. This PR is bench coverage only: no behaviour changes, and it exists so a later change to that path has a base-side counterpart at the same benchmark ids.

## What

- `attention::standard::bench_support`, a `#[cfg(feature = "bench-internals")]` re-export of `multi_head_attention_batched`, which stays `pub(crate)` in every other build. Same visibility discipline as the existing `weights::bench_support` and `forward::neon_forward::bench_support`, so the default public API is unchanged and no non-bench build can reach the new module.
- `attention_batched_kernel`, registered in `inference_bench`'s target list, with two axes at bge-small geometry (`HIDDEN_SIZE` 384, `NUM_HEADS` 12, `HEAD_DIM` 32):
  - `seq_len` in 16, 32, 64, 128, 256, 384, 512 at batch=1. Cost in this path is dominated by the score and context products, both `O(num_heads * seq_len^2 * head_dim)`, and by per-`matmul_bt` dispatch cost, which scales with the number of calls rather than their size. Those two terms move in opposite directions as `seq_len` grows, so any change to how the per-head products are issued has a crossover somewhere in `seq_len` that a single point cannot locate. The sweep brackets the dispatch-bound short end against the arithmetic-bound long end. 512 is bge-small's `max_position_embeddings`.
  - `batch_size` in 1, 4, 8, 16 at `seq_len` 32, mirroring `bench_batch_encoding_throughput`'s sweep, so a multi-segment `cu_seqlens` batch is covered alongside the single packed segment.
- Without `--features bench-internals` the group body compiles to a no-op and the target stays registered, matching the `inference_perf` bench's convention for gated groups.

## Test plan

- `cargo clippy --release -p lattice-inference --all-targets --features f16,metal-gpu,bench-internals -- -D warnings`: clean. This is the command CI runs; a narrower `--features bench-internals` run without `f16` reports pre-existing unused imports in `f16_convert_bench.rs`, which this PR does not touch and which are present on main unchanged.
- `cargo check -p lattice-inference --benches`, feature off, exercising the no-op arm: clean.
- `cargo fmt --check -p lattice-inference`: clean.
- `cargo bench -p lattice-inference --bench inference_bench --features bench-internals -- attention_batched_kernel --test`: all 11 benchmark ids execute (7 `seq_len`, 4 `batch_size`), each reporting Success. This is a single-iteration correctness pass, not a timing run, and no number from it is quoted anywhere.
- No library or model code path is modified, so runtime behaviour is unaffected.

## How to compare this group

Neither default bench workflow selects it. `scripts/bench-ci.sh` and `scripts/bench-gate.sh` both run `lattice-inference:elementwise_cpu_bench` with no features, so an A/B that names no target and no features will not touch `inference_bench` at all, and this group's body compiles to a no-op without `bench-internals` besides. Comparing it requires naming `lattice-inference:inference_bench` and enabling `bench-internals` on both arms. Stated here and in the source comment because the failure mode is a silently empty comparison, which reads like a pass.

## bench-compare waiver

No `make bench-compare` table. This PR adds no executable library or model code: the only non-bench change is a `#[cfg(feature = "bench-internals")]` module that no default build compiles, so every existing benchmark measures byte-identical code on both arms and an A/B here can only report noise. The group this PR adds has no base-side counterpart by construction, since landing it on the base is the entire point of the PR, so it has no comparison either.

The dedicated bench host is also unreachable from here right now, and this repository's rule is that timed runs happen there and nowhere else. Waiving rather than substituting a local run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
