### PR TITLE
feat(inference): make Ernie45KvCache reusable and give it a model-bound constructor

### DIFF
--- a/crates/inference/src/model/ernie45.rs
+++ b/crates/inference/src/model/ernie45.rs
@@ -677,6 +677,24 @@ impl Ernie45Model {
     /// enough for `positions.len()` tokens; the cache is caller-owned and
     /// the model keeps no state of its own.
     ///
+    /// Build a cache laid out for this model, sized for `capacity` tokens.
+    ///
+    /// [`Ernie45KvCache::new`] takes the layer count and the per-token KV width
+    /// as raw numbers, and the checked helper that derives the second one from a
+    /// config is crate-private. An out-of-crate caller therefore had to re-derive
+    /// `num_key_value_heads * head_dim` by hand, unchecked, and a layout that
+    /// disagrees with the model's is not rejected at construction: it surfaces
+    /// later and indirectly, as a shape mismatch inside a prefill. Going through
+    /// the model removes both the duplicated arithmetic and that failure mode.
+    ///
+    /// # Errors
+    ///
+    /// [`InferenceError::Inference`] on a zero dimension or a checked-arithmetic
+    /// overflow in the layout, propagated from [`Ernie45KvCache::new`].
+    pub fn new_kv_cache(&self, capacity: usize) -> Result<Ernie45KvCache, InferenceError> {
+        Ernie45KvCache::new(self.cfg.num_hidden_layers, self.cfg.kv_dim()?, capacity)
+    }
+
     /// # Errors
     ///
     /// [`InferenceError::Inference`] on an empty sequence, a sequence that
@@ -1329,6 +1347,43 @@ impl Ernie45KvCache {
     pub fn kv_dim(&self) -> usize {
         self.kv_dim
     }
+
+    /// Drop the stored rows without releasing the allocation, so the cache can
+    /// serve another prompt.
+    ///
+    /// Without this a caller decoding a second prompt has to drop the cache and
+    /// build a new one, because [`Ernie45Model::kv_prefill`] refuses a non-empty
+    /// cache and the stores are private. That throws away buffers which were
+    /// sized correctly and are about to be refilled with the same shapes, which
+    /// is the ordinary serving pattern rather than an edge case.
+    pub fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    /// Roll the stored row count back to `len`, keeping the allocation.
+    ///
+    /// Rows above `len` are left in place rather than zeroed, and that is sound
+    /// rather than a shortcut: every read of the stores is bounded by the live
+    /// row count (the decode step attends over `len + 1` keys and slices
+    /// `..keys * kv_dim`), and each appended row is written at row `len` before
+    /// any read of it. So a stale row above `len` is unreachable until it is
+    /// overwritten by the append that makes it live again.
+    ///
+    /// Growing is not truncation: `len` above the current length is refused
+    /// rather than clamped, because the rows it would expose were never written
+    /// by this sequence and clamping would silently hand back a shorter cache
+    /// than the caller asked for.
+    pub fn truncate(&mut self, len: usize) -> Result<(), InferenceError> {
+        if len > self.len {
+            return Err(InferenceError::Inference(format!(
+                "ernie45 kv cache truncate: requested length {len} exceeds the {} rows stored; \
+                 truncation cannot grow a cache",
+                self.len
+            )));
+        }
+        self.len = len;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -1881,6 +1936,137 @@ mod tests {
         let cfg = model.config();
         let kv_dim = cfg.num_key_value_heads * cfg.head_dim;
         Ernie45KvCache::new(cfg.num_hidden_layers, kv_dim, capacity).unwrap()
+    }
+
+    /// The point of `clear`: a reused cache must be indistinguishable from a
+    /// freshly allocated one, not merely "close". Both arms run the same prompt
+    /// through prefill plus one decode step; the reused arm has already served a
+    /// different, longer prompt first, so if `clear` left any observable trace --
+    /// a stale row inside the attention window, a length that did not reset --
+    /// the two logit vectors would part. They are compared bitwise because both
+    /// arms perform identical arithmetic in identical order, so anything less
+    /// than equality is a defect rather than drift.
+    #[test]
+    fn kv_cleared_cache_is_indistinguishable_from_a_fresh_one() {
+        let (cfg, model) = equiv_model();
+        let h = cfg.hidden_size;
+        let embeds_a: Vec<f32> = pseudo_random_vec(6 * h, 0x51ed_c0de_c1ea_0001);
+        let positions_a: Vec<[u32; 3]> = (0..6u32).map(|i| [i, i, i]).collect();
+        let embeds_b: Vec<f32> = pseudo_random_vec(3 * h, 0x51ed_c0de_c1ea_0002);
+        let positions_b: Vec<[u32; 3]> = (0..3u32).map(|i| [i, i, i]).collect();
+        let step_row: Vec<f32> = pseudo_random_vec(h, 0x51ed_c0de_c1ea_0003);
+
+        // Reused arm: serve the LONGER prompt first, so any row left behind sits
+        // inside the window the second prompt will attend over.
+        let mut reused = kv_test_cache(&model, 8);
+        model
+            .kv_prefill(&embeds_a, &positions_a, &mut reused)
+            .unwrap();
+        model
+            .kv_decode_step(&step_row, [6, 6, 6], &mut reused)
+            .unwrap();
+        assert_eq!(
+            reused.len(),
+            7,
+            "setup: the first prompt must actually fill rows"
+        );
+        reused.clear();
+        assert!(reused.is_empty(), "clear must reset the live row count");
+        assert_eq!(
+            reused.capacity(),
+            8,
+            "clear must keep the allocation -- releasing it defeats the purpose"
+        );
+        let reused_prefill = model
+            .kv_prefill(&embeds_b, &positions_b, &mut reused)
+            .unwrap();
+        let reused_step = model
+            .kv_decode_step(&step_row, [3, 3, 3], &mut reused)
+            .unwrap();
+
+        // Fresh arm: same second prompt, never used before.
+        let mut fresh = kv_test_cache(&model, 8);
+        let fresh_prefill = model
+            .kv_prefill(&embeds_b, &positions_b, &mut fresh)
+            .unwrap();
+        let fresh_step = model
+            .kv_decode_step(&step_row, [3, 3, 3], &mut fresh)
+            .unwrap();
+
+        assert_eq!(
+            reused_prefill, fresh_prefill,
+            "prefill into a cleared cache diverged from a fresh one"
+        );
+        assert_eq!(
+            reused_step, fresh_step,
+            "decode after a cleared cache diverged from a fresh one"
+        );
+        assert_eq!(reused.len(), fresh.len());
+    }
+
+    /// `truncate` rolls back and refuses to grow. The growth arm matters more
+    /// than it looks: clamping instead of refusing would hand back a cache
+    /// shorter than asked for while reporting success.
+    #[test]
+    fn kv_truncate_rolls_back_and_refuses_to_grow() {
+        let (cfg, model) = equiv_model();
+        let h = cfg.hidden_size;
+        let embeds: Vec<f32> = pseudo_random_vec(5 * h, 0x51ed_c0de_c1ea_0004);
+        let positions: Vec<[u32; 3]> = (0..5u32).map(|i| [i, i, i]).collect();
+        let mut cache = kv_test_cache(&model, 8);
+        model.kv_prefill(&embeds, &positions, &mut cache).unwrap();
+        assert_eq!(cache.len(), 5);
+
+        cache.truncate(2).unwrap();
+        assert_eq!(cache.len(), 2, "truncate must roll the live row count back");
+        assert_eq!(
+            cache.capacity(),
+            8,
+            "truncate must not release the allocation"
+        );
+
+        // Growing is refused, and the length is left untouched by the refusal.
+        let grown = cache.truncate(4);
+        assert!(
+            matches!(&grown, Err(InferenceError::Inference(m)) if m.contains("cannot grow")),
+            "truncate must refuse to grow, got {grown:?}"
+        );
+        assert_eq!(
+            cache.len(),
+            2,
+            "a refused truncate must not move the length"
+        );
+
+        // Truncating to the current length is a no-op, not an error.
+        cache.truncate(2).unwrap();
+        assert_eq!(cache.len(), 2);
+        cache.truncate(0).unwrap();
+        assert!(cache.is_empty());
+    }
+
+    /// The model-bound constructor must produce exactly the layout the hand-built
+    /// one does -- otherwise it trades a duplicated calculation for a divergent
+    /// one, which is worse than the problem it solves.
+    #[test]
+    fn kv_model_bound_cache_matches_the_hand_built_layout() {
+        let (cfg, model) = equiv_model();
+        let built = model.new_kv_cache(8).unwrap();
+        let hand = kv_test_cache(&model, 8);
+        assert_eq!(built.layers(), hand.layers());
+        assert_eq!(built.kv_dim(), hand.kv_dim());
+        assert_eq!(built.capacity(), hand.capacity());
+        assert!(built.is_empty());
+        // And it agrees with the config's own checked derivation.
+        assert_eq!(built.kv_dim(), cfg.kv_dim().unwrap());
+        assert_eq!(built.layers(), cfg.num_hidden_layers);
+        // A cache from this path is usable by prefill -- the layout check inside
+        // kv_prefill is what would reject a wrong one.
+        let h = cfg.hidden_size;
+        let embeds: Vec<f32> = pseudo_random_vec(2 * h, 0x51ed_c0de_c1ea_0005);
+        let positions: Vec<[u32; 3]> = (0..2u32).map(|i| [i, i, i]).collect();
+        let mut built = built;
+        model.kv_prefill(&embeds, &positions, &mut built).unwrap();
+        assert_eq!(built.len(), 2);
     }
 
     /// The prefill's returned logits are the full forward's last row —


### PR DESCRIPTION
## What changed

`Ernie45KvCache` could be filled but not emptied. `kv_prefill` refuses a
non-empty cache, the stores are private, and there was no reset, so a caller
decoding a second prompt had to drop the cache and allocate a new one. That
discards buffers already sized correctly and about to be refilled with the same
shapes, and it is the ordinary serving pattern -- one model, many prompts --
rather than an edge case.

Three additions, no existing code path touched:

- **`clear()`** drops the stored rows and keeps the allocation.
- **`truncate(len)`** rolls the row count back to any length at or below the
  current one, which also covers rolling back speculative rows. Rows above the
  new length are left in place rather than zeroed. That is sound rather than a
  shortcut: every read of the stores is bounded by the live row count (the decode
  step attends over `len + 1` keys and slices `..keys * kv_dim`), and each
  appended row is written at row `len` before anything reads it, so a stale row
  is unreachable until the append that makes it live overwrites it. Growth is
  refused rather than clamped, because clamping hands back a shorter cache than
  the caller asked for while reporting success.
- **`Ernie45Model::new_kv_cache(capacity)`** builds a cache laid out for the
  model. `Ernie45KvCache::new` takes the layer count and per-token KV width as
  raw numbers while the checked helper deriving the second one is crate-private,
  so an out-of-crate caller re-derived `num_key_value_heads * head_dim` by hand,
  unchecked. This is the part with a correctness edge rather than only
  ergonomics: a layout disagreeing with the model's was not rejected at
  construction, it surfaced later and indirectly as a shape mismatch inside a
  prefill.

`kv_dim()` stays crate-private. Callers going through `new_kv_cache` do not need
it, and widening an API without a caller is not worth doing.

## Tests

Three, each mutation-checked against the specific defect it exists to catch, with
the expected reddened arm named before running and reconciled after.

| Test | Mutation applied | Result |
| --- | --- | --- |
| a cleared cache is bitwise indistinguishable from a fresh one | `clear()` made a no-op | FAILED as intended |
| truncate rolls back and refuses to grow | guard replaced with `if false` (clamp instead of refuse) | FAILED as intended |
| the model-bound cache matches the hand-built layout | `head_dim` substituted for the checked KV width | FAILED as intended |

The first is the load-bearing one. Both arms run the same prompt through prefill
plus one decode step, but the reused arm has already served a **longer** prompt
first, so any row surviving the clear would sit inside the second prompt's
attention window. The comparison is bitwise because both arms perform identical
arithmetic in identical order, so anything short of equality is a defect rather
than drift.

All three mutants were reverted by inverse mutation and the restoration verified
by asserting each site is back to its correct form, with zero markers left.

Gates: `cargo fmt --check` 0, `cargo clippy -p lattice-inference --all-targets --
-D warnings` 0, the same with `--features f16,metal-gpu` 0, and
`cargo test -p lattice-inference --lib kv_` 152 passed / 0 failed.

## bench-compare disposition

No A/B was run and none is owed, on the structural grounds rather than by
waiver.

The diff is **186 insertions and zero deletions**. It adds three methods and
three tests; no existing function body is modified, so no code path that any
bench binary executes is different before and after. The three new methods have
no callers outside the new tests yet, so they cannot appear in a bench profile
either. There is no before-and-after to measure, because nothing that previously
ran runs differently.

The separate bench-harness A/B still owed for the KV-cache lane is unaffected by
this PR and remains queued on its host.

Closes #1488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
