### PR TITLE
feat(inference): KV-cached greedy decode for the PaddleOCR-VL ERNIE-4.5 decoder

### DIFF
--- a/.github/workflows/e2e-parity.yml
+++ b/.github/workflows/e2e-parity.yml
@@ -903,7 +903,12 @@ jobs:
           # assertion passed; a run that skipped prints neither. The counts pin the fixture sets
           # (three synthetic grids, one image) so a silently shrunk fixture cannot pass as a run.
           test "$(grep -c '^case g[0-9]*x[0-9]*: grid [0-9]*x[0-9]* ([0-9]* patches) all checkpoints within tolerance' paddleocr-gates.log)" -eq 3
-          grep -q '^paddleocr_vl_e2e: prefill .* greedy exact 24 of 24$' paddleocr-gates.log
+          # The trailing `cached == uncached` is load-bearing, not decoration: it is
+          # the last thing the end-to-end test prints, and only after the KV-cached
+          # greedy loop has been re-run uncached and the two token sequences compared.
+          # Anchoring on it means a build whose cached/uncached comparison was removed
+          # or short-circuited fails this gate instead of passing on the older line.
+          grep -q '^paddleocr_vl_e2e: prefill .* greedy exact 24 of 24, cached == uncached$' paddleocr-gates.log
 
   # The QuaRot converter and its refuse-on-fail forward-equivalence check are
   # pure f64 CPU work. Generating the 0.62 GB artifact on the macOS runner held

--- a/crates/inference/src/model/ernie45.rs
+++ b/crates/inference/src/model/ernie45.rs
@@ -9,11 +9,14 @@
 //! (`Ernie4_5ForCausalLM` in the checkpoint's own modeling source): 18-layer
 //! pre-norm dense decoder, GQA with expanded heads (`num_heads * head_dim !=
 //! hidden_size`: q 1024->2048, k/v 1024->256, o 2048->1024), SiLU gate/up/down
-//! MLP, RMSNorm (`w * x * rsqrt(mean(x^2) + eps)`), untied `lm_head`. No KV
-//! cache and no sampling here — this module exists to be held against the HF
-//! reference activations captured in
-//! `tests/fixtures/paddleocr_vl/decoder/decoder_goldens.json`, and later
-//! slices build generation on top of a verified forward.
+//! MLP, RMSNorm (`w * x * rsqrt(mean(x^2) + eps)`), untied `lm_head`. No
+//! sampling here — this module exists to be held against the HF reference
+//! activations captured in
+//! `tests/fixtures/paddleocr_vl/decoder/decoder_goldens.json`, with greedy
+//! generation built on top of the verified forward: the uncached entry
+//! points re-run the whole sequence per step (the differential reference),
+//! and the caller-owned [`Ernie45KvCache`] prefills once, then steps one
+//! token at a time.
 //!
 //! RoPE: the reference applies Qwen2-VL-style multimodal-section RoPE
 //! (`apply_multimodal_rotary_pos_emb`, `mrope_section` doubled and chunks
@@ -228,7 +231,11 @@ impl Ernie45Config {
         )
     }
 
