### PR TITLE
test(embed): assert exact equality in the INT8 SIMD parity tests

### DIFF
--- a/crates/embed/src/simd/quantized.rs
+++ b/crates/embed/src/simd/quantized.rs
@@ -1100,7 +1100,7 @@ mod simd_parity_tests {
 
             let diff = (neon - scalar).abs();
             assert!(
-                diff <= 1.0,
+                diff == 0.0,
                 "NEON vs scalar i8 dot product dim={dim}: neon={neon} scalar={scalar} diff={diff}"
             );
         }
@@ -1126,10 +1126,12 @@ mod simd_parity_tests {
 
                 let diff = (avx2 - scalar).abs();
                 assert!(
-                    diff <= 1.0,
+                    diff == 0.0,
                     "AVX2 vs scalar i8 dot product dim={dim}: avx2={avx2} scalar={scalar} diff={diff}"
                 );
             }
+        } else {
+            eprintln!("skipping AVX2 parity test: avx2 not available");
         }
     }
 
@@ -1159,10 +1161,12 @@ mod simd_parity_tests {
 
                 let diff = (vnni - scalar).abs();
                 assert!(
-                    diff <= 1.0,
+                    diff == 0.0,
                     "VNNI vs scalar i8 dot product dim={dim}: vnni={vnni} scalar={scalar} diff={diff}"
                 );
             }
+        } else {
+            eprintln!("skipping VNNI parity test: avx512f/bw/vnni not available");
         }
     }
 }


### PR DESCRIPTION
The three INT8 dot-product parity tests accepted `(simd - scalar).abs() <= 1.0`. Both sides of every one of those comparisons are exact integers, so the tolerance was strictly looser than the kernel contract permits: a kernel wrong by exactly one in its integer accumulator passed.

## Why equality is the right oracle

1. Both sides consume the **same** already-quantized `i8` slices (`a_q.data`, `b_q.data`). Neither re-quantizes, so there is no quantization error to absorb.
2. All three kernels accumulate in `i32` and cast exactly once at the end, `(sum + remainder) as f32` — `quantized.rs:582`, `:676`, `:766`. There is no other floating-point arithmetic in any of the three kernel bodies.
3. The scalar oracle does the same: `.map(|(&x, &y)| x as i32 * y as i32).sum::<i32>() as f32`.
4. The largest tested dimension is 768, so the largest magnitude any valid sum can reach is `768 * 127^2 = 12_387_072`, below `2^24 = 16_777_216`. Both casts are exact, so any difference between the two sides is an integer.

Since the difference is always an integer, `<= 1.0` admitted exactly the failure a parity test exists to catch and admitted nothing else. Equality strictly increases what the test can detect and cannot introduce flakiness, because there is no floating-point reassociation on either path. The failure messages are unchanged, so a mismatch still reports both operands and the dimension.

## Visible skips on the two x86 tests

`test_i8_avx2_scalar_parity` and `test_i8_avx512vnni_scalar_parity` wrap their whole body in a runtime feature check with no `else`. On a CPU without the feature they returned green having asserted nothing, and silently — unlike `test_i8_neon_scalar_parity`, which prints `skipping SDOT parity test`. Both now print a skip line in the same shape.

#1501 named only the VNNI test for this second point. AVX2 has the identical hole three lines away in the same file and gets the same one-line arm.

## Verification

Expected result is unchanged (green) on both an aarch64 and an x86_64 runner, unless a kernel currently carries an off-by-one, in which case the tightened assertion is what surfaces it. CI is the gate here: `cargo test -p lattice-embed` was not run locally.

Closes #1501

## bench-compare disposition

**N/A — compiled out. The change is entirely inside a `#[cfg(test)]` module, so the effective source of every non-test build, benches included, is identical.**

Proof rather than assertion:

- The cfg gate is `#[cfg(test)]` at `crates/embed/src/simd/quantized.rs:864`, directly above `mod simd_parity_tests {` at :865. The module's closing brace is line 1172, which is the last line of the file — nothing follows it.
- Every hunk in this PR falls inside that range. `git diff -U0` hunk headers: `@@ -1103 +1103 @@`, `@@ -1129 +1129 @@`, `@@ -1132,0 +1133,2 @@`, `@@ -1162 +1164 @@`, `@@ -1165,0 +1168,2 @@` — and each one names `mod simd_parity_tests` as its enclosing context.
- The benchmark that covers this code is `crates/embed/benches/simd.rs`, built by `cargo bench`, a non-test profile in which `cfg(test)` is false. None of the three kernels (`dot_product_i8_neon_unrolled`, `dot_product_i8_avx2_unrolled`, `dot_product_i8_avx512vnni`) or their dispatch is touched.

So there is no benchable source change to measure, and a bench-compare A/B here would be an A/A by construction.
