### PR TITLE
perf(tune): parallelize frozen-prefix cache construction across samples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1656,6 +1656,7 @@ dependencies = [
  "lattice-inference",
  "parking_lot",
  "proptest",
+ "rayon",
  "rusqlite",
  "safetensors",
  "serde",

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -41,6 +41,7 @@ chrono.workspace = true
 sha2.workspace = true
 arc-swap.workspace = true
 parking_lot.workspace = true
+rayon = { workspace = true }
 
 # GPU dependencies (optional)
 wgpu = { version = "23.0", optional = true }

--- a/crates/tune/src/train_support/full_driver.rs
+++ b/crates/tune/src/train_support/full_driver.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 
 use lattice_inference::model::qwen35::Qwen35Model;
 use lattice_inference::tokenizer::Tokenizer;
+use rayon::prelude::*;
 
 use crate::lora::AdamState;
 use crate::lora::train_core::{
@@ -15,6 +16,11 @@ use crate::lora::train_core::{
 
 use super::{Sample, load_jsonl, verify_tbv};
 
+const _: () = {
+    const fn _assert_sync<T: Sync>() {}
+    _assert_sync::<Qwen35Model>();
+};
+
 /// Capture the frozen-prefix output (h_in entering `first_layer`) and RoPE
 /// tables per sample, yielding the `SeqCtx` set the tape forward consumes.
 /// Returns the caches plus the total number of masked completion positions.
@@ -23,22 +29,23 @@ fn build_caches(
     samples: &[Sample],
     first_layer: usize,
 ) -> Result<(Vec<SeqCtx>, usize), Box<dyn std::error::Error>> {
-    let mut caches = Vec::with_capacity(samples.len());
-    let mut total_positions = 0usize;
-    for s in samples {
-        let (h_in, _real_out) = model.capture_attn_io(&s.tokens, first_layer)?;
-        let seq_len = s.tokens.len();
-        let (cos, sin) = model.rope_cos_sin_tables(seq_len)?;
-        total_positions += seq_len - s.completion_start;
-        caches.push(SeqCtx {
-            h_in,
-            cos,
-            sin,
-            tokens: s.tokens.clone(),
-            completion_start: s.completion_start,
-            seq_len,
-        });
-    }
+    let caches = samples
+        .par_iter()
+        .map(|s| {
+            let (h_in, _real_out) = model.capture_attn_io(&s.tokens, first_layer)?;
+            let seq_len = s.tokens.len();
+            let (cos, sin) = model.rope_cos_sin_tables(seq_len)?;
+            Ok(SeqCtx {
+                h_in,
+                cos,
+                sin,
+                tokens: s.tokens.clone(),
+                completion_start: s.completion_start,
+                seq_len,
+            })
+        })
+        .collect::<Result<Vec<_>, lattice_inference::InferenceError>>()?;
+    let total_positions = caches.iter().map(|s| s.seq_len - s.completion_start).sum();
     Ok((caches, total_positions))
 }
 
@@ -687,10 +694,11 @@ pub fn run(config: FullDriverConfig) -> Result<FullDriverOutcome, Box<dyn std::e
     let tcache = Instant::now();
     let (caches, total_positions) = build_caches(&model, &train_samples, first_layer)?;
     println!(
-        "  {} completion positions across {} samples in {:.1}s",
+        "  {} completion positions across {} samples in {:.1}s ({} threads)",
         total_positions,
         caches.len(),
-        tcache.elapsed().as_secs_f64()
+        tcache.elapsed().as_secs_f64(),
+        rayon::current_num_threads()
     );
 
     // Hold out valid.jsonl from training; compare its NLL to the training NLL.
@@ -707,9 +715,10 @@ pub fn run(config: FullDriverConfig) -> Result<FullDriverOutcome, Box<dyn std::e
                 let tvalid = Instant::now();
                 let (vc, vpos) = build_caches(&model, &vs, first_layer)?;
                 println!(
-                    "  held-out: {vpos} completion positions across {} valid samples in {:.1}s",
+                    "  held-out: {vpos} completion positions across {} valid samples in {:.1}s ({} threads)",
                     vc.len(),
-                    tvalid.elapsed().as_secs_f64()
+                    tvalid.elapsed().as_secs_f64(),
+                    rayon::current_num_threads()
                 );
                 vc
             }


### PR DESCRIPTION
> _PR description authored by Claude (Anthropic agent) on behalf of @ohdearquant._

## Summary

- `build_caches` in the exact-gradient trainer built one frozen-prefix cache per sample in a serial loop. It now uses `rayon`'s indexed `par_iter`, so the per-sample `capture_attn_io` + `rope_cos_sin_tables` work spreads across cores.
- **No speedup is claimed here.** See "Out of scope" for why, and for the bar a future measurement has to clear.
- The motivation is a measurement, not an assumption: over 254 one-second samples covering model load, both cache builds, the TBV check and the scoring passes, the trainer's `ps -o pcpu` never exceeded 100.0 on a 10-core macOS host (mean 96.9, zero samples above 110). It was using one core end to end. Contention on that host can only push `pcpu` down, so a ceiling observed under load is a ceiling.
- Safety is enforced by the compiler rather than asserted in a comment. `capture_attn_io(&self, ..)` and `rope_cos_sin_tables(&self, ..)` both take `&self` and allocate every piece of mutable state (`gdn_states`, `kv_cache`, `scratch`) inside the call, and a `const _: () = { const fn _assert_sync<T: Sync>() {} _assert_sync::<Qwen35Model>(); };` turns the `Sync` requirement into a build error if a future field breaks it.
- Ordering and totals are unchanged by construction: indexed `par_iter().map(..).collect::<Result<Vec<_>, _>>()` preserves input order, and `total_positions` is now summed from the collected vector instead of accumulated inside the loop, so no value crosses threads.
- Both cache-phase lines now print `rayon::current_num_threads()`, so a run states its own worker count instead of leaving it to be inferred.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p lattice-tune --all-targets --features train-backward -- -D warnings` — clean, 0 warnings (forced re-check, `Checking lattice-tune` present in the log rather than a cached "Finished")
- [x] `cargo build --release -p lattice-tune --features train-backward --bin train_grad_full` — clean
- [x] **Numeric identity across worker counts.** The same 8-sample run (`--seed 1`, same data, same hyperparameters) at `RAYON_NUM_THREADS=1` and `RAYON_NUM_THREADS=4`, compared after stripping wall-clock timings and the thread count, is byte-identical:

```
  150 completion positions across 8 samples
  held-out: 102 completion positions across 4 valid samples
  TBV (sample 0): model=5.15182  chain=5.15182  diff=0.00e0
  step    0  train NLL: 4.8968  held-out NLL: 4.4687
  step    1  train NLL: 4.8121  held-out NLL: 4.4251  (train d -0.0847)
  step    2  train NLL: 4.6891  held-out NLL: 4.3492  (train d -0.2077)
=== done: train 4.8968→4.6891 (-0.2077)  |  held-out 4.4687→4.3492 (-0.1196)  ===
```

- [x] **The identity check can express a difference.** An empty diff is also what a broken comparison prints, so the same comparison was run against an arm that differs only in `--seed 2`. It moves exactly the three lines it should — the two per-step NLL lines and the final summary — and leaves the completion counts and the TBV line untouched. Without this control the block above would not be evidence of anything.
- [ ] `cargo test --workspace` — left to CI. Note that the feature-matrix job builds this crate's `train-backward` surface with `--no-run`, so the behavioural check for this change is the two runs above, not the test suite.

## ADR

n/a — no architectural change, no new contract.

Bench-compare disposition: not required (the diff touches no `crates/{inference,embed,fann}` path) and none is offered, because this PR claims no performance number.

## AI-assisted contribution checklist

- [x] Every claim in this PR description matches the actual diff
- [x] No SIMD intrinsics in this diff
- [x] Attribution line present
- [x] Behavioural evidence included above; no bench output, because no perf claim is made

## Out of scope

- **No speedup number.** Wall-clock timings were observed while verifying the change, and they are deliberately not reported: the host was contended by other builds throughout, and one arm read *super-linear* in the worker count, which is itself evidence the readings are noise rather than a result. A real measurement needs a quiet host and is not in this PR.
- **The bar for that measurement, stated before it runs so it cannot be re-read later as "needs tuning":** at 4 workers on a quiet host, if a sample-parallel cache build does not beat the serial build by at least **2x wall clock** on identical inputs, then the shared-AMX-per-cluster explanation wins over the parallelism explanation, and this direction stops rather than being tuned.
- **No worker cap.** `check_cache_budget` runs before the build and bounds the *resident* cache set, which is unchanged — the same caches are produced either way. What parallelism adds is *transient* per-worker forward state (a `GatedDeltaNetState` set, `KvCache` and `ForwardScratch` per in-flight sample, N live at once instead of 1), and nothing bounds that today. Sizing a cap for small-memory hosts depends on the measurement above.
- The scoring pass and the backward tape are untouched; only cache construction is parallel.