-    fn kv_dim(&self) -> Result<usize, InferenceError> {
+    /// `num_key_value_heads * head_dim`, checked. Crate-visible because it
+    /// is also the width an [`Ernie45KvCache`] must be built for, and a
+    /// caller recomputing that product by hand could disagree with the
+    /// value `kv_prefill` validates against.
+    pub(crate) fn kv_dim(&self) -> Result<usize, InferenceError> {
         checked_product(
             self.num_key_value_heads,
             self.head_dim,
@@ -620,7 +627,7 @@ impl Ernie45Model {
         embeds: &[f32],
         positions: &[[u32; 3]],
     ) -> Result<Ernie45Trace, InferenceError> {
-        let core = self.forward_embeds_core(embeds, positions, true)?;
+        let core = self.forward_embeds_core(embeds, positions, true, None)?;
         Ok(Ernie45Trace {
             embed: core.embed,
             layer_outputs: core.layer_outputs,
@@ -648,8 +655,317 @@ impl Ernie45Model {
         embeds: &[f32],
         positions: &[[u32; 3]],
     ) -> Result<Vec<f32>, InferenceError> {
-        let core = self.forward_embeds_core(embeds, positions, false)?;
+        let core = self.forward_embeds_core(embeds, positions, false, None)?;
         Ok(core.logits)
+    }
+
+    /// Fill a fresh [`Ernie45KvCache`] with the prompt's post-RoPE keys and
+    /// values and return the last row's logits (`vocab_size` values).
+    ///
+    /// This is the full-sequence causal forward over `embeds` and
+    /// `positions` — the same arithmetic as
+    /// [`Self::forward_embeds_last_logits`], which stays the uncached
+    /// differential reference — with one addition: each layer's post-RoPE
+    /// key rows and value rows are copied into the cache at rows
+    /// `0..seq_len` as they are produced, so every subsequent
+    /// [`Self::kv_decode_step`] attends over them without recomputing the
+    /// prompt. The returned logits are therefore bit-for-bit what
+    /// [`Self::forward_embeds_last_logits`] returns for the same input:
+    /// the sink only copies rows the kernel already computed.
+    ///
+    /// `cache` must be empty ([`Ernie45KvCache::is_empty`]) and large
+    /// enough for `positions.len()` tokens; the cache is caller-owned and
+    /// the model keeps no state of its own.
+    ///
+    /// # Errors
+    ///
+    /// [`InferenceError::Inference`] on an empty sequence, a sequence that
+    /// exceeds the cache capacity, a non-empty or shape-mismatched cache,
+    /// or a checked-arithmetic overflow; [`InferenceError::InvalidInput`]
+    /// on an `embeds` length that disagrees with `positions` and the
+    /// config.
+    pub fn kv_prefill(
+        &self,
+        embeds: &[f32],
+        positions: &[[u32; 3]],
+        cache: &mut Ernie45KvCache,
+    ) -> Result<Vec<f32>, InferenceError> {
+        let s = positions.len();
+        if s == 0 {
+            return Err(InferenceError::Inference(
+                "ernie45 kv prefill: empty token sequence".into(),
+            ));
+        }
+        let kv_dim = self.cfg.kv_dim()?;
+        self.check_cache_shape(cache, kv_dim)?;
+        if s > cache.capacity {
+            return Err(InferenceError::Inference(format!(
+                "ernie45 kv prefill: {} prompt tokens exceed the cache capacity {capacity}",
+                s,
+                capacity = cache.capacity
+            )));
+        }
+        if !cache.is_empty() {
+            return Err(InferenceError::Inference(format!(
+                "ernie45 kv prefill: cache already holds {} tokens; prefill requires an empty cache",
+                cache.len()
+            )));
+        }
+        let h = self.cfg.hidden_size;
+        let embed_len = checked_product(s, h, "kv prefill hidden buffer size")?;
+        if embeds.len() != embed_len {
+            return Err(InferenceError::InvalidInput(format!(
+                "ernie45 kv prefill: embeds has {} values; expected {} tokens x {} hidden",
+                embeds.len(),
+                s,
+                h
+            )));
+        }
+        if !embeds.iter().all(|v| v.is_finite()) {
+            return Err(InferenceError::Inference(
+                "ernie45 kv prefill: embeds carry a non-finite value".into(),
+            ));
+        }
+        // Per-layer views of the cache's two row stores; the field borrows
+        // end before `cache.len` is written below. `cap_kv` is one layer's
+        // footprint in elements.
+        let cap_kv = checked_product(cache.capacity, kv_dim, "kv cache per-layer capacity")?;
+        let k_sink = &mut cache.layer_k;
+        let v_sink = &mut cache.layer_v;
+        let core =
+            self.forward_embeds_core(embeds, positions, false, Some((k_sink, v_sink, cap_kv)))?;
+        cache.len = s;
+        Ok(core.logits)
+    }
+
+    /// Decode one token against a prefilled [`Ernie45KvCache`]: append the
+    /// token's post-RoPE key and value rows to the cache, run the decoder
+    /// over that single token with its attention attending over cache rows
+    /// `0..=cache.len()`, and return its logits (`vocab_size` values).
+    ///
+    /// `embeds` is exactly one row of `hidden_size` values (the embedding,
+    /// or spliced projector row, of the new token); `position` is its
+    /// 3-row mrope position, the same triple the uncached path would have
+    /// used for that token. Per layer the arithmetic mirrors
+    /// [`Self::forward_embeds_core`] for a one-token sequence — same
+    /// norm/projection/MLP calls, same exact-exp softmax — except the
+    /// attention reads its keys and values from the cache instead of from
+    /// this call's own projections, which is precisely the KV-cache
+    /// invariant: the cached rows are bit-for-bit the rows the full
+    /// forward would have computed.
+    ///
+    /// # Errors
+    ///
+    /// [`InferenceError::Inference`] on an empty cache (no prefill ran), a
+    /// cache at capacity, a shape-mismatched cache, a non-finite `embeds`,
+    /// or a checked-arithmetic overflow; [`InferenceError::InvalidInput`]
+    /// on an `embeds` length that disagrees with the config (the same
+    /// split [`Self::kv_prefill`] uses).
+    pub fn kv_decode_step(
+        &self,
+        embeds: &[f32],
+        position: [u32; 3],
+        cache: &mut Ernie45KvCache,
+    ) -> Result<Vec<f32>, InferenceError> {
+        let h = self.cfg.hidden_size;
+        let len = cache.len();
+        if len == 0 {
+            return Err(InferenceError::Inference(
+                "ernie45 kv step: cache is empty; run kv_prefill first".into(),
+            ));
+        }
+        if len == cache.capacity {
+            return Err(InferenceError::Inference(format!(
+                "ernie45 kv step: cache is full ({} tokens at capacity {capacity}); the sequence would overflow",
+                len,
+                capacity = cache.capacity
+            )));
+        }
+        let kv_dim = self.cfg.kv_dim()?;
+        self.check_cache_shape(cache, kv_dim)?;
+        if embeds.len() != h {
+            return Err(InferenceError::InvalidInput(format!(
+                "ernie45 kv step: embeds has {} values; expected 1 token x {} hidden",
+                embeds.len(),
+                h
+            )));
+        }
+        if !embeds.iter().all(|v| v.is_finite()) {
+            return Err(InferenceError::Inference(
+                "ernie45 kv step: embeds carry a non-finite value".into(),
+            ));
+        }
+        self.kv_decode_core(embeds, position, cache, kv_dim)
+    }
+
+    /// The cached decode kernel: one token through every layer, attention
+    /// reading keys/values from `cache` rows `0..=cache.len()`.
+    fn kv_decode_core(
+        &self,
+        embeds: &[f32],
+        position: [u32; 3],
+        cache: &mut Ernie45KvCache,
+        kv_dim: usize,
+    ) -> Result<Vec<f32>, InferenceError> {
+        let cfg = &self.cfg;
+        let w = &self.weights;
+        let h = cfg.hidden_size;
+        let len = cache.len();
+        // The caller checked len < capacity, so len + 1 cannot wrap.
+        let keys = len + 1;
+
+        let q_dim = cfg.q_dim()?;
+        let s_q_dim = checked_product(1, q_dim, "kv step query buffer size")?;
+        let s_kv_dim = checked_product(1, kv_dim, "kv step key/value buffer size")?;
+        let s_h = checked_product(1, h, "kv step hidden buffer size")?;
+        let s_intermediate =
+            checked_product(1, cfg.intermediate_size, "kv step intermediate buffer size")?;
+        let s_keys = checked_product(1, keys, "kv step attention score buffer size")?;
+        let keys_hd = checked_product(keys, cfg.head_dim, "kv step key head buffer size")?;
+        let hd_keys = checked_product(cfg.head_dim, keys, "kv step transposed value buffer size")?;
+        let hd = cfg.head_dim;
+
+        let mut x = embeds.to_vec();
+        let (cos, sin) = mrope_cos_sin_table(cfg, &[position]);
+
+        let heads = cfg.num_attention_heads;
+        let kv_heads = cfg.num_key_value_heads;
+        let groups = heads / kv_heads;
+        let scale = 1.0 / (hd as f32).sqrt();
+        let cap_kv = checked_product(cache.capacity, kv_dim, "kv cache per-layer capacity")?;
+
+        let mut normed = vec![0f32; s_h];
+        let mut q = vec![0f32; s_q_dim];
+        let mut k = vec![0f32; s_kv_dim];
+        let mut v = vec![0f32; s_kv_dim];
+        let mut attn_out = vec![0f32; s_q_dim];
+        let mut proj = vec![0f32; s_h];
+        let mut gate = vec![0f32; s_intermediate];
+        let mut up = vec![0f32; s_intermediate];
+        let mut scores = vec![0f32; s_keys];
+        let mut q_h = vec![0f32; hd];
+        let mut k_h = vec![0f32; keys_hd];
+        let mut v_t = vec![0f32; hd_keys];
+        let mut out_h = vec![0f32; hd];
+
+        for (layer_idx, layer) in w.layers.iter().enumerate() {
+            // Attention block: same norm/projection/RoPE calls as
+            // `forward_embeds_core` at s == 1.
+            normed.copy_from_slice(&x);
+            rms_norm(&mut normed, &layer.input_layernorm, h, cfg.rms_norm_eps);
+            matmul_bt(&normed, &layer.q_proj, &mut q, 1, h, q_dim);
+            matmul_bt(&normed, &layer.k_proj, &mut k, 1, h, kv_dim);
+            matmul_bt(&normed, &layer.v_proj, &mut v, 1, h, kv_dim);
+            gemma4_apply_rope(&mut q, &cos, &sin, 1, heads, hd);
+            gemma4_apply_rope(&mut k, &cos, &sin, 1, kv_heads, hd);
+
+            // Append this token's rows to the cache at row `len`, in the
+            // same `[token, kv_head, head_dim]` layout the kernel's own
+            // `k` / `v` buffers use.
+            let row_base = checked_product(
+                checked_product(layer_idx, cache.capacity, "kv cache layer offset")?,
+                kv_dim,
+                "kv cache row offset",
+            )? + checked_product(len, kv_dim, "kv cache row offset")?;
+            cache.layer_k[row_base..row_base + kv_dim].copy_from_slice(&k);
+            cache.layer_v[row_base..row_base + kv_dim].copy_from_slice(&v);
+
+            // Causal GQA attention over the cached keys. Every cached key
+            // is at or before this token's position, so there is no
+            // masking row to zero (the uncached path's `row[tq + 1..]`
+            // tail). The exact `f32::exp` softmax and the one-KV-head-at-a-
+            // time `k_h` / `v_t` scratch copies are the prefill kernel's.
+            let layer_k = &cache.layer_k[layer_idx * cap_kv..][..keys * kv_dim];
+            let layer_v = &cache.layer_v[layer_idx * cap_kv..][..keys * kv_dim];
+            for kvh in 0..kv_heads {
+                for tk in 0..keys {
+                    let k_row = &layer_k[tk * kv_dim + kvh * hd..][..hd];
+                    k_h[tk * hd..(tk + 1) * hd].copy_from_slice(k_row);
+                    for d in 0..hd {
+                        v_t[d * keys + tk] = layer_v[tk * kv_dim + kvh * hd + d];
+                    }
+                }
+                for qh in kvh * groups..(kvh + 1) * groups {
+                    let q_row = &q[qh * hd..(qh + 1) * hd];
+                    q_h.copy_from_slice(q_row);
+                    matmul_bt(&q_h, &k_h, &mut scores, 1, hd, keys);
+                    for score in &mut scores[..keys] {
+                        *score *= scale;
+                    }
+                    softmax_row_fail_closed(&mut scores[..keys]);
+                    matmul_bt(&scores, &v_t, &mut out_h, 1, keys, hd);
+                    attn_out[qh * hd..(qh + 1) * hd].copy_from_slice(&out_h);
+                }
+            }
+            matmul_bt(&attn_out, &layer.o_proj, &mut proj, 1, q_dim, h);
+            for (xi, pi) in x.iter_mut().zip(proj.iter()) {
+                *xi += pi;
+            }
+
+            // MLP block: identical calls to `forward_embeds_core` at s == 1.
+            normed.copy_from_slice(&x);
+            rms_norm(
+                &mut normed,
+                &layer.post_attention_layernorm,
+                h,
+                cfg.rms_norm_eps,
+            );
+            matmul_bt(
+                &normed,
+                &layer.gate_proj,
+                &mut gate,
+                1,
+                h,
+                cfg.intermediate_size,
+            );
+            matmul_bt(
+                &normed,
+                &layer.up_proj,
+                &mut up,
+                1,
+                h,
+                cfg.intermediate_size,
+            );
+            silu_inplace(&mut gate);
+            for (g, &u) in gate.iter_mut().zip(up.iter()) {
+                *g *= u;
+            }
+            matmul_bt(
+                &gate,
+                &layer.down_proj,
+                &mut proj,
+                1,
+                cfg.intermediate_size,
+                h,
+            );
+            for (xi, pi) in x.iter_mut().zip(proj.iter()) {
+                *xi += pi;
+            }
+        }
+
+        let mut final_normed = x;
+        rms_norm(&mut final_normed, &w.final_norm, h, cfg.rms_norm_eps);
+        let mut logits = vec![0f32; cfg.vocab_size];
+        matmul_bt(&final_normed, &w.lm_head, &mut logits, 1, h, cfg.vocab_size);
+        cache.len = len + 1;
+        Ok(logits)
+    }
+
+    /// Fail-closed cache/model shape check, run before any allocation: a
+    /// cache built from a different checkpoint layout would index the
+    /// layer buffers at wrong offsets.
+    fn check_cache_shape(
+        &self,
+        cache: &Ernie45KvCache,
+        kv_dim: usize,
+    ) -> Result<(), InferenceError> {
+        if cache.layers != self.cfg.num_hidden_layers || cache.kv_dim != kv_dim {
+            return Err(InferenceError::Inference(format!(
+                "ernie45 kv: cache was built for {} layers x kv_dim {}, this model has {} layers x kv_dim {}",
+                cache.layers, cache.kv_dim, self.cfg.num_hidden_layers, kv_dim
+            )));
+        }
+        Ok(())
     }
 
     /// Shared body of [`Self::forward_embeds_trace`] and
@@ -659,11 +975,21 @@ impl Ernie45Model {
     /// per-layer `layer_outputs` clone, and applies `lm_head` to the last
     /// row only, allocating a `vocab`-length `logits` buffer instead of
     /// `seq_len * vocab`.
+    ///
+    /// `kv_sink`, when `Some`, is `(&mut layer_k, &mut layer_v, cap_kv)`:
+    /// the caller cache's per-layer key and value row stores, each
+    /// `[layers * cap_kv]` with `cap_kv = capacity * kv_dim`, and `cap_kv`
+    /// the element stride between layers. After each layer's post-RoPE
+    /// `k` / `v` buffers are produced, every token's row is copied into
+    /// both stores at row `token` — the pure-memcpy side effect of
+    /// [`Self::kv_prefill`]. `None` (the uncached paths) skips it, so the
+    /// no-cache forward is bit-for-bit the pre-sink kernel.
     fn forward_embeds_core(
         &self,
         embeds: &[f32],
         positions: &[[u32; 3]],
         keep_trace: bool,
+        mut kv_sink: Option<(&mut Vec<f32>, &mut Vec<f32>, usize)>,
     ) -> Result<Ernie45CoreOut, InferenceError> {
         let cfg = &self.cfg;
         let w = &self.weights;
@@ -741,7 +1067,7 @@ impl Ernie45Model {
         let mut v_t = vec![0f32; hd_s];
         let mut out_h = vec![0f32; s_hd];
 
-        for layer in &w.layers {
+        for (layer_idx, layer) in w.layers.iter().enumerate() {
             // Attention block.
             normed.copy_from_slice(&x);
             rms_norm(&mut normed, &layer.input_layernorm, h, cfg.rms_norm_eps);
@@ -750,6 +1076,16 @@ impl Ernie45Model {
             matmul_bt(&normed, &layer.v_proj, &mut v, s, h, kv_dim);
             gemma4_apply_rope(&mut q, &cos, &sin, s, heads, hd);
             gemma4_apply_rope(&mut k, &cos, &sin, s, kv_heads, hd);
+
+            if let Some((k_sink, v_sink, cap_kv)) = kv_sink.as_mut() {
+                let layer_base = checked_product(layer_idx, *cap_kv, "kv cache layer offset")?;
+                let (k_chunks, v_chunks) = (k.chunks_exact(kv_dim), v.chunks_exact(kv_dim));
+                for (tk, (k_row, v_row)) in k_chunks.zip(v_chunks).enumerate() {
+                    let dst = layer_base + tk * kv_dim;
+                    k_sink[dst..dst + kv_dim].copy_from_slice(k_row);
+                    v_sink[dst..dst + kv_dim].copy_from_slice(v_row);
+                }
+            }
 
             // Causal GQA attention, batched through GEMM one KV head at a time. The softmax is
             // exact `f32::exp` deliberately (mirroring `gemma4_model.rs`'s
@@ -873,6 +1209,121 @@ struct Ernie45CoreOut {
     layer_outputs: Vec<Vec<f32>>,
     final_norm: Vec<f32>,
     logits: Vec<f32>,
+}
+
+/// Caller-owned KV cache for the ERNIE-4.5 decoder's cached decode:
+/// `kv_prefill` fills it with the prompt's post-RoPE keys and values, and
+/// `kv_decode_step` appends one row per step.
+///
+/// Layout: per layer, the post-RoPE key rows and value rows for tokens
+/// `0..len`, each row `[kv_head, head_dim]` — the exact layout the
+/// uncached kernel's per-layer `k` / `v` buffers use, so the attention
+/// code reads cached rows with the same indexing and no second layout.
+/// The two stores are pre-allocated for `capacity` tokens in
+/// [`Self::new`]; nothing here allocates on the decode hot path.
+///
+/// The cache is opaque and explicit — [`Ernie45Model`] keeps no hidden
+/// state, and every entry point re-validates the cache's shape before
+/// touching it (a cache built for a different checkpoint layout is
+/// rejected rather than indexed at wrong offsets).
+///
+/// Why a type of its own rather than
+/// [`FlatKVCache`][crate::kv_cache::flat::FlatKVCache]: that cache stores
+/// f16 and dequantises on read, which is the right trade where memory is
+/// the constraint, but it cannot carry this decoder's contract — the
+/// cached rows must be *bit-for-bit* the rows the uncached forward
+/// computed, which is what
+/// [`Ernie45Model::kv_prefill`]'s equality with
+/// [`Ernie45Model::forward_embeds_last_logits`] rests on. Storing f32
+/// keeps that equality exact. `model/gemma4_cache.rs` holds its own f32
+/// cache for the same reason.
+pub struct Ernie45KvCache {
+    layers: usize,
+    capacity: usize,
+    kv_dim: usize,
+    /// Number of tokens currently stored (`0..=capacity`).
+    len: usize,
+    /// Post-RoPE key rows, `[layers * capacity * kv_dim]`.
+    layer_k: Vec<f32>,
+    /// Value rows, `[layers * capacity * kv_dim]`.
+    layer_v: Vec<f32>,
+}
+
+impl Ernie45KvCache {
+    /// Allocate an empty cache for `num_hidden_layers` layers, each row of
+    /// `kv_dim` values (the model's `num_key_value_heads * head_dim`),
+    /// holding up to `capacity` tokens.
+    ///
+    /// # Errors
+    ///
+    /// [`InferenceError::Inference`] on zero dimensions or a
+    /// checked-arithmetic overflow; the OS returning no memory for the
+    /// allocation.
+    pub fn new(
+        num_hidden_layers: usize,
+        kv_dim: usize,
+        capacity: usize,
+    ) -> Result<Self, InferenceError> {
+        for (name, value) in [
+            ("num_hidden_layers", num_hidden_layers),
+            ("kv_dim", kv_dim),
+            ("capacity", capacity),
+        ] {
+            if value == 0 {
+                return Err(InferenceError::Inference(format!(
+                    "ernie45 kv cache: {name} must be positive, got 0"
+                )));
+            }
+        }
+        let per_layer = checked_product(
+            checked_product(num_hidden_layers, capacity, "kv cache token capacity")?,
+            kv_dim,
+            "kv cache row store",
+        )?;
+        let mut layer_k = Vec::new();
+        let mut layer_v = Vec::new();
+        layer_k
+            .try_reserve_exact(per_layer)
+            .map_err(|error| reserve_error("kv cache key rows", error))?;
+        layer_k.resize(per_layer, 0.0);
+        layer_v
+            .try_reserve_exact(per_layer)
+            .map_err(|error| reserve_error("kv cache value rows", error))?;
+        layer_v.resize(per_layer, 0.0);
+        Ok(Self {
+            layers: num_hidden_layers,
+            capacity,
+            kv_dim,
+            len: 0,
+            layer_k,
+            layer_v,
+        })
+    }
+
+    /// Tokens currently stored, `0..=capacity`.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Whether no token has been stored yet.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// The token count this cache was allocated for.
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    /// The decoder layer count this cache was built for.
+    pub fn layers(&self) -> usize {
+        self.layers
+    }
+
+    /// Per-token key/value projection width this cache was built for.
+    pub fn kv_dim(&self) -> usize {
+        self.kv_dim
+    }
 }
 
 #[cfg(test)]
@@ -1413,5 +1864,585 @@ mod tests {
         assert!(
             matches!(result, Err(InferenceError::Inference(message)) if message.contains("non-finite"))
         );
+    }
+
+    // -- kv_prefill / kv_decode_step: the cached decode path --
+    //
+    // The sink copies post-RoPE k/v rows the kernel already computed, and
+    // the step kernel mirrors the full forward at s == 1, so the cached
+    // path must be bit-for-bit the uncached one — assert_eq, no tolerance.
+
+    fn kv_test_cache(model: &Ernie45Model, capacity: usize) -> Ernie45KvCache {
+        let cfg = model.config();
+        let kv_dim = cfg.num_key_value_heads * cfg.head_dim;
+        Ernie45KvCache::new(cfg.num_hidden_layers, kv_dim, capacity).unwrap()
+    }
+
+    /// The prefill's returned logits are the full forward's last row —
+    /// the sink is a pure copy side effect, so the two must agree exactly,
+    /// at a multi-row sequence length.
+    #[test]
+    fn kv_prefill_last_logits_bit_exact_vs_uncached() {
+        let (cfg, model) = equiv_model();
+        let s = 5usize;
+        let embeds = pseudo_random_vec(s * cfg.hidden_size, 333);
+        let positions: Vec<[u32; 3]> = (0..s as u32).map(|i| [i, i, i]).collect();
+        let uncached = model
+            .forward_embeds_last_logits(&embeds, &positions)
+            .unwrap();
+        let mut cache = kv_test_cache(&model, s);
+        let cached = model.kv_prefill(&embeds, &positions, &mut cache).unwrap();
+        assert_eq!(cache.len(), s);
+        assert_eq!(cached, uncached);
+    }
+
+    /// The cached decode loop (prefill + one step per token) must match
+    /// the uncached re-forward loop: the prefill's logits bit-for-bit
+    /// (identical code path), every step's logits within a quoted
+    /// measured bound — see the comparison block below for why exactness
+    /// is unavailable for the steps — and the prompt's cached rows
+    /// untouched by the stepping.
+    #[test]
+    fn kv_cached_decode_sequence_matches_uncached() {
+        let (cfg, model) = equiv_model();
+        let s = 3usize;
+        let steps = 2usize;
+        let embeds = pseudo_random_vec((s + steps) * cfg.hidden_size, 444);
+        let positions: Vec<[u32; 3]> = (0..(s + steps) as u32).map(|i| [i, i, i]).collect();
+
+        // Uncached reference: prefill slice + one re-forward per step.
+        let ref_prefill = model
+            .forward_embeds_last_logits(&embeds[..s * cfg.hidden_size], &positions[..s])
+            .unwrap();
+        let mut ref_step_logits: Vec<Vec<f32>> = Vec::new();
+        for t in 0..steps {
+            let n = s + t + 1;
+            ref_step_logits.push(
+                model
+                    .forward_embeds_last_logits(&embeds[..n * cfg.hidden_size], &positions[..n])
+                    .unwrap(),
+            );
+        }
+
+        // Cached path: one prefill, then one token at a time.
+        let mut cache = kv_test_cache(&model, s + steps);
+        let cached_prefill = model
+            .kv_prefill(&embeds[..s * cfg.hidden_size], &positions[..s], &mut cache)
+            .unwrap();
+        // Snapshot the prompt rows before any step mutates the cache.
+        let kv_dim = cfg.num_key_value_heads * cfg.head_dim;
+        // The layout is `[layer][capacity][kv_dim]` — the layer stride is
+        // `capacity * kv_dim`, not `kv_dim`.
+        let layer_stride = cache.capacity() * kv_dim;
+        let snapshot_rows = |cache: &Ernie45KvCache, rows: usize| -> (Vec<f32>, Vec<f32>) {
+            let mut k = Vec::new();
+            let mut v = Vec::new();
+            for layer in 0..cfg.num_hidden_layers {
+                let base = layer * layer_stride;
+                k.extend_from_slice(&cache.layer_k[base..base + rows * kv_dim]);
+                v.extend_from_slice(&cache.layer_v[base..base + rows * kv_dim]);
+            }
+            (k, v)
+        };
+        let (prompt_k, prompt_v) = snapshot_rows(&cache, s);
+        let mut cached_step_logits: Vec<Vec<f32>> = Vec::new();
+        for t in 0..steps {
+            let n = s + t;
+            let row = &embeds[n * cfg.hidden_size..(n + 1) * cfg.hidden_size];
+            // The step attends over `cache.len() + 1` keys; printed so the
+            // comment below about the two paths' GEMM shapes is read off a
+            // run rather than taken on trust.
+            println!("kv step {t}: keys = {}", cache.len() + 1);
+            cached_step_logits.push(model.kv_decode_step(row, positions[n], &mut cache).unwrap());
+        }
+
+        assert_eq!(cached_prefill, ref_prefill);
+        assert_eq!(cache.len(), s + steps);
+        // Every step gets the tolerance, step 0 included. The two paths'
+        // GEMMs differ only in `m`: for the last row the cached path calls
+        // `matmul_bt(q, K, scores, 1, hd, keys)` and `matmul_bt(scores,
+        // V^T, out, 1, keys, hd)`, while the uncached path calls the same
+        // two with `m = seq_len` and reads the last output row. `k` and
+        // `n` agree — `keys == seq_len` at every step — so the difference
+        // is purely which BLAS kernel Accelerate picks for a 1-row versus
+        // an m-row call, and how it orders the accumulation. Nothing about
+        // that varies between step 0 and step 1: an earlier version of
+        // this test asserted step 0 bit-for-bit on the stated grounds that
+        // its attention had `keys == 1`, which is false — after a
+        // 3-token prefill step 0 runs with `keys == 4` (printed below).
+        // It passed, but on coincidence, so it was a flake waiting for a
+        // different machine or a different Accelerate build.
+        //
+        // The bound is what the equality is actually worth. Measured on
+        // this seeded model (dev profile, 2026-09-03, this machine):
+        // worst |diff| 9.54e-7. The bound allows ~1000x headroom over
+        // that, and is still orders of magnitude below the smallest
+        // greedy top-1/top-2 margin this codebase gates on (3.78, e2e
+        // fixture), so it cannot hide a decision change. It is not a
+        // weak check for the failures that matter: a structural error
+        // (wrong cache offset, wrong head mapping, wrong position row)
+        // moves logits by O(1), which this catches by three orders of
+        // magnitude, and the prefill assert above is still exact.
+        const STEP_LOGIT_MAX_DIFF: f32 = 1e-3;
+        for (t, (cached, ref_row)) in cached_step_logits
+            .iter()
+            .zip(ref_step_logits.iter())
+            .enumerate()
+        {
+            let worst = cached
+                .iter()
+                .zip(ref_row.iter())
+                .map(|(a, b)| (*a - *b).abs())
+                .fold(0f32, f32::max);
+            println!("kv step {t} worst |diff| vs uncached: {worst:e}");
+            assert!(
+                worst <= STEP_LOGIT_MAX_DIFF,
+                "step {t} worst |diff| {worst:e} exceeds the measured bound {STEP_LOGIT_MAX_DIFF:e}"
+            );
+        }
+
+        // Cache row invariant: the steps only append — every prompt row
+        // written by the prefill is untouched afterward (bit-for-bit).
+        let (cached_k, cached_v) = snapshot_rows(&cache, s);
+        assert_eq!(
+            cached_k, prompt_k,
+            "prompt key rows disturbed after stepping"
+        );
+        assert_eq!(
+            cached_v, prompt_v,
+            "prompt value rows disturbed after stepping"
+        );
+    }
+
+    /// Disagreed mrope rows (the vision-block layout, where a token's
+    /// three position rows differ from each other) must round-trip
+    /// through the cache: a step's RoPE tables come from the step's own
+    /// triple, not the prompt's.
+    ///
+    /// Two arms, because the matching arm alone proves nothing about what
+    /// this test is named for — it would still pass if the step ignored
+    /// its position argument and the reference happened to agree. The
+    /// second arm feeds the step a *wrong* triple (the prompt's last
+    /// token) and requires the result to move far more than the
+    /// reduction-order bound, so a step that dropped its own position
+    /// would redden this test rather than sail through it.
+    #[test]
+    fn kv_decode_step_uses_its_own_mrope_position_rows() {
+        let (cfg, model) = equiv_model();
+        let s = 2usize;
+        let prompt_embeds = pseudo_random_vec(s * cfg.hidden_size, 555);
+        let prompt_positions = [[0u32, 2, 5], [1, 4, 7]];
+        let step_embeds = pseudo_random_vec(cfg.hidden_size, 666);
+        let step_position = [9u32, 11, 13];
+
+        let mut all_embeds = prompt_embeds.clone();
+        all_embeds.extend_from_slice(&step_embeds);
+        let ref_logit = model
+            .forward_embeds_last_logits(
+                &all_embeds,
+                &[prompt_positions[0], prompt_positions[1], step_position],
+            )
+            .unwrap();
+
+        // Both arms are measured against one bound, `MRope_TOL`, so they
+        // bracket: arm 1 must land inside it and arm 2 outside, which is
+        // only possible if the step actually reads its position argument.
+        // The bound is 1e-4 — 100x above the reduction-order noise the
+        // sequence test measured for a step (9.5e-7, and 0 for this one),
+        // and 20x below the arm-2 gap measured here (2.06e-3, 2026-09-03,
+        // this machine). A step that ignored its own triple and reused
+        // the prompt's would put arm 2 at the noise floor, three orders
+        // of magnitude the wrong side of the bound.
+        const MROPE_TOL: f32 = 1e-4;
+
+        // Arm 1: the step's own triple reproduces the uncached forward.
+        // Not asserted bit-for-bit: the GEMMs differ in `m`; see
+        // `kv_cached_decode_sequence_matches_uncached`.
+        let mut cache = kv_test_cache(&model, s + 1);
+        model
+            .kv_prefill(&prompt_embeds, &prompt_positions, &mut cache)
+            .unwrap();
+        let cached_logit = model
+            .kv_decode_step(&step_embeds, step_position, &mut cache)
+            .unwrap();
+        let worst = cached_logit
+            .iter()
+            .zip(ref_logit.iter())
+            .map(|(a, b)| (*a - *b).abs())
+            .fold(0f32, f32::max);
+        assert!(
+            worst <= MROPE_TOL,
+            "step with its own mrope triple diverged by {worst:e} from the uncached forward"
+        );
+
+        // Arm 2: the same step with the wrong triple must land outside
+        // the bound arm 1 passed under. The comparison is against arm 1's
+        // own result, not against `ref_logit`: a step that ignored its
+        // `position` argument entirely would return the *same* value for
+        // both triples, which is a gap of exactly zero here, but would
+        // still sit far from `ref_logit` and so would sail past a
+        // gap-vs-reference form of this arm.
+        let mut wrong_cache = kv_test_cache(&model, s + 1);
+        model
+            .kv_prefill(&prompt_embeds, &prompt_positions, &mut wrong_cache)
+            .unwrap();
+        let wrong_logit = model
+            .kv_decode_step(&step_embeds, prompt_positions[s - 1], &mut wrong_cache)
+            .unwrap();
+        let gap = wrong_logit
+            .iter()
+            .zip(cached_logit.iter())
+            .map(|(a, b)| (*a - *b).abs())
+            .fold(0f32, f32::max);
+        println!("mrope arm 1 worst |diff| {worst:e}, arm 2 (wrong triple) gap {gap:e}");
+        assert!(
+            gap > MROPE_TOL,
+            "stepping with the prompt's triple instead of the step's own moved the logits by \
+             only {gap:e}: this test cannot see the defect it is named for"
+        );
+        let _ = cfg;
+    }
+
+    #[test]
+    fn kv_prefill_rejects_empty_sequence() {
+        let (_cfg, model) = equiv_model();
+        let mut cache = kv_test_cache(&model, 4);
+        let result = model.kv_prefill(&[], &[], &mut cache);
+        assert!(matches!(
+            result,
+            Err(InferenceError::Inference(message))
+                if message.contains("empty token sequence")
+        ));
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn kv_prefill_rejects_over_capacity_before_filling() {
+        let (cfg, model) = equiv_model();
+        let mut cache = kv_test_cache(&model, 3);
+        let s = 4usize;
+        let embeds = pseudo_random_vec(s * cfg.hidden_size, 777);
+        let positions: Vec<[u32; 3]> = (0..s as u32).map(|i| [i, i, i]).collect();
+        let result = model.kv_prefill(&embeds, &positions, &mut cache);
+        assert!(matches!(
+            result,
+            Err(InferenceError::Inference(message))
+                if message.contains("exceed the cache capacity")
+        ));
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn kv_prefill_rejects_non_empty_cache() {
+        let (cfg, model) = equiv_model();
+        let s = 2usize;
+        let mut cache = kv_test_cache(&model, 4);
+        let fill = pseudo_random_vec(s * cfg.hidden_size, 888);
+        let fill_pos: Vec<[u32; 3]> = (0..s as u32).map(|i| [i, i, i]).collect();
+        model.kv_prefill(&fill, &fill_pos, &mut cache).unwrap();
+        let result = model.kv_prefill(&fill, &fill_pos, &mut cache);
+        assert!(matches!(
+            result,
+            Err(InferenceError::Inference(message))
+                if message.contains("already holds")
+        ));
+        assert_eq!(cache.len(), s);
+    }
+
+    #[test]
+    fn kv_prefill_rejects_wrong_embeds_length() {
+        let (cfg, model) = equiv_model();
+        let mut cache = kv_test_cache(&model, 4);
+        let positions: Vec<[u32; 3]> = (0..3u32).map(|i| [i, i, i]).collect();
+        // 3 positions but only 2 rows of embeds.
+        let embeds = pseudo_random_vec(2 * cfg.hidden_size, 999);
+        let result = model.kv_prefill(&embeds, &positions, &mut cache);
+        assert!(matches!(result, Err(InferenceError::InvalidInput(_))));
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn kv_prefill_rejects_non_finite_embeds() {
+        let (cfg, model) = equiv_model();
+        let mut cache = kv_test_cache(&model, 4);
+        let mut embeds = pseudo_random_vec(2 * cfg.hidden_size, 1010);
+        embeds[0] = f32::NAN;
+        let positions = [[0u32, 0, 0], [1, 1, 1]];
+        let result = model.kv_prefill(&embeds, &positions, &mut cache);
+        assert!(matches!(
+            result,
+            Err(InferenceError::Inference(message))
+                if message.contains("non-finite")
+        ));
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn kv_decode_step_rejects_empty_cache() {
+        let (cfg, model) = equiv_model();
+        let mut cache = kv_test_cache(&model, 4);
+        let embed = pseudo_random_vec(cfg.hidden_size, 1111);
+        let result = model.kv_decode_step(&embed, [0, 0, 0], &mut cache);
+        assert!(matches!(
+            result,
+            Err(InferenceError::Inference(message))
+                if message.contains("cache is empty")
+        ));
+    }
+
+    #[test]
+    fn kv_decode_step_rejects_full_cache() {
+        let (cfg, model) = equiv_model();
+        let s = 2usize;
+        let mut cache = kv_test_cache(&model, s);
+        let embeds = pseudo_random_vec(s * cfg.hidden_size, 1212);
+        let positions: Vec<[u32; 3]> = (0..s as u32).map(|i| [i, i, i]).collect();
+        model.kv_prefill(&embeds, &positions, &mut cache).unwrap();
+        let embed = pseudo_random_vec(cfg.hidden_size, 1313);
+        let result = model.kv_decode_step(&embed, [s as u32, s as u32, s as u32], &mut cache);
+        assert!(matches!(
+            result,
+            Err(InferenceError::Inference(message))
+                if message.contains("cache is full")
+        ));
+        assert_eq!(cache.len(), s);
+    }
+
+    #[test]
+    fn kv_entries_reject_mismatched_cache_shape() {
+        let (cfg, model) = equiv_model();
+        // A cache for a different layer count.
+        let mut foreign_layers = Ernie45KvCache::new(
+            cfg.num_hidden_layers + 1,
+            cfg.num_key_value_heads * cfg.head_dim,
+            4,
+        )
+        .unwrap();
+        let s = 2usize;
+        let embeds = pseudo_random_vec(s * cfg.hidden_size, 1414);
+        let positions: Vec<[u32; 3]> = (0..s as u32).map(|i| [i, i, i]).collect();
+        let result = model.kv_prefill(&embeds, &positions, &mut foreign_layers);
+        assert!(matches!(
+            result,
+            Err(InferenceError::Inference(message))
+                if message.contains("built for")
+        ));
+        // Same layer count, wrong kv_dim.
+        let mut narrow = Ernie45KvCache::new(cfg.num_hidden_layers, cfg.head_dim, 4).unwrap();
+        let result = model.kv_prefill(&embeds, &positions, &mut narrow);
+        assert!(matches!(
+            result,
+            Err(InferenceError::Inference(message))
+                if message.contains("built for")
+        ));
+        // The step path checks the shape too: a non-empty cache with the
+        // right layer count but the wrong kv_dim must be rejected, not
+        // indexed at wrong offsets.
+        let mut nonempty_wrong_kv =
+            Ernie45KvCache::new(cfg.num_hidden_layers, cfg.head_dim, 4).unwrap();
+        nonempty_wrong_kv.len = 1;
+        let embed = pseudo_random_vec(cfg.hidden_size, 1416);
+        let result = model.kv_decode_step(&embed, [0, 0, 0], &mut nonempty_wrong_kv);
+        assert!(matches!(
+            result,
+            Err(InferenceError::Inference(message))
+                if message.contains("built for")
+        ));
+    }
+
+    #[test]
+    fn kv_decode_step_rejects_wrong_embeds_length() {
+        let (cfg, model) = equiv_model();
+        let s = 2usize;
+        let mut cache = kv_test_cache(&model, 4);
+        let embeds = pseudo_random_vec(s * cfg.hidden_size, 1515);
+        let positions: Vec<[u32; 3]> = (0..s as u32).map(|i| [i, i, i]).collect();
+        model.kv_prefill(&embeds, &positions, &mut cache).unwrap();
+        let short = pseudo_random_vec(cfg.hidden_size - 1, 1616);
+        let result = model.kv_decode_step(&short, [2, 2, 2], &mut cache);
+        assert!(matches!(result, Err(InferenceError::InvalidInput(_))));
+        assert_eq!(cache.len(), s);
+    }
+
+    #[test]
+    fn kv_decode_step_rejects_non_finite_embeds() {
+        let (cfg, model) = equiv_model();
+        let s = 2usize;
+        let mut cache = kv_test_cache(&model, 4);
+        let embeds = pseudo_random_vec(s * cfg.hidden_size, 1717);
+        let positions: Vec<[u32; 3]> = (0..s as u32).map(|i| [i, i, i]).collect();
+        model.kv_prefill(&embeds, &positions, &mut cache).unwrap();
+        let mut bad = pseudo_random_vec(cfg.hidden_size, 1818);
+        bad[0] = f32::INFINITY;
+        let result = model.kv_decode_step(&bad, [2, 2, 2], &mut cache);
+        assert!(matches!(
+            result,
+            Err(InferenceError::Inference(message))
+                if message.contains("non-finite")
+        ));
+        assert_eq!(cache.len(), s);
+    }
+
+    /// The issue's acceptance test at the decoder level, on the committed
+    /// fixture's token sequences: the greedy token sequence produced with
+    /// the KV cache (prefill once, then one step per token) must equal
+    /// the sequence produced by the uncached re-forward loop. Embedding
+    /// rows come from the model's own `embed_tokens`, positions continue
+    /// the plain `arange` — the text-only reduction the whole module is
+    /// built on.
+    #[test]
+    fn kv_greedy_sequence_matches_uncached_on_committed_fixture() {
+        let cfg = Ernie45Config::from_config_json_str(
+            r#"{"hidden_size": 1024, "intermediate_size": 3072, "num_hidden_layers": 18,
+                "num_attention_heads": 16, "num_key_value_heads": 2, "head_dim": 128,
+                "vocab_size": 103424, "rms_norm_eps": 1e-5, "rope_theta": 500000.0,
+                "rope_scaling": {"mrope_section": [16, 24, 24]},
+                "tie_word_embeddings": false, "use_bias": false}"#,
+        )
+        .unwrap();
+        let mut seed = 0x51ed_c0de_a11c_e5b0_u64;
+        let mut next = |len: usize| -> Vec<f32> {
+            seed = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            pseudo_random_vec(len, seed)
+        };
+        let h = cfg.hidden_size;
+        let weights = Ernie45Weights {
+            embed_tokens: next(cfg.vocab_size * h),
+            layers: (0..cfg.num_hidden_layers)
+                .map(|_| Ernie45LayerWeights {
+                    q_proj: next(cfg.num_attention_heads * cfg.head_dim * h),
+                    k_proj: next(cfg.num_key_value_heads * cfg.head_dim * h),
+                    v_proj: next(cfg.num_key_value_heads * cfg.head_dim * h),
+                    o_proj: next(h * cfg.num_attention_heads * cfg.head_dim),
+                    gate_proj: next(cfg.intermediate_size * h),
+                    up_proj: next(cfg.intermediate_size * h),
+                    down_proj: next(h * cfg.intermediate_size),
+                    input_layernorm: next(h).into_iter().map(|v| v + 1.5).collect(),
+                    post_attention_layernorm: next(h).into_iter().map(|v| v + 1.5).collect(),
+                })
+                .collect(),
+            final_norm: next(h).into_iter().map(|v| v + 1.5).collect(),
+            lm_head: next(cfg.vocab_size * h),
+        };
+        let model = Ernie45Model::new(cfg, weights).unwrap();
+        let embeds = model.embed_tokens();
+
+        let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/paddleocr_vl/decoder/decoder_goldens.json");
+        let golden: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&fixture).unwrap()).unwrap();
+        let cases: Vec<Vec<u32>> = golden
+            .get("cases")
+            .and_then(|c| c.as_array())
+            .unwrap()
+            .iter()
+            .map(|c| {
+                c["ids"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|i| i.as_u64().unwrap() as u32)
+                    .collect()
+            })
+            .collect();
+        assert!(cases.len() >= 4, "fixture shrank to {} cases", cases.len());
+
+        for (case_idx, ids) in cases.iter().enumerate() {
+            let prompt_len = ids.len();
+            let max_new_tokens = 4usize;
+            let prompt_embeds: Vec<f32> = ids
+                .iter()
+                .flat_map(|&id| embeds[id as usize * h..][..h].iter().copied())
+                .collect();
+            let prompt_positions: Vec<[u32; 3]> =
+                (0..prompt_len as u32).map(|i| [i, i, i]).collect();
+
+            // Uncached reference loop: re-forward the whole sequence.
+            let mut ref_embeds = prompt_embeds.clone();
+            let mut ref_positions = prompt_positions.clone();
+            let mut ref_logits = model
+                .forward_embeds_last_logits(&ref_embeds, &ref_positions)
+                .unwrap();
+            let mut ref_greedy: Vec<u32> = Vec::new();
+            for _ in 0..max_new_tokens {
+                let next = ref_logits
+                    .iter()
+                    .enumerate()
+                    .max_by(|a, b| a.1.total_cmp(b.1))
+                    .map(|(i, _)| i as u32)
+                    .unwrap();
+                ref_greedy.push(next);
+                if next == 2 {
+                    break;
+                }
+                let p = ref_positions
+                    .iter()
+                    .fold(0u32, |m, r| m.max(r[0]).max(r[1]).max(r[2]))
+                    + 1;
+                ref_embeds.extend_from_slice(&embeds[next as usize * h..][..h]);
+                ref_positions.push([p, p, p]);
+                ref_logits = model
+                    .forward_embeds_last_logits(&ref_embeds, &ref_positions)
+                    .unwrap();
+            }
+
+            // Cached loop: one prefill, then one step per token.
+            let kv_dim = model.config().num_key_value_heads * model.config().head_dim;
+            let mut cache = Ernie45KvCache::new(
+                model.config().num_hidden_layers,
+                kv_dim,
+                prompt_len + max_new_tokens,
+            )
+            .unwrap();
+            let mut max_pos = prompt_positions
+                .iter()
+                .fold(0u32, |m, r| m.max(r[0]).max(r[1]).max(r[2]));
+            let mut cached_logits = model
+                .kv_prefill(&prompt_embeds, &prompt_positions, &mut cache)
+                .unwrap();
+            let mut cached_greedy: Vec<u32> = Vec::new();
+            for _ in 0..max_new_tokens {
+                let next = cached_logits
+                    .iter()
+                    .enumerate()
+                    .max_by(|a, b| a.1.total_cmp(b.1))
+                    .map(|(i, _)| i as u32)
+                    .unwrap();
+                cached_greedy.push(next);
+                if next == 2 {
+                    break;
+                }
+                max_pos += 1;
+                let position = [max_pos, max_pos, max_pos];
+                let row = &embeds[next as usize * h..][..h];
+                cached_logits = model.kv_decode_step(row, position, &mut cache).unwrap();
+            }
+
+            assert_eq!(
+                cached_greedy,
+                ref_greedy,
+                "case {case_idx}: greedy token sequence diverges ({} tokens)",
+                ref_greedy.len()
+            );
+        }
+    }
+
+    #[test]
+    fn kv_cache_new_rejects_zero_dimensions_and_overflow() {
+        assert!(Ernie45KvCache::new(0, 8, 4).is_err());
+        assert!(Ernie45KvCache::new(2, 0, 4).is_err());
+        assert!(Ernie45KvCache::new(2, 8, 0).is_err());
+        let result = Ernie45KvCache::new(4, 8, usize::MAX);
+        assert!(matches!(
+            result,
+            Err(InferenceError::Inference(message))
+                if message.contains("overflow")
+        ));
+        let cache = Ernie45KvCache::new(2, 8, 4).unwrap();
+        assert!(cache.is_empty());
+        assert_eq!(cache.len(), 0);
+        assert_eq!(cache.capacity(), 4);
+        assert_eq!(cache.layers(), 2);
+        assert_eq!(cache.kv_dim(), 8);
     }
 }

--- a/crates/inference/src/model/ernie45.rs
+++ b/crates/inference/src/model/ernie45.rs
@@ -2295,10 +2295,21 @@ mod tests {
     /// rows come from the model's own `embed_tokens`, positions continue
     /// the plain `arange` — the text-only reduction the whole module is
     /// built on.
+    ///
+    /// The layer count is the one shape here that is NOT production-sized, and
+    /// it is the only one that can be cut without weakening the test: the cache
+    /// is indexed per layer, so four layers exercise the same offset arithmetic
+    /// eighteen do, while every shape the kernels actually compute against --
+    /// `hidden_size`, `intermediate_size`, `head_dim`, and the 2/16 KV-to-query
+    /// head ratio -- stays exactly as the checkpoint ships it. `vocab_size` is
+    /// pinned by the committed fixture, whose token ids are real tokenizer
+    /// output and index straight into `embed_tokens`. Measured on this test:
+    /// eighteen layers cost 1.45 GiB peak RSS and 12.1s in an ordinary
+    /// `cargo test` run, of which the extra fourteen layers are 0.79 GiB.
     #[test]
     fn kv_greedy_sequence_matches_uncached_on_committed_fixture() {
         let cfg = Ernie45Config::from_config_json_str(
-            r#"{"hidden_size": 1024, "intermediate_size": 3072, "num_hidden_layers": 18,
+            r#"{"hidden_size": 1024, "intermediate_size": 3072, "num_hidden_layers": 4,
                 "num_attention_heads": 16, "num_key_value_heads": 2, "head_dim": 128,
                 "vocab_size": 103424, "rms_norm_eps": 1e-5, "rope_theta": 500000.0,
                 "rope_scaling": {"mrope_section": [16, 24, 24]},
@@ -2423,6 +2434,18 @@ mod tests {
                 cached_logits = model.kv_decode_step(row, position, &mut cache).unwrap();
             }
 
+            // Compared BEFORE the equality assert, because two loops that both
+            // stopped after one token agree trivially and would report a pass
+            // that covered a single decode step. The bound is what the loop is
+            // allowed to produce, so a fixture or a break condition that
+            // silently shortens the sequence fails here rather than passing.
+            assert_eq!(
+                ref_greedy.len(),
+                max_new_tokens,
+                "case {case_idx}: reference loop produced {} of {max_new_tokens} tokens, so the \
+                 equality below would compare a shorter sequence than intended",
+                ref_greedy.len()
+            );
             assert_eq!(
                 cached_greedy,
                 ref_greedy,

--- a/crates/inference/src/model/ernie45.rs
+++ b/crates/inference/src/model/ernie45.rs
@@ -1219,8 +1219,13 @@ struct Ernie45CoreOut {
 /// `0..len`, each row `[kv_head, head_dim]` — the exact layout the
 /// uncached kernel's per-layer `k` / `v` buffers use, so the attention
 /// code reads cached rows with the same indexing and no second layout.
-/// The two stores are pre-allocated for `capacity` tokens in
-/// [`Self::new`]; nothing here allocates on the decode hot path.
+/// The two stores are sized for `capacity` tokens in [`Self::new`] and
+/// are only ever written into afterwards, so the cache itself never
+/// reallocates or grows as the sequence advances. That is a statement
+/// about the cache, not about the step: [`Ernie45Model::kv_decode_step`]
+/// still allocates its own per-call scratch buffers, exactly as the
+/// uncached kernel does, and reusing those across steps is a separate
+/// change.
 ///
 /// The cache is opaque and explicit — [`Ernie45Model`] keeps no hidden
 /// state, and every entry point re-validates the cache's shape before

--- a/crates/inference/src/model/paddleocr_vl.rs
+++ b/crates/inference/src/model/paddleocr_vl.rs
@@ -23,16 +23,20 @@
 //!    block holds `t = start` while `h`/`w` walk the merged grid in
 //!    raster order; text after the image resumes all three from
 //!    (max so far) + 1.
-//! 4. **Greedy loop** — no KV cache (first slice): every step re-runs the
-//!    full forward over prompt + generated so far and takes the argmax of
-//!    the last row's logits; generated tokens are text, so their position
-//!    columns continue the text-after rule. Stops at eos or
-//!    `max_new_tokens`.
+//! 4. **Greedy loop** — prefill the prompt once into the decoder's
+//!    caller-owned KV cache, then step one token at a time (each step
+//!    forwards only the new token and attends over the cached rows);
+//!    every step takes the argmax of the produced logits; generated
+//!    tokens are text, so their position columns continue the
+//!    text-after rule. Stops at eos or `max_new_tokens`. The uncached
+//!    re-forward loop stays on the type as `generate_greedy_uncached`:
+//!    it is the differential reference the cached loop is held equal to,
+//!    and the e2e gate runs both and requires the same tokens.
 
 use std::path::Path;
 
 use crate::error::InferenceError;
-use crate::model::ernie45::{Ernie45Config, Ernie45Model, Ernie45Weights};
+use crate::model::ernie45::{Ernie45Config, Ernie45KvCache, Ernie45Model, Ernie45Weights};
 use crate::tokenizer::common::Tokenizer;
 use crate::tokenizer::gemma_bpe::GemmaBpeTokenizer;
 use crate::vision::paddleocr_preprocess::{
@@ -68,6 +72,19 @@ pub struct PrefillTrace {
     pub grid_thw: (usize, usize, usize),
     /// `(height, width)` after smart-resize.
     pub resized_hw: (usize, usize),
+}
+
+/// The pipeline's output up to the decoder forward — every field of
+/// [`PrefillTrace`] except `logits`. Produced by
+/// `PaddleOcrVlModel::assemble_prompt` and consumed by whichever forward
+/// the caller wants: the traced full-sequence one, or `kv_prefill`.
+struct PromptAssembly {
+    prompt_ids: Vec<u32>,
+    positions: Vec<[u32; 3]>,
+    projector_rows: Vec<f32>,
+    spliced_embeds: Vec<f32>,
+    grid_thw: (usize, usize, usize),
+    resized_hw: (usize, usize),
 }
 
 /// Image + text -> greedy tokens, over the full PaddleOCR-VL-1.6
@@ -252,6 +269,40 @@ impl PaddleOcrVlModel {
         w: usize,
         text: &str,
     ) -> Result<PrefillTrace, InferenceError> {
+        let assembly = self.assemble_prompt(tokenizer, rgb, h, w, text)?;
+        let trace = self
+            .decoder
+            .forward_embeds_trace(&assembly.spliced_embeds, &assembly.positions)?;
+        Ok(PrefillTrace {
+            prompt_ids: assembly.prompt_ids,
+            positions: assembly.positions,
+            projector_rows: assembly.projector_rows,
+            spliced_embeds: assembly.spliced_embeds,
+            logits: trace.logits,
+            grid_thw: assembly.grid_thw,
+            resized_hw: assembly.resized_hw,
+        })
+    }
+
+    /// Everything the decoder needs from an image and a prompt — token
+    /// ids, mrope positions, projector rows, spliced embedding rows — that
+    /// is, every stage of the pipeline up to but not including the decoder
+    /// forward.
+    ///
+    /// This is split out of [`Self::prefill`] so that each greedy loop runs
+    /// exactly one prompt forward. Routing the cached loop through
+    /// `prefill` instead would run the traced forward, which materialises
+    /// `[seq_len, vocab]` logits and a clone of every layer's output, and
+    /// then discard all of it before running `kv_prefill` over the same
+    /// tokens — two full prompt forwards where the cache exists to buy one.
+    fn assemble_prompt(
+        &self,
+        tokenizer: &GemmaBpeTokenizer,
+        rgb: &[u8],
+        h: usize,
+        w: usize,
+        text: &str,
+    ) -> Result<PromptAssembly, InferenceError> {
         let PreprocessedImage {
             pixel_values,
             grid_thw,
@@ -297,27 +348,100 @@ impl PaddleOcrVlModel {
 
         let positions =
             Self::rope_index(&prompt_ids, grid_thw, self.vision_cfg.spatial_merge_size)?;
-        let trace = self.decoder.forward_embeds_trace(&spliced, &positions)?;
 
-        Ok(PrefillTrace {
+        Ok(PromptAssembly {
             prompt_ids,
             positions,
             projector_rows: projector,
             spliced_embeds: spliced,
-            logits: trace.logits,
             grid_thw,
             resized_hw,
         })
     }
 
-    /// Greedy decode over `max_new_tokens` steps with **no KV cache**:
-    /// every step re-runs the full forward over the whole sequence (first
-    /// slice; a cached decode is a follow-up). `rgb` is interleaved HWC
-    /// RGB8, length `h * w * 3`.
+    /// Run the prompt half of the uncached greedy loop: prompt assembly
+    /// plus the decoder's traced full-sequence forward, returning the
+    /// prefill trace and the last row's logits (the loop's first decision
+    /// row). The cached loop does not use this — it assembles the prompt
+    /// and forwards it once through `kv_prefill`.
+    fn greedy_prefill(
+        &self,
+        tokenizer: &GemmaBpeTokenizer,
+        rgb: &[u8],
+        h: usize,
+        w: usize,
+        text: &str,
+    ) -> Result<(PrefillTrace, Vec<f32>), InferenceError> {
+        let prefill = self.prefill(tokenizer, rgb, h, w, text)?;
+        let vocab = self.decoder_cfg.vocab_size;
+        let last = prefill.prompt_ids.len();
+        let last_logits = prefill.logits[(last - 1) * vocab..][..vocab].to_vec();
+        Ok((prefill, last_logits))
+    }
+
+    /// Uncached greedy reference: prefill once, then re-forward the whole
+    /// prompt-plus-generated sequence at every step and take the argmax
+    /// of the last row. This is the original full-re-forward loop, kept
+    /// as the differential baseline the cached [`Self::generate_greedy`]
+    /// is held equal to; both stop at `EOS_ID` or `max_new_tokens`.
     ///
     /// # Errors
     ///
-    /// Any pipeline error; stops early at `EOS_ID` or when
+    /// Same as [`Self::generate_greedy`].
+    pub fn generate_greedy_uncached(
+        &self,
+        tokenizer: &GemmaBpeTokenizer,
+        rgb: &[u8],
+        h: usize,
+        w: usize,
+        text: &str,
+        max_new_tokens: usize,
+    ) -> Result<Vec<u32>, InferenceError> {
+        if max_new_tokens == 0 {
+            return Ok(Vec::new());
+        }
+        let hidden = self.decoder_cfg.hidden_size;
+        let (prefill, mut last_logits) = self.greedy_prefill(tokenizer, rgb, h, w, text)?;
+
+        let mut embeds = prefill.spliced_embeds;
+        let mut positions = prefill.positions;
+        let mut generated: Vec<u32> = Vec::with_capacity(max_new_tokens);
+
+        for _ in 0..max_new_tokens {
+            let next = argmax_u32(&last_logits);
+            generated.push(next);
+            if next == EOS_ID {
+                break;
+            }
+            // Extend the sequence by one text token and re-forward.
+            let embed_len = embeds.len();
+            embeds.resize(embed_len + hidden, 0.0);
+            embeds[embed_len..]
+                .copy_from_slice(&self.decoder.embed_tokens()[next as usize * hidden..][..hidden]);
+            let p = positions
+                .iter()
+                .fold(0u32, |m, r| m.max(r[0]).max(r[1]).max(r[2]))
+                + 1;
+            positions.push([p, p, p]);
+            last_logits = self
+                .decoder
+                .forward_embeds_last_logits(&embeds, &positions)?;
+        }
+        Ok(generated)
+    }
+
+    /// Greedy decode over `max_new_tokens` steps with a KV cache: the
+    /// prompt is assembled and forwarded once into a freshly allocated
+    /// [`Ernie45KvCache`] (capacity `prompt + max_new_tokens`), then each
+    /// step forwards only the new token, attending over the cached rows.
+    /// [`Self::generate_greedy_uncached`] stays available as the
+    /// differential reference the two are held equal to. `rgb` is
+    /// interleaved HWC RGB8, length `h * w * 3`.
+    ///
+    /// # Errors
+    ///
+    /// Any pipeline error, or a prompt plus `max_new_tokens` that overflows
+    /// the cache capacity; stops early at `EOS_ID` or when
     /// `max_new_tokens` tokens have been produced.
     pub fn generate_greedy(
         &self,
@@ -332,35 +456,44 @@ impl PaddleOcrVlModel {
             return Ok(Vec::new());
         }
         let hidden = self.decoder_cfg.hidden_size;
-        let vocab = self.decoder_cfg.vocab_size;
-        let prefill = self.prefill(tokenizer, rgb, h, w, text)?;
-
-        let mut ids = prefill.prompt_ids;
-        let mut embeds = prefill.spliced_embeds;
-        let mut positions = prefill.positions;
-        let mut last_logits: Vec<f32> = prefill.logits[(ids.len() - 1) * vocab..][..vocab].to_vec();
+        // Prompt assembly only: the cached loop's one and only prompt
+        // forward is the `kv_prefill` below.
+        let assembly = self.assemble_prompt(tokenizer, rgb, h, w, text)?;
+        let prompt_len = assembly.prompt_ids.len();
+        let capacity = prompt_len.checked_add(max_new_tokens).ok_or_else(|| {
+            InferenceError::Inference(format!(
+                "paddleocr greedy: prompt {prompt_len} + {max_new_tokens} tokens overflows usize"
+            ))
+        })?;
+        let mut cache = Ernie45KvCache::new(
+            self.decoder_cfg.num_hidden_layers,
+            self.decoder_cfg.kv_dim()?,
+            capacity,
+        )?;
+        let mut last_logits =
+            self.decoder
+                .kv_prefill(&assembly.spliced_embeds, &assembly.positions, &mut cache)?;
         let mut generated: Vec<u32> = Vec::with_capacity(max_new_tokens);
 
+        // The new text tokens' positions continue the text-after rule:
+        // (max position so far) + 1 on all three rows. The max over the
+        // prompt rows is computed once; every generated token's row is
+        // then strictly larger than all earlier rows, so it advances the
+        // max by exactly one per step.
+        let mut max_pos = assembly
+            .positions
+            .iter()
+            .fold(0u32, |m, r| m.max(r[0]).max(r[1]).max(r[2]));
         for _ in 0..max_new_tokens {
             let next = argmax_u32(&last_logits);
             generated.push(next);
             if next == EOS_ID {
                 break;
             }
-            // Extend the sequence by one text token and re-forward.
-            ids.push(next);
-            let embed_len = embeds.len();
-            embeds.resize(embed_len + hidden, 0.0);
-            embeds[embed_len..]
-                .copy_from_slice(&self.decoder.embed_tokens()[next as usize * hidden..][..hidden]);
-            let p = positions
-                .iter()
-                .fold(0u32, |m, r| m.max(r[0]).max(r[1]).max(r[2]))
-                + 1;
-            positions.push([p, p, p]);
-            last_logits = self
-                .decoder
-                .forward_embeds_last_logits(&embeds, &positions)?;
+            max_pos += 1;
+            let position = [max_pos, max_pos, max_pos];
+            let embed = &self.decoder.embed_tokens()[next as usize * hidden..][..hidden];
+            last_logits = self.decoder.kv_decode_step(embed, position, &mut cache)?;
         }
         Ok(generated)
     }

--- a/crates/inference/tests/paddleocr_vl_e2e_goldens_test.rs
+++ b/crates/inference/tests/paddleocr_vl_e2e_goldens_test.rs
@@ -1,5 +1,5 @@
 //! PaddleOCR-VL-1.6 end-to-end CPU forward vs the HF reference: one image
-//! plus the `"OCR:"` prompt, greedy decode, no KV cache.
+//! plus the `"OCR:"` prompt, greedy decode, cached and uncached.
 //!
 //! The committed fixture (`fixtures/paddleocr_vl/e2e/e2e_goldens.json` +
 //! `e2e_image.png`) was captured from the pinned checkpoint's own
@@ -18,7 +18,9 @@
 //! - spliced embeddings (last-token first8, mean_abs),
 //! - prompt logits (argmax at every position, last-token first8 / top-5 /
 //!   mean_abs),
-//! - the 24 greedy tokens (exact, in order).
+//! - the 24 greedy tokens (exact, in order), produced by the KV-cached
+//!   loop and again by the uncached re-forward loop, which must agree
+//!   with each other as well as with the fixture.
 //!
 //! **Fail-closed contract** (mirrors `paddleocr_vl_decoder_goldens_test.rs`):
 //! the ~1.9 GB checkpoint is not committed. With `LATTICE_POCR_MODEL_DIR`
@@ -26,7 +28,7 @@
 //! test prints a skip line and returns. With `LATTICE_POCR_GATE_ENFORCE=1`,
 //! a missing checkpoint panics instead of skipping.
 //!
-//! Run (release only — the no-cache greedy loop re-forwards the ~0.9B
+//! Run (release only — the uncached reference loop re-forwards the ~0.9B
 //! decoder over the full sequence per step):
 //! ```bash
 //! cargo test --release -p lattice-inference --features f16 \
@@ -269,11 +271,11 @@ mod gate {
             "prompt logits last_tok_mean_abs",
         ));
 
-        // 8. Greedy decode, no cache: every token reproduced exactly.
-        // The fixture records per-step top1/top2 margins; the smallest
-        // recorded margin is 3.78 (step 7: 16.072 - 12.289), far above the
-        // 0.05 threshold, so all 24 steps are compared exactly with no
-        // early stop.
+        // 8. Greedy decode with the KV cache: every token reproduced
+        // exactly. The fixture records per-step top1/top2 margins; the
+        // smallest recorded margin is 3.78 (step 7: 16.072 - 12.289), far
+        // above the 0.05 threshold, so all 24 steps are compared exactly
+        // with no early stop.
         let t1 = std::time::Instant::now();
         let generated = model
             .generate_greedy(
@@ -301,10 +303,39 @@ mod gate {
             assert_eq!(g, e, "greedy step {i}");
         }
 
+        // 9. The cache's own acceptance: the cached loop above and the
+        // uncached re-forward loop must produce the same tokens on the
+        // same input. Holding both against the golden would not settle
+        // this — the golden is 24 tokens of one image, and a cache that
+        // diverged only after the horizon, or only on another prompt,
+        // would still match it. The two loops share every stage except
+        // the attention read, so an equality here is the invariant
+        // stated as an equation.
+        let t2 = std::time::Instant::now();
+        let uncached = model
+            .generate_greedy_uncached(
+                &tokenizer,
+                rgb,
+                h,
+                w,
+                &golden.prompt_text,
+                golden.greedy.max_new_tokens,
+            )
+            .expect("uncached greedy decode");
+        let uncached_s = t2.elapsed().as_secs_f64();
+        assert_eq!(
+            generated, uncached,
+            "cached and uncached greedy sequences diverged"
+        );
+
+        // Both loops ran in this process, on this machine, over this one
+        // input: a single observation of what the cache bought here, not a
+        // benchmark. Real before/after numbers come from the bench harness.
         println!(
-            "paddleocr_vl_e2e: prefill {prefill_s:.2}s, greedy {greedy_s:.2}s ({} steps), \
-             worst |diff| {worst:.2e} (ATOL=RTOL={ATOL:e}) — all fields within tolerance, \
-             greedy exact {} of {}",
+            "paddleocr_vl_e2e: prefill {prefill_s:.2}s, greedy cached {greedy_s:.2}s vs \
+             uncached {uncached_s:.2}s ({} steps, single run), worst |diff| {worst:.2e} \
+             (ATOL=RTOL={ATOL:e}) — all fields within tolerance, greedy exact {} of {}, \
+             cached == uncached",
             generated.len(),
             generated.len(),
             golden.greedy.tokens.len()

--- a/crates/inference/tests/paddleocr_vl_e2e_goldens_test.rs
+++ b/crates/inference/tests/paddleocr_vl_e2e_goldens_test.rs
@@ -331,10 +331,10 @@ mod gate {
         // Read the two greedy timings with care, and do not quote them as a
         // decode benchmark. Each call runs the whole pipeline, image
         // processor and vision encoder included, and on this fixture that
-        // shared prefix dominates: the prompt is 157 tokens, so the 22
-        // full-sequence decoder forwards the uncached loop makes and the
-        // cached one does not are worth a few seconds against a total near
-        // 230s. Measured 2026-09-03 on one machine, one run: cached
+        // shared prefix dominates: the prompt is 157 tokens, so the 24
+        // full-sequence decoder forwards the uncached loop makes, against
+        // the cached loop's 24 single-token steps, are worth a few seconds
+        // against a total near 230s. Measured 2026-09-03, one run: cached
         // 229.39s against uncached 224.49s, i.e. the difference came out
         // negative, which is the shared vision pass varying by more than
         // the decoder work being compared. What the cache saves per step

--- a/crates/inference/tests/paddleocr_vl_e2e_goldens_test.rs
+++ b/crates/inference/tests/paddleocr_vl_e2e_goldens_test.rs
@@ -328,9 +328,18 @@ mod gate {
             "cached and uncached greedy sequences diverged"
         );
 
-        // Both loops ran in this process, on this machine, over this one
-        // input: a single observation of what the cache bought here, not a
-        // benchmark. Real before/after numbers come from the bench harness.
+        // Read the two greedy timings with care, and do not quote them as a
+        // decode benchmark. Each call runs the whole pipeline, image
+        // processor and vision encoder included, and on this fixture that
+        // shared prefix dominates: the prompt is 157 tokens, so the 22
+        // full-sequence decoder forwards the uncached loop makes and the
+        // cached one does not are worth a few seconds against a total near
+        // 230s. Measured 2026-09-03 on one machine, one run: cached
+        // 229.39s against uncached 224.49s, i.e. the difference came out
+        // negative, which is the shared vision pass varying by more than
+        // the decoder work being compared. What the cache saves per step
+        // is a structural property of the code (one token instead of the
+        // whole sequence); isolating it is a bench-harness job.
         println!(
             "paddleocr_vl_e2e: prefill {prefill_s:.2}s, greedy cached {greedy_s:.2}s vs \
              uncached {uncached_s:.2}s ({} steps, single run), worst |diff| {worst:.2e} \


### PR DESCRIPTION
Closes #1466.

## What changed

`PaddleOcrVlModel::generate_greedy` re-ran the whole ERNIE-4.5 decoder over
prompt plus generated tokens at every step, materialising a `[seq_len, vocab]`
logits matrix to read one row. It now prefills the prompt once into a
caller-owned `Ernie45KvCache` and forwards one token per step, attending over
the cached rows.

### Decoder (`crates/inference/src/model/ernie45.rs`)

`Ernie45KvCache` holds, per layer, the post-RoPE key and value rows for tokens
`0..len`, in exactly the `[token, kv_head, head_dim]` layout the uncached
kernel's own `k` / `v` buffers use, so the attention reads cached rows with the
same indexing and there is no second layout to keep in sync. It is f32 rather
than a reuse of the f16 `FlatKVCache` because the cached rows have to be
bit-for-bit the rows the uncached forward computed, which is what the
equivalence below rests on; `model/gemma4_cache.rs` keeps its own f32 cache for
the same reason. Both row stores are allocated up front through
`try_reserve_exact` and are only written into afterwards, so the cache never
reallocates as the sequence advances. That is a claim about the cache and not
about the step: `kv_decode_step` still allocates its own per-call scratch, as
the uncached kernel does; hoisting that out is a separate change.

`kv_prefill` is the full-sequence forward with each layer's post-RoPE rows
copied into the cache as they are produced. It reuses `forward_embeds_core`, so
the sink is a pure copy side effect and its returned logits are bit-for-bit
`forward_embeds_last_logits` on the same input.

`kv_decode_step` runs one token through every layer with attention over cache
rows `0..=len`: the same norm, projection, MLP and exact-exp softmax calls the
uncached kernel makes at `s == 1`.

Every entry point revalidates the cache's layer count and `kv_dim` before
touching it, and rejects an empty sequence, an over-capacity prompt, a
non-empty cache at prefill, an empty or full cache at step, and wrong-length or
non-finite embeds. The cache is caller-owned; the model keeps no hidden state.

### Pipeline (`crates/inference/src/model/paddleocr_vl.rs`)

Prompt assembly is split out of `prefill` into `assemble_prompt`, so each greedy
loop runs exactly one prompt forward. The cached loop assembles and then calls
`kv_prefill`; routing it through `prefill` would have run the traced forward,
which materialises the full logits matrix and a clone of every layer's output,
and discarded all of it first.

The previous full-re-forward loop stays on the type as
`generate_greedy_uncached`. It is the differential reference, and the e2e gate
runs both.

## Equivalence, and what it is worth

Asserted bit-for-bit:

- the prefill's logits against `forward_embeds_last_logits` on the same input;
- the prompt's cached rows before and after stepping (the steps only append).

Held to `1e-3` rather than exactly: the step logits. The two paths' GEMMs differ
only in `m` (one row against the whole causal block) with `k` and `n` equal, and
Accelerate orders that accumulation differently. Worst measured `|diff|` on the
seeded unit model is `9.5e-7`. The bound sits three orders above that and orders
of magnitude below the smallest top-1/top-2 margin these goldens gate on
(`3.78`), so it cannot hide a decision change; a structural error (wrong cache
offset, wrong head mapping, wrong position row) moves logits by O(1).

`kv_decode_step_uses_its_own_mrope_position_rows` has two arms against one
bound: the step's own mrope triple must land inside it, and the same step fed
the prompt's triple must land outside it. Both arms were mutation-checked. With
the step's position argument replaced by a constant, arm 1 reddens at `8.3e-4`;
widening arm 1 so arm 2 is reached, arm 2 reddens at a gap of exactly `0`.

## Acceptance

| Issue item | Result |
| --- | --- |
| `paddleocr_vl_e2e_goldens_test` still passes on the committed goldens | PASS in release with the checkpoint present: 24 of 24 greedy tokens exact, all per-field comparisons within `ATOL=RTOL=2e-3` at worst `|diff| 9.83e-5`, `cached == uncached`. 694.53s |
| a test asserts cached == uncached greedy output on the fixture | in the e2e gate (24 tokens, both loops, one model load) and at decoder level in `kv_greedy_sequence_matches_uncached_on_committed_fixture` |
| per-step cost drops from a full-sequence forward to a single-token forward | structurally held and asserted by the tests; **not measured by a bench-compare**. The Linux CI run of the same gate separates the two loops by 100s in the predicted direction, but one run per arm on a shared runner is an observation, not a measurement -- see below |

Unit tests: `cargo test -p lattice-inference --lib --features f16 kv_` gives
149 passed, 0 failed. Lints: `cargo clippy -p lattice-inference --all-targets
-- -D warnings` and the same with `--features f16,metal-gpu` both exit 0 with
zero warnings.

The decoder-level equivalence test declares four layers rather than the
checkpoint's eighteen. Measured on the built test binary, same binary and same
invocation for both arms, that is 649 MiB peak and 6.40s against 1.374 GiB and
11.51s -- 757 MiB and 5.1s off an ordinary `cargo test` run, matching the 793
MB predicted from the declared shapes. The cache is indexed per layer, so four
exercise the same offset arithmetic as eighteen; every shape the kernels
compute against, and the `vocab_size` the committed fixture's real token ids
index into, is unchanged. The test also asserts the reference loop's length
before comparing sequences, so two loops that both stopped after one token can
no longer agree trivially.

The CI gate that greps this test's summary line is anchored on the
`cached == uncached` suffix, so a build whose cached/uncached comparison was
removed or short-circuited fails the gate rather than passing on the older,
shorter line.

## bench-compare disposition

No bench-compare A/B was run for this PR, and nothing below is offered as one.
The bench host is offline, so the harness run that would isolate the decoder is
queued behind it.

What was run instead, and why it does not substitute: the issue asks for measured
wall time before and after. The e2e gate now prints
both loops, and the honest reading of that print is that it does not settle the
question:

```
paddleocr_vl_e2e: prefill 234.74s, greedy cached 229.39s vs uncached 224.49s
(24 steps, single run), worst |diff| 9.83e-5 (ATOL=RTOL=2e-3) - all fields
within tolerance, greedy exact 24 of 24, cached == uncached
```

The cached number came out *higher*. That is not the cache costing time; it is
the measurement being unable to see the cache. Each greedy call runs the whole
pipeline, image processor and vision encoder included, and the two calls differ
in their decoder work: 24 full-sequence forwards plus a traced prefill against
one plain prefill plus 24 single-token steps. On this fixture the prompt is 157
tokens, so those forwards are worth a few seconds against a total near 230s, and
the shared vision pass varies by more than that between runs.

Two things follow. The per-step reduction stated in the issue is a structural
property of the code and the tests hold it exactly (one token forwarded per
step, attending over cached rows, producing the same sequence); it is not a
claim that run measures.

And separately, decode is not where the time goes *on that machine*. The two
greedy calls differ by 24 full-sequence decoder forwards against 24
single-token steps and came out 4.9s apart, so one 157-token forward is worth a
fraction of a second there. The standalone `prefill` at 234.74s contains
exactly one such forward plus its `[157, vocab]` head, so essentially all of it
is the shared image-processing and vision stage.

### The same test on the Linux CI runner disagrees, and that is the useful part

The ARM Linux gate ran the identical test and printed:

```
paddleocr_vl_e2e: prefill 159.15s, greedy cached 161.40s vs uncached 261.46s
(24 steps, single run), worst |diff| 9.35e-5 (ATOL=RTOL=2e-3) - all fields
within tolerance, greedy exact 24 of 24, cached == uncached
```

There the arms separate by 100s, in the direction the change predicts, and
`cached` lands within 2.3s of a bare `prefill` -- which is what a working cache
should look like, since the cached loop is one prefill plus 24 single-token
steps.

The two boxes disagree because the decoder's GEMMs take different paths. On
macOS `matmul_bt` dispatches to Accelerate's `cblas_sgemm`, so 24 full-sequence
forwards are cheap next to the vision stage and sink below its run-to-run
variance; on the Linux runner they are not, and the same arithmetic becomes
visible. The measurement was blind on one machine and not the other, which is
worth more than either number: an A/B whose two arms share a dominant prefix
can report the wrong sign without anything being wrong with the code.

The gate has since run twice on that runner, and the two runs agree closely:

| | run 1 | run 2 | between-run |
| --- | --- | --- | --- |
| `prefill` (the shared prefix) | 159.15s | 158.30s | 0.85s |
| `greedy cached` | 161.40s | 158.92s | 2.48s |
| `greedy uncached` | 261.46s | 257.59s | 3.87s |
| cached vs uncached | 100.06s | 98.67s | 1.4% |

That second run is what makes the first one readable. The quantity under test
separates the arms by about 99s while the shared image-processing and vision
prefix varies by under a second between runs, so on this machine the effect is
roughly two orders of magnitude clear of the noise it sits on. That is the
comparison the macOS run could not make.

**It is still not a bench-compare and should not be quoted as a speedup.** Two
runs per arm on a shared hosted runner, with no A/A control on an untouched path
and no idle-headroom admission gate; the runs are also not independent of each
other in the way a bench harness arranges. It is a consistent observation that
points the same way as the structure. The isolating harness run is still owed.

## Not in this PR

The bench-harness A/B that would isolate the decoder. It needs the bench host,
which is offline; the run is queued behind it. Nothing here is quoted as a
bench-compare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


