### PR TITLE
fix(inference): make the f16 KV Metal probe opt-in by environment

### DIFF
--- a/crates/inference/src/forward/metal_qwen35/inner/tests/dispatch.rs
+++ b/crates/inference/src/forward/metal_qwen35/inner/tests/dispatch.rs
@@ -7,6 +7,14 @@ use super::*;
 /// KV kernels actually construct and execute, and fails loudly
 /// (LATTICE_METAL_TEST_ENFORCE=1) instead of skip-passing when a Metal
 /// device is absent.
+///
+/// It is opt-in by environment, not by name: `LATTICE_KV_F16` and
+/// `LATTICE_METAL_PATH_PROOF` select the path being probed and must be set
+/// before the state is constructed, so a run that does not set them has not
+/// asked the question and reports `reason=not_configured` rather than failing.
+/// `LATTICE_METAL_TEST_ENFORCE=1`, which the CI leg sets alongside both, turns
+/// that same absence back into a hard failure, so the fail-closed property the
+/// probe exists for is unchanged where it is actually exercised.
 #[test]
 fn f16_kv_metal_path_executes_and_reports_capability() {
     let _gpu_guard = gpu_test_lock();
@@ -20,20 +28,30 @@ fn f16_kv_metal_path_executes_and_reports_capability() {
         return;
     };
 
-    assert!(
-        matches!(
-            std::env::var("LATTICE_KV_F16").as_deref(),
-            Ok("1") | Ok("true")
-        ),
-        "f16 KV Metal probe must run with LATTICE_KV_F16=1"
+    // Not configured to run and configured-but-incapable are different answers, and
+    // only the second one is a defect. Both variables must be read before the state is
+    // built, so the test cannot set them itself: `MetalQwen35State::new` reads
+    // `LATTICE_KV_F16` during construction, and setting a process-wide variable from
+    // inside one test would reach every other test running beside it. So the leg that
+    // wants this probe sets them, and the enforcement flag is what makes their absence
+    // a failure — exactly as it does for a missing device above.
+    let configured = matches!(
+        std::env::var("LATTICE_KV_F16").as_deref(),
+        Ok("1") | Ok("true")
+    ) && matches!(
+        std::env::var("LATTICE_METAL_PATH_PROOF").as_deref(),
+        Ok("1") | Ok("true")
     );
-    assert!(
-        matches!(
-            std::env::var("LATTICE_METAL_PATH_PROOF").as_deref(),
-            Ok("1") | Ok("true")
-        ),
-        "f16 KV Metal probe must run with LATTICE_METAL_PATH_PROOF=1"
-    );
+    if !configured {
+        eprintln!("[METAL_F16_KV_CAPABILITY] supported=false reason=not_configured");
+        assert!(
+            !enforce,
+            "LATTICE_METAL_TEST_ENFORCE=1 but LATTICE_KV_F16 and LATTICE_METAL_PATH_PROOF \
+             are not both set: the probe cannot report a capability it was never asked to \
+             exercise, and skipping here would be the skip-pass this test exists to prevent"
+        );
+        return;
+    }
 
     let (cfg, weights) = tiny_metal_qwen35_fixture();
     let mut state = match MetalQwen35State::new(&weights, &cfg, 16) {


### PR DESCRIPTION
Closes #1484.

## The failure

`forward::metal_qwen35::inner::tests::dispatch::f16_kv_metal_path_executes_and_reports_capability` fails on any unfiltered run on a Metal-capable macOS host:

```
cargo test -p lattice-inference --features metal-gpu --lib -- --test-threads=1
test result: FAILED. 3177 passed; 1 failed; 23 ignored; 0 measured; 0 filtered out

panicked at .../inner/tests/dispatch.rs:23:5:
f16 KV Metal probe must run with LATTICE_KV_F16=1
```

The test hard-asserts `LATTICE_KV_F16` and `LATTICE_METAL_PATH_PROOF`, which only the dedicated `inference - f16 KV-cache Metal path (macOS only)` step sets. That step selects the test by name, so CI is green; nothing marks the test as opt-in, so every unfiltered run selects it too and the assertion is guaranteed to fire there.

## The fix

Not configured to run and configured but incapable are different answers, and only the second is a defect. The two variables select the path being probed and must be set before construction, so the test cannot set them itself: `MetalQwen35State::new` reads `LATTICE_KV_F16` while building, and a test that set a process-wide variable would reach every test running beside it.

So the absence of the variables now takes the same shape the absence of a Metal device already had two lines above: print the capability marker with `reason=not_configured` and return, unless `LATTICE_METAL_TEST_ENFORCE` is set, in which case it stays a hard failure. The CI step sets all three, so its behaviour is byte-for-byte unchanged, and its `grep -Fq '[METAL_F16_KV_CAPABILITY] supported=true'` still rejects a run that reports anything else.

This can only relax the not-configured arm. Every path where the test passes today has the variables set, so it takes the same branch it took before; and no other leg can silently start skipping, because a leg that runs this test with enforcement on and the variables missing fails, which is the third arm below.

Test-only change. No library or model code path is modified.

## Verification

On a Metal host, GPU otherwise idle:

- Reproduction at the base commit: the unfiltered `--lib` run fails exactly as filed, with this the only failure among 3177 passing tests.
- Arm 1, no environment set: `test result: ok. 1 passed`, and the run prints `[METAL_F16_KV_CAPABILITY] supported=false reason=not_configured`.
- Arm 2, the CI environment (`LATTICE_METAL_TEST_ENFORCE=1 LATTICE_KV_F16=1 LATTICE_METAL_PATH_PROOF=1`): `test result: ok. 1 passed`, and the run prints `[METAL_F16_KV_CAPABILITY] supported=true`, which is the CI step's own grep.
- Arm 3, the must-fail control (`LATTICE_METAL_TEST_ENFORCE=1` alone): the test still fails, so the fail-closed property survives where it is exercised.
- The unfiltered `--lib` run that reproduced the failure now reports this probe `ok`. That run
  is not yet fully green on this base: its one remaining failure is the MoE routing-trace test
  from #1447, a separate defect whose fix is in flight and not on main here.

## bench-compare waiver

No `make bench-compare` table. This changes one `#[cfg(test)]` function and no compiled-in code path, so both arms would execute byte-identical production code and any reported difference would be noise. The dedicated bench host is unreachable from here, and timed runs belong there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
