### PR TITLE
docs: withdraw three timing ratios that were measured against a sleeping machine

### DIFF
--- a/crates/tune/src/train_support/full_driver.rs
+++ b/crates/tune/src/train_support/full_driver.rs
@@ -1035,10 +1035,24 @@ pub fn run(config: FullDriverConfig) -> Result<FullDriverOutcome, Box<dyn std::e
     };
 
     // These two passes are reported because they are real work that used to print nothing at all.
-    // Measured on a representative run, the phases outside the step-loop clock cover roughly 46% of
-    // the run, so a cost model built from the step loop alone understates by a term that grows with
-    // the pool and the held-out size. Every phase now states its own duration, which makes an
-    // external wall clock a CHECK on this log rather than the only place the time can be found.
+    // A cost model built from the step-loop clock alone understates by a term that grows with the
+    // pool and the held-out size, so every phase states its own duration and an external wall clock
+    // becomes a CHECK on this log rather than the only place the time can be found.
+    //
+    // THE "ROUGHLY 46% OF THE RUN" FIGURE THIS COMMENT CARRIED IS WITHDRAWN. It was a ratio of
+    // phase time to WALL time taken on a machine that thermally sleeps under load, and a sleep
+    // inflates the denominator without touching the numerator: `Instant` is `mach_absolute_time`
+    // and does not advance while the machine is asleep. That ratio therefore measured the box's
+    // thermal behaviour mixed with this code's instrumentation gap, and the two cannot be
+    // separated after the fact. The gap it described is real and was verified at source; only its
+    // size came from the bad instrument.
+    //
+    // Replacement, from one externally stamped run at max-train 32 / max-valid 22 — named rather
+    // than called "representative", because that word is not checkable: prologue phases totalled
+    // 1895.4s (model load 3.7, prefix cache 959.9, held-out cache 350.5, consistency check 23.2,
+    // baseline train 354.6, baseline held-out 203.5) against 533s inside the step loop. The phases
+    // outside the loop are the large majority of the work, which is a stronger claim than the
+    // withdrawn one rather than a weaker one.
     let tbase_train = Instant::now();
     let base_nll = eval_chain_nll(&caches, &layers, &loras, &gdn_loras, &head, &train_ctx)?;
     let base_train_secs = tbase_train.elapsed().as_secs_f64();

--- a/scripts/microlora/run_w1.sh
+++ b/scripts/microlora/run_w1.sh
@@ -52,8 +52,13 @@ done
 [ -x "$BIN" ] || { echo "not executable: $BIN" >&2; exit 2; }
 TIMER="$(cd "$(dirname "$0")" && pwd)/time_run.sh"
 # The trainer's own "in Xs" figure is its step loop only and omits the model load, the held-out
-# cache build and both baseline scoring passes; measured on a representative run it covered 42%
-# of the wall clock. Any duration this script leaves behind must therefore come from an external clock.
+# cache build and both baseline scoring passes. Any duration this script leaves behind must
+# therefore come from an external clock.
+#
+# The "42% of the wall clock" figure this line used to carry is WITHDRAWN. It was a ratio of the
+# trainer's own clock to WALL clock, measured on a machine that thermally sleeps under load; a
+# sleep inflates wall while the trainer's clock does not advance, so the ratio measured the box as
+# much as the trainer. The omission it described is real and was verified against the source.
 [ -x "$TIMER" ] || { echo "REFUSED: $TIMER missing; wall clocks would be loop-only" >&2; exit 2; }
 [ -f "$DATA/train.jsonl" ] && [ -f "$DATA/valid.jsonl" ] || { echo "need train.jsonl and valid.jsonl under $DATA" >&2; exit 2; }
 

--- a/scripts/microlora/timing2pt.sh
+++ b/scripts/microlora/timing2pt.sh
@@ -11,10 +11,19 @@
 #
 # WHAT THIS VERSION FIXES, and it would have produced a confidently wrong number. The previous
 # version reported `total=${t}s` where t was scraped from the trainer's own `in Xs ===` line. That
