### PR TITLE
feat(microlora): refuse a timing run that shares its machine, instead of printing that it does

### DIFF
--- a/scripts/microlora/size_w1_run.py
+++ b/scripts/microlora/size_w1_run.py
@@ -5,7 +5,7 @@ The exact-gradient CPU trainer has three cost terms and only one of them is the 
 itself. Reading them off a real run matters because the two overheads dominate:
 
   CACHE   building the frozen-prefix cache, once per run, linear in the number of TRAIN
-          samples. It is not persisted, so every arm of a multi-seat experiment pays it again.
+          samples. It is not persisted, so every arm of a multi-arm experiment pays it again.
   SCORE   a scoring pass over EVERY train cache plus every held-out cache. It fires at the
           baseline, at each `--log-every` boundary, at the last step, and once more at the
           end, so a run pays for at least three of them however the flag is set.

--- a/scripts/microlora/test_time_run_exclusive.sh
+++ b/scripts/microlora/test_time_run_exclusive.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Controls for time_run.sh --exclusive. A guard that fails open is worse than no guard, so the
+# refusal arm asserts the COMMAND DID NOT RUN, not merely that the exit code was 4.
+set -u
+TR="$(cd "$(dirname "$0")" && pwd)/time_run.sh"
+D=$(mktemp -d); fails=0; ran=0
+MARK="zzexclusivitymarker$$"
+
+note () { ran=$((ran+1)); if [ "$1" = ok ]; then :; else fails=$((fails+1)); echo "  FAIL $2"; fi; }
+
+# --- A. clean machine, pattern matches nothing -> runs normally.
+rm -f "$D/a.touched"
+"$TR" --label a --out "$D" --exclusive "$MARK" -- /usr/bin/touch "$D/a.touched" >/dev/null 2>&1
+rc=$?
+[ $rc -eq 0 ] && [ -f "$D/a.touched" ] && note ok || note bad "A: clean run should proceed (rc=$rc, touched=$([ -f $D/a.touched ] && echo yes || echo no))"
+grep -q "competing_at_start" "$D/a.timing.tsv" && note ok || note bad "A2: tsv missing the new columns"
+awk 'NR==2{exit !($8==0)}' "$D/a.timing.tsv" && note ok || note bad "A3: competing_at_start should be 0, tsv=$(sed -n 2p $D/a.timing.tsv)"
+
+# --- B. a competitor exists -> REFUSE, and the command must NOT run.
+# The decoy must carry the property the search looks for, and that is ASSERTED, not assumed.
+# `bash -c "sleep 120" MARK` does NOT work: a single simple command makes bash exec sleep
+# directly, so the process argv is "sleep 120" and the marker is gone. The first version of this
+# test used that form, the guard correctly found nothing, and the test reported the GUARD as
+# failing open. A decoy that does not carry the property tests the test, not the subject.
+bash -c "sleep 120; :" "$MARK" &
+COMP=$!
+sleep 1
+if [ "$(/bin/ps -o command= -p $COMP | /usr/bin/grep -c "$MARK")" -ne 1 ]; then
+  echo "  FAIL B0: the decoy does not carry the marker in its argv, so arms B..B4 would be vacuous"
+  echo "     argv: $(/bin/ps -o command= -p $COMP)"
+  fails=$((fails+1))
+fi
+ran=$((ran+1))
+rm -f "$D/b.touched"
+"$TR" --label b --out "$D" --exclusive "$MARK" -- /usr/bin/touch "$D/b.touched" >/dev/null 2>"$D/b.err"
+rc=$?
+[ $rc -eq 4 ] && note ok || note bad "B: expected exit 4, got $rc"
+[ ! -f "$D/b.touched" ] && note ok || note bad "B2: THE GUARD FAILED OPEN -- the command ran anyway"
+grep -q "REFUSED" "$D/b.err" && note ok || note bad "B3: refusal must say so on stderr; got: $(cat $D/b.err)"
+[ ! -f "$D/b.timing.tsv" ] && note ok || note bad "B4: a refused run must not leave a timing row"
+
+# --- B5. MUST-MATCH control: prove the counter can SEE that process at all. Without this, arm B
+#         would pass identically if the counter were simply broken and returned 0... except it
+#         returns 4, so instead prove the negative arm is a real negative: same competitor, a
+#         pattern that should NOT match, must proceed.
+rm -f "$D/c.touched"
+"$TR" --label c --out "$D" --exclusive "definitelynotrunning${MARK}xyz" -- /usr/bin/touch "$D/c.touched" >/dev/null 2>&1
+rc=$?
+[ $rc -eq 0 ] && [ -f "$D/c.touched" ] && note ok || note bad "B5: a non-matching pattern must not refuse (rc=$rc)"
+
+kill "$COMP" 2>/dev/null; wait "$COMP" 2>/dev/null
+
+# --- C. no --exclusive -> unchanged behaviour, still runs.
+rm -f "$D/d.touched"
+"$TR" --label d --out "$D" -- /usr/bin/touch "$D/d.touched" >/dev/null 2>&1
+rc=$?
+[ $rc -eq 0 ] && [ -f "$D/d.touched" ] && note ok || note bad "C: without --exclusive the wrapper must behave as before (rc=$rc)"
+
+# --- D. the wrapper still propagates the command's own exit code.
+"$TR" --label e --out "$D" --exclusive "$MARK" -- /bin/sh -c 'exit 7' >/dev/null 2>&1
+[ $? -eq 7 ] && note ok || note bad "D: the command's rc must survive the wrapper"
+
+echo "exclusivity controls: $ran run, $fails failed"
+rm -rf "$D"
+exit $([ $fails -eq 0 ] && echo 0 || echo 1)

