### PR TITLE
docs(inference): record that the PaddleOCR-VL e2e fixture image carries no personal data

### DIFF
--- a/crates/inference/tests/paddleocr_vl_e2e_goldens_test.rs
+++ b/crates/inference/tests/paddleocr_vl_e2e_goldens_test.rs
@@ -22,6 +22,15 @@
 //!   loop and again by the uncached re-forward loop, which must agree
 //!   with each other as well as with the fixture.
 //!
+//! `e2e_image.png` itself is a synthetic document rendered for this test: a
+//! plain white page of generic mid-range lab values in a uniform system font,
+//! with no personal name, patient id, date, or institution, and none of the
+//! perspective, shadow, or page-edge artifacts a photographed document carries.
+//! It is not a photograph of a real record and holds no personal data, which is
+//! what makes it safe in a public repository. Recorded here because the rendered
+//! content is a medical report, so the question is a reasonable one to ask and
+//! an expensive one to re-answer from the bytes alone.
+//!
 //! **Fail-closed contract** (mirrors `paddleocr_vl_decoder_goldens_test.rs`):
 //! the ~1.9 GB checkpoint is not committed. With `LATTICE_POCR_MODEL_DIR`
 //! unset and the default `~/.lattice/models/paddleocr-vl-1.6` absent, this


### PR DESCRIPTION
## What

The PaddleOCR-VL end-to-end gate's fixture image renders a medical lab report.
The test header documents where the *goldens* came from (HF transformers
4.57.1, torch 2.13.0, PIL 12.3.0, CPU f32, eager attention) but says nothing
about where the *image* came from, and `e2e_goldens.json` records only its
hashes.

That leaves a reasonable question — is a medical-looking document safe in a
public repository — answerable only by re-deriving it from the bytes.

## Change

Nine lines of module documentation recording what the image is: a synthetic
document rendered for this test. Generic mid-range values in a uniform system
font on a plain white page, with no personal name, patient id, date, or
institution, and none of the perspective, shadow, or page-edge artifacts a
photographed document carries.

Comment-only. No behaviour change, no fixture bytes touched.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] Pre-commit `cargo check -p lattice-inference` clean
- [x] Doc lint clean (191 of 192 tracked Markdown files, plus its recursive
      discovery self-test, capability-matrix fixture check, and absolute-path
      check)
- [x] `e2e_image.png` is byte-identical; the test's own
      `e2e_image.png bytes drifted from the fixture hash` assertion still
      pins it

## bench-compare disposition

**Waived, and this is a waiver rather than a deferral.** No `make bench-compare`
was run and none is owed.

The diff is 9 added lines and 0 removed lines in one file, and every added line
begins with `//!` — module documentation in a test file. Verified mechanically
on the diff, not asserted:

```
added lines: 9 | starting with '+//!': 9 | non-doc: 0
removed lines: 0
files touched: crates/inference/tests/paddleocr_vl_e2e_goldens_test.rs
```

There is no compiled code change, in this crate or any other, so there is no
path whose timing could move and nothing for an A/B to measure. A bench run
here would produce two samples of identical code and invite a reader to treat
the difference between them as a result.

Separately, the benchmark host is offline, so a run would not have been
available on request either — but the waiver rests on the diff, not on that.

Refs #1456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