-# figure is the STEP LOOP ONLY. Measured on a representative run: model load 4.3s, prefix cache
-# 312.9s, step loop 1088.8s, total accounted 1406.0s against a wall span of about 2590s. The
-# held-out cache build and both baseline scoring passes print NO duration at all, so roughly 1184s,
-# 46% of the arm, was invisible, and the self-report covered 42% of the run.
+# figure is the STEP LOOP ONLY: the held-out cache build and both baseline scoring passes printed
+# no duration at all, which was verified by reading the driver rather than inferred from a clock.
+#
+# THE ARITHMETIC THIS PARAGRAPH CARRIED IS WITHDRAWN: "total accounted 1406.0s against a wall span
+# of about 2590s, so roughly 1184s, 46% of the arm, was invisible, and the self-report covered 42%
+# of the run." The 1184s was a wall-minus-accounted residual on a machine that thermally sleeps
+# under load, and that machine's own sleep log records single events of 388s, 556s and 864s on the
+# day in question. A residual of that size in a span of that size is indistinguishable from one or
+# two sleeps, so it cannot be attributed to missing instrumentation. `Instant` does not advance
+# while the machine sleeps, so a sleep enlarges the residual by its full duration.
+#
+# What survives, and it is the part this script acts on: the reported figure covers the step loop
+# only, so a total must come from an external clock around the whole process.
 #
 # The failure would not have looked like a failure: both points would have been understated by their
 # own prologues while the DIFFERENCE still isolated scoring passes correctly inside the timed


### PR DESCRIPTION
## One measurement, quoted in three places, taken against a sleeping machine

Three committed comments carried the same run: accounted phase time **1406.0s** against a wall span
of about **2590s**, written up as *"roughly 1184s, 46% of the arm, was invisible, and the self-report
covered 42% of the run."*

Every one of those is a ratio of a phase clock to a **wall** clock, and they were measured on a
machine that thermally sleeps under load. That machine's own sleep log records single events of
**388s, 556s and 864s** on the day in question.

`Instant` is `mach_absolute_time` and does not advance while the machine is asleep, so a sleep
inflates the denominator by its full duration and leaves the numerator untouched. **A 1184s residual
inside a 2590s span is indistinguishable from one or two sleeps**, so it cannot be attributed to
missing instrumentation. Withdrawn in all three places.

## What survives, and why

The conclusion those comments support is unaffected: the reported figure covers the step loop only,
and the held-out cache build and both baseline scoring passes printed no duration at all.

**That was established by reading the driver, not by a clock** — which is exactly why it survives
the clock turning out to be wrong. The instrument produced the magnitude, not the finding.

## The replacement names its run

The withdrawn figures called their source "a representative run", which is not a checkable claim.
The replacements name conditions instead: one externally stamped run at `--max-train 32`
`--max-valid 22`, prologue phases totalling **1895.4s** (model load 3.7, prefix cache 959.9,
held-out cache 350.5, consistency check 23.2, baseline train 354.6, baseline held-out 203.5) against
**533s** inside the step loop.

That states the case more strongly than the withdrawn number did, not more weakly.

## bench-compare disposition

**No benchmark was run and none is owed: this changes no code.**

Mechanical evidence rather than an assertion of intent — diffing the head against `main` and
discarding every line beginning with `//` or `#` leaves zero changed lines, against a control
proving the diff was actually read:

```
git diff -U0 origin/main 851f4dada7c5685e953db011dcd62a655442d9f1 | grep -E '^[+-]' | grep -v '^[+-][+-]' \
  | grep -vE '^[+-][[:space:]]*(//|#)' | wc -l   ->   0    (non-comment changed lines)
git diff -U0 origin/main 851f4dada7c5685e953db011dcd62a655442d9f1 | grep -E '^[+-]' | grep -v '^[+-][+-]' | wc -l
                                                 ->  48    (control: total changed lines)
```

Comments do not reach codegen, so effective source is identical and any before/after run could only
measure harness noise. ADR-058 structural exception; no `cfg` gate is involved because nothing
outside comments changed.

Both shell scripts were re-checked with `bash -n` and the Rust file with `rustfmt --check`, since
a comment edit can still break a parse.
