### PR TITLE
docs(grammar): state the UTF-8 contract at both ends of the byte/string seam

### DIFF
--- a/crates/inference/src/grammar/pda.rs
+++ b/crates/inference/src/grammar/pda.rs
@@ -28,6 +28,34 @@
 //!
 //! The root rule has id 0 (by convention enforced by `CompiledGrammar`).
 //!
+//! # The UTF-8 contract, and where it stops
+//!
+//! **This automaton matches BYTES, not characters.** `Symbol::AnyByte`, which is what
+//! GBNF `.` and `[^...]` compile to, accepts any of the 256 byte values. That includes
+//! `0xFF`, which is not legal anywhere in UTF-8, and lone `0x80..=0xBF` continuation
+//! bytes. It is deliberate: byte-level `.` is GBNF's established meaning, and narrowing
+//! it to "one UTF-8 scalar" would silently change the language accepted by every grammar
+//! ported from a byte-level GBNF implementation.
+//!
+//! The consequence is a seam that neither side of it used to name. A grammar built from
+//! `.` or `[^...]` can accept a byte sequence that is not well-formed UTF-8; the
+//! detokenizer then renders those bytes through `String::from_utf8_lossy`, substituting
+//! `U+FFFD`. **So the returned string is not necessarily the byte sequence this automaton
+//! validated, and re-validating that string against the same grammar can fail.** What
+//! grammar-constrained decoding guarantees is a property of the emitted bytes, not of the
+//! decoded string.
+//!
+//! Two things bound that in practice, and both are checkable rather than hoped for:
+//!
+//! * A grammar that uses neither `.` nor a negated class cannot reach the case at all,
+//!   because every other terminal names one specific byte.
+//! * The JSON-schema compiler does not use `AnyByte` for string contents. It models
+//!   well-formed 2/3/4-byte UTF-8 with the correct lead and continuation ranges
+//!   (issue #931), so schema-constrained output is valid UTF-8 by construction and its
+//!   decoded string does re-validate.
+//!
+//! The other end of the seam is documented on `tokenizer::detokenize::decode_tokens`.
+//!
 //! # State machine encoding
 //!
 //! A `GrammarState` encodes the full PDA configuration:

--- a/crates/inference/src/tokenizer/detokenize.rs
+++ b/crates/inference/src/tokenizer/detokenize.rs
@@ -26,6 +26,18 @@ fn append_token_bytes(
 }
 
 /// Decode token IDs back to text using the BPE tokenizer's reverse lookup.
+///
+/// **Lossy by contract, and silently so.** Byte-level BPE can emit any byte sequence, so
+/// the assembled bytes are converted with `String::from_utf8_lossy`: anything not
+/// well-formed UTF-8 becomes `U+FFFD`, and the return type carries no signal that any
+/// substitution happened.
+///
+/// That matters under grammar-constrained decoding, because the grammar validates BYTES.
+/// A GBNF grammar using `.` or `[^...]` can accept a non-UTF-8 sequence, and the string
+/// returned here is then not the sequence the grammar accepted, so it may not re-validate
+/// against that same grammar. JSON-schema-constrained output is unaffected: that compiler
+/// models well-formed UTF-8 explicitly, so no substitution can occur. The full statement
+/// of the seam is in the `grammar::pda` module documentation.
 pub(crate) fn decode_tokens(tokenizer: &BpeTokenizer, ids: &[u32]) -> String {
     let byte_decoder = build_byte_decoder();
     let mut bytes = Vec::new();


### PR DESCRIPTION
## The seam

Grammar-constrained decoding validates **bytes**. `Symbol::AnyByte` — what GBNF `.` and `[^...]`
compile to — accepts all 256 byte values, including `0xFF`, which is legal nowhere in UTF-8, and
lone `0x80..=0xBF` continuation bytes.

The detokenizer then renders whatever was emitted through `String::from_utf8_lossy`, substituting
`U+FFFD`, and the return type carries no signal that substitution occurred.

So for a grammar built from `.` or a negated class, **the returned string is not necessarily the
byte sequence the automaton validated, and re-validating that string against the same grammar can
fail.** Neither side of the seam said so. Each side is separately reasonable, which is what makes
this easy to miss: the automaton is correct to be byte-level, and the decoder is correct to be
lossy.

## Documented, not changed

Narrowing `.` to "one UTF-8 scalar" would silently change the language accepted by every grammar
ported from a byte-level GBNF implementation. A stated limit is the better outcome than a quiet
semantic change to an established notation.

## Two bounds, both checkable rather than asserted

- A grammar that uses neither `.` nor a negated class **cannot reach the case at all**, because
  every other terminal names one specific byte.
- The JSON-schema compiler does **not** use `AnyByte` for string contents. It models well-formed
  2/3/4-byte UTF-8 with the correct lead and continuation ranges (issue #931), so
  schema-constrained output is valid UTF-8 by construction and its decoded string does re-validate.
  This was checked at source, not assumed — the same issue had previously fixed a rule where the
  escape alternative *was* `'\' + AnyByte`.

## bench-compare disposition

**No benchmark was run, and none is owed: this change cannot affect performance because it changes
no code.**

The evidence is mechanical rather than a claim about intent. Diffing the PR head against `main`
over `crates/` and discarding every line that begins with `//!` or `///` leaves **zero** changed
lines, against a control of **40** total changed lines proving the diff was actually read:

```
git diff -U0 origin/main 256a8646fb -- crates/ | grep -E '^[+-]' | grep -v '^[+-][+-]' \
  | grep -vE '^[+-]\s*(//!|///)' | wc -l     ->  0      (non-comment changed lines)
git diff -U0 origin/main 256a8646fb -- crates/ | grep -E '^[+-]' | grep -v '^[+-][+-]' \
  | wc -l                                    ->  40     (control: total changed lines)
```

Doc comments do not reach codegen, so effective source is identical and a before/after comparison
could only measure harness noise. This is the ADR-058 structural exception; no `cfg` gate is
involved, because nothing outside comments changed.

If a reviewer wants the run anyway, say so and I will queue it — but note it would be an A/A, and
this repository's own harness null is wide enough that such a run is more likely to produce a
misleading number than an informative one.

## Scope

Nothing here changes what is accepted or emitted. If the silent-substitution property should
instead become *detectable* — a decode path that reports whether `U+FFFD` was substituted, so a
caller under a grammar constraint can tell the returned string is not the validated bytes — that is
a behaviour change and belongs in its own PR.
