### PR TITLE
feat(tune): time the training step separately, and stop re-scoring the same weights twice

### DIFF
--- a/crates/tune/src/train_support/full_driver.rs
+++ b/crates/tune/src/train_support/full_driver.rs
@@ -1073,7 +1073,7 @@ pub fn run(config: FullDriverConfig) -> Result<FullDriverOutcome, Box<dyn std::e
     // just scored, recomputing an identical value from an unchanged state: a full train pass plus a
     // full held-out pass, 558s at the sizes above, paid once per run for nothing. Carry the loop's
     // own last scoring forward instead of repeating it.
-    let mut last_scored: Option<(f64, Option<f64>)> = None;
+    let mut last_scored: Option<(f32, Option<f32>)> = None;
     let tstep = Instant::now();
     for step in 1..=steps {
         let tone = Instant::now();

--- a/crates/tune/src/train_support/full_driver.rs
+++ b/crates/tune/src/train_support/full_driver.rs
@@ -1053,8 +1053,30 @@ pub fn run(config: FullDriverConfig) -> Result<FullDriverOutcome, Box<dyn std::e
         None => println!("\n  step    0  train NLL: {base_nll:.4}"),
     }
 
+    // THREE CLOCKS, NOT ONE, AND A STEP COST THAT IS READ RATHER THAN DERIVED.
+    //
+    // What this replaces: a single clock started before the loop and read AFTER the epilogue's
+    // extra train pass but BEFORE the epilogue's held-out pass. Its `in {secs}s` figure therefore
+    // carried one whole scoring pass it never named and omitted a second one. Anybody recovering a
+    // per-step cost from it — loop figure minus the in-loop scoring points, divided by steps —
+    // subtracts from a quantity with an invisible term in it and gets an answer too large by that
+    // term over the step count. Measured at 32-train/22-valid on a 2-step run: the unnamed pass was
+    // 314.7s, inflating a step by ~157s against a true cost of tens of seconds. The reported
+    // 847.7s decomposed exactly as 533s of loop plus that 314.7s, which is how the term was found.
+    //
+    // Each quantity now accumulates on its own clock and prints on its own line.
+    let mut train_step_secs = 0.0f64;
+    let mut in_loop_score_secs = 0.0f64;
+    let mut score_points = 0usize;
+    // The final step ALWAYS scores, because `step == steps` forces the log even when log_every does
+    // not divide it. So after any run with steps >= 1 the epilogue re-scored weights the loop had
+    // just scored, recomputing an identical value from an unchanged state: a full train pass plus a
+    // full held-out pass, 558s at the sizes above, paid once per run for nothing. Carry the loop's
+    // own last scoring forward instead of repeating it.
+    let mut last_scored: Option<(f64, Option<f64>)> = None;
     let tstep = Instant::now();
     for step in 1..=steps {
+        let tone = Instant::now();
         let ctx = &caches[(step - 1) % caches.len()];
         let (_nll, _n, grads, gdn_grads) = {
             let fwd = forward_full(ctx, &layers, &loras, &gdn_loras, &head, &train_ctx)?;
@@ -1063,10 +1085,16 @@ pub fn run(config: FullDriverConfig) -> Result<FullDriverOutcome, Box<dyn std::e
 
         apply_adam_updates(&mut adam, &mut loras, &grads, &train_ctx);
         apply_gdn_adam_updates(&mut adam, &mut gdn_loras, &gdn_grads, &train_ctx);
+        train_step_secs += tone.elapsed().as_secs_f64();
 
         if step % log_every == 0 || step == steps {
+            let tscore = Instant::now();
             let mean_nll = eval_chain_nll(&caches, &layers, &loras, &gdn_loras, &head, &train_ctx)?;
-            match eval_valid(&loras, &gdn_loras)? {
+            let valid_nll = eval_valid(&loras, &gdn_loras)?;
+            in_loop_score_secs += tscore.elapsed().as_secs_f64();
+            score_points += 1;
+            last_scored = Some((mean_nll, valid_nll));
+            match valid_nll {
                 Some(v) => println!(
                     "  step {step:4}  train NLL: {mean_nll:.4}  held-out NLL: {v:.4}  (train d {:+.4})",
                     mean_nll - base_nll
@@ -1078,10 +1106,35 @@ pub fn run(config: FullDriverConfig) -> Result<FullDriverOutcome, Box<dyn std::e
             }
         }
     }
-
-    let final_nll = eval_chain_nll(&caches, &layers, &loras, &gdn_loras, &head, &train_ctx)?;
     let secs = tstep.elapsed().as_secs_f64();
-    match (base_valid, eval_valid(&loras, &gdn_loras)?) {
+
+    // steps == 0 leaves the loop with nothing to have scored, so the epilogue still has to. That is
+    // the only path on which this clock is nonzero, and it prints either way so that a reader can
+    // see the redundant pass is gone rather than take it on trust.
+    let mut epilogue_score_secs = 0.0f64;
+    let (final_nll, final_valid) = match last_scored {
+        Some(pair) => pair,
+        None => {
+            let tepi = Instant::now();
+            let n = eval_chain_nll(&caches, &layers, &loras, &gdn_loras, &head, &train_ctx)?;
+            let v = eval_valid(&loras, &gdn_loras)?;
+            epilogue_score_secs = tepi.elapsed().as_secs_f64();
+            (n, v)
+        }
+    };
+
+    let per_step = if steps > 0 {
+        format!("{:.2}s/step", train_step_secs / steps as f64)
+    } else {
+        "no steps".to_string()
+    };
+    println!(
+        "  step loop: {steps} steps in {train_step_secs:.1}s ({per_step}), \
+in-loop scoring {in_loop_score_secs:.1}s over {score_points} point(s), \
+epilogue re-scoring {epilogue_score_secs:.1}s"
+    );
+
+    match (base_valid, final_valid) {
         (Some(b), Some(f)) => println!(
             "\n=== done: train {base_nll:.4}→{final_nll:.4} ({:+.4})  |  held-out {b:.4}→{f:.4} ({:+.4})  in {secs:.1}s ===",
             final_nll - base_nll,


### PR DESCRIPTION
## The defect

The driver reported one duration for the step loop, and it was scoped wrong in both directions:

```rust
let final_nll = eval_chain_nll(...)?;      // a FULL extra train pass
let secs = tstep.elapsed().as_secs_f64();  // ...read AFTER it
match (base_valid, eval_valid(...)?) {     // a FULL held-out pass, AFTER secs
```

The clock started before the loop but was read *after* the epilogue's extra train pass and *before*
the epilogue's held-out pass. So `in {secs}s` carried a whole scoring pass it never named, and
omitted a second one.

That matters because `secs` is the number a per-step cost gets recovered from: loop figure, minus
the in-loop scoring points, divided by steps. That subtraction takes place against a quantity with
an invisible term in it. Measured at 32-train/22-valid on a two-step run, the unnamed pass was
**314.7s** and inflated a step by roughly **157s** against a true cost of tens of seconds.

**How it was found, since the method generalises.** Wall stamps were put on every emitted line, so
each phase could be compared against the driver's own arithmetic. The reported 847.7s decomposed as
exactly 533s of stamped loop plus 314.7s — one train pass, to the tenth of a second. An external
clock disagreeing with an internal one by precisely the cost of a named operation is what located
the term; nothing about the source had to be read to suspect it.

## What changed

**Three clocks, each printing its own line**, so the step cost is read rather than derived:

```
step loop: 48 steps in 190.4s (3.97s/step), in-loop scoring 2232.4s over 4 point(s), epilogue re-scoring 0.0s
```

**And one redundant pass removed.** The final step *always* scores, because `step == steps` forces
the log even when `log_every` does not divide it. So every run with at least one step re-scored, in
the epilogue, weights the loop had just scored from an unchanged state — recomputing an identical
value at the cost of a full train pass plus a full held-out pass. At the sizes above that is **558s
per run**. The loop's own last scoring is carried forward instead.

The zero-step path has nothing to carry forward, so it still scores in the epilogue. That clock
prints on both paths, so a reader can *see* the redundant pass is gone rather than take it on trust.

## Verification status, stated plainly

- **Not compiled locally.** This machine is under a build freeze, so the compile and lint gates that
  normally run pre-commit are running here in CI instead. `rustfmt --edition 2024 --check` was run on
  the file and is clean, but that is a parse check and catches no type or borrow error.
- **The behavioural check has not been run.** That the new lines report sane values, that
  `epilogue re-scoring` reads `0.0s` on any run with steps, and that total wall time drops by about
  one scoring pass against the previous binary, all need the bench machine and a real model. Queued,
  not done.
- The numeric claims in this description (314.7s, 533s, 847.7s, 558s) come from stamped output of
  the *unmodified* binary. They describe the defect, not the fix.