--- a/scripts/microlora/time_run.sh
+++ b/scripts/microlora/time_run.sh
@@ -14,22 +14,62 @@
 # program's own figure is still recorded, labelled as the loop-only span, because the DIFFERENCE
 # between the two is the prologue cost and that is a quantity worth having.
 #
+# EXCLUSIVITY, and why it is enforced here rather than trusted to the caller. A wall clock that
+# shares its machine with a second copy of the same job is not a measurement of that job. On
+# 2026-09-08 a run of this trainer took 3994s; the identical run, same binary and same inputs, on
+# an idle machine took 615s. The driver had checked for competing processes and PRINTED the result:
+#
+#     === nothing of ours running: 1 ===
+#
+# The label asserts the answer while the value beside it contradicts it, and the run proceeded. A
+# printed count is not a guard, it is a number waiting to be read past, so --exclusive REFUSES
+# instead of reporting. The competing process was left over from an earlier run that had been
+# discarded as invalid: discarding a MEASUREMENT says nothing about the PROCESS, which keeps
+# running and keeps consuming exactly the resource the next measurement needs.
+#
+# The post-run count is recorded too, because contention can arrive after launch and a check that
+# only runs at t=0 certifies a window it did not observe.
+#
 # Usage:
-#   time_run.sh --label NAME --out DIR -- <command> [args...]
+#   time_run.sh --label NAME --out DIR [--exclusive PATTERN] -- <command> [args...]
 #
 # Writes:  <out>/<label>.log          the command's stdout+stderr
-#          <out>/<label>.timing.tsv   label, wall_s, self_reported_s, prologue_s, rc, start, end
+#          <out>/<label>.timing.tsv   label, wall_s, self_reported_s, prologue_s, rc, start, end,
+#                                     competing_at_start, competing_at_end
 set -u
 
-LABEL="" OUT=""
+LABEL="" OUT="" EXCLUSIVE=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --label) LABEL=$2; shift 2;;
     --out) OUT=$2; shift 2;;
+    --exclusive) EXCLUSIVE=$2; shift 2;;
     --) shift; break;;
     *) echo "unknown argument: $1" >&2; exit 2;;
   esac
 done
+
+# Counts processes whose command line contains PATTERN, excluding this script and its own shell.
+#
+# The process table is snapshotted into a variable BEFORE any grep runs, which is what keeps the
+# search from matching itself: a naive `ps | grep "$PATTERN"` puts PATTERN in the grep's own argv
+# and the grep appears in its own results. The bracket trick does not help when the pattern arrives
+# as a variable. Prints the count on stdout and the pids on stderr.
+competing_count () {
+  snap=$(/bin/ps -Ao pid=,command=)
+  # ARM: a number-bearing instrument asserts its input was non-empty in the same breath. An
+  # unreadable process table returning "0 competitors" is the reassuring failure.
+  if [ -z "$snap" ]; then
+    echo "REFUSED: the process table read back empty, so the exclusivity check could not run." >&2
+    echo "         An instrument that cannot see anything must not report that it saw nothing." >&2
+    exit 5
+  fi
+  hits=$(printf '%s\n' "$snap" | /usr/bin/grep -F -- "$1" \
+           | /usr/bin/grep -v "time_run.sh" \
+           | /usr/bin/awk -v self="$$" '$1 != self { print }')
+  [ -n "$hits" ] && printf '%s\n' "$hits" >&2
+  printf '%s\n' "$hits" | /usr/bin/grep -c . 
+}
 [ -n "$LABEL" ] || { echo "missing --label" >&2; exit 2; }
 [ -n "$OUT" ] || { echo "missing --out" >&2; exit 2; }
 [ $# -gt 0 ] || { echo "no command given after --" >&2; exit 2; }
@@ -37,6 +77,17 @@ done
 mkdir -p "$OUT"
 LOG="$OUT/$LABEL.log"
 TSV="$OUT/$LABEL.timing.tsv"
+
+COMPETING_START=0
+if [ -n "$EXCLUSIVE" ]; then
+  COMPETING_START=$(competing_count "$EXCLUSIVE")
+  if [ "$COMPETING_START" -ne 0 ]; then
+    echo "REFUSED: $COMPETING_START process(es) matching '$EXCLUSIVE' are already running (pids above)." >&2
+    echo "         A timing run that shares the machine with another copy of its own workload" >&2
+    echo "         measures the contention, not the workload. Stop them and re-run." >&2
+    exit 4
+  fi
+fi
 
 START_EPOCH=$(date +%s)
 START_ISO=$(date -Iseconds)
@@ -65,8 +116,18 @@ else
   esac
 fi
 
-printf 'label\twall_s\tself_reported_s\tprologue_s\trc\tstart\tend\n' > "$TSV"
-printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$LABEL" "$WALL" "$SELF" "$PROLOGUE" "$RC" "$START_ISO" "$END_ISO" >> "$TSV"
+# Measured AFTER the run, not assumed from the pre-check: a machine that was quiet at t=0 can
+# acquire a competitor at minute 13, and contamination landing on one arm of a comparison biases
+# that comparison with a sign rather than averaging out.
+COMPETING_END=0
+[ -n "$EXCLUSIVE" ] && COMPETING_END=$(competing_count "$EXCLUSIVE" 2>/dev/null)
+
+printf 'label\twall_s\tself_reported_s\tprologue_s\trc\tstart\tend\tcompeting_at_start\tcompeting_at_end\n' > "$TSV"
+printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$LABEL" "$WALL" "$SELF" "$PROLOGUE" "$RC" "$START_ISO" "$END_ISO" "$COMPETING_START" "$COMPETING_END" >> "$TSV"
+if [ -n "$EXCLUSIVE" ] && [ "$COMPETING_END" -ne 0 ]; then
+  echo "WARNING: $COMPETING_END process(es) matching '$EXCLUSIVE' were running when this finished," >&2
+  echo "         so the machine was not exclusive for the whole span and this number is SUSPECT." >&2
+fi
 
 # "NA" must not be printed as "NAs": a unit suffix on a non-value reads like a measurement.
 case "$PROLOGUE" in NA) PSHOW=NA;; *) PSHOW="${PROLOGUE}s";; esac


### PR DESCRIPTION
## The failure this comes from

The driver *had* checked for competing processes before a timing run, and printed:

```
=== nothing of ours running: 1 ===
```

The label asserts the answer while the value beside it contradicts it. The run proceeded on a machine
it was sharing with another copy of itself, and the number went on to support a scheduling estimate
before the discrepancy was found.

A printed count is not a guard.

The stray process came from an earlier run that had been discarded as invalid. Discarding a
*measurement* says nothing about the *process*, which keeps running and keeps consuming exactly the
resource the next measurement needs.

**On the magnitude, stated precisely because an earlier draft of this description over-attributed
it.** That shared run took 3994s against 615s for the identical run on a quiet machine, and it is
tempting to read the whole 6.5x as the cost of sharing. It is not established that it was. The
machine has since been found to enter thermal sleep repeatedly under load — 23 recorded events over
two days, the largest 907s — which inflates wall clock while leaving every CPU-based sampler reading
100% busy, since a sampler only produces samples while the machine is awake. On a later run that
carried per-line wall stamps, wall clock exceeded the process's own CPU time by 996s and 907s of
that was one recorded sleep. Sleep is therefore a large independent term in the 3994s, and how the
remainder divides is still open.

None of that weakens the reason for this change. A check that prints `1` beside the word `nothing`
is broken whatever else was wrong that day, and it is broken in the direction that lets bad
measurements through.

## What changed

`time_run.sh --exclusive PATTERN` **refuses**, with a distinct exit code and the offending pids named.

Two details that are load-bearing rather than defensive:

- It snapshots the process table *before* any grep runs. A naive `ps | grep "$PATTERN"` puts the
  pattern in the grep's own argv, so the grep appears in its own results; the usual `[p]attern`
  bracket trick does not help when the pattern arrives as a variable.
- It asserts the process table read back non-empty, so an unreadable one cannot report that it saw
  nothing. An instrument that cannot see anything must not report that there was nothing to see.

Competing counts are recorded at **start and end**, in two new TSV columns, because a machine that
was quiet at t=0 can acquire a competitor at minute 13, and a check that only runs at launch
certifies a window it never observed.

## Scope, and what this does not do

This guard covers competing *processes*. It does not detect a machine that goes to sleep underneath
a run, which is a separate contaminant found later and not addressed here. The cheap instrument for
that one is `ps -o etime,time` on the running pid: a process accrues no CPU time while the machine is
asleep, so a gap between elapsed and CPU time measures the loss directly and needs no privilege.
Recording it belongs in a follow-up rather than in this change.

## Tests

`test_time_run_exclusive.sh`, eleven arms. Two worth naming:

- **A refused run must not execute its command.** A guard that fails open is worse than no guard, so
  this asserts the side effect is absent, not merely that the exit code was right.
- **The decoy must carry the marker being searched for.** The first version did not: `bash -c` execs
  a single simple command directly, so the marker never reached the process table. The guard
  correctly found nothing and the test reported the guard as failing open. A decoy that does not
  carry the property under test tests the test, not the subject.

Also included: a one-word comment fix in `size_w1_run.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
