### PR TITLE
build: pre-commit skips the workspace compile when no Rust is staged, and locks it when it does

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,27 +1,141 @@
 #!/bin/sh
 set -e
 
+# `cargo clippy --workspace --all-targets` compiles the whole workspace. Paying
+# that to commit a markdown file costs minutes, and on a shared machine it
+# competes with every other build running there. So this hook decides whether the
+# staged changes can reach the Rust gates at all, and when they can, it takes a
+# lock itself rather than trusting every call site to remember one.
+#
+# The lock path is configurable and defaults to a repo-local name in the system
+# temp dir. Set LATTICE_BUILD_LOCK to join a wider lane -- a machine that also
+# runs other heavy Rust builds wants them all on one lock, not one per repo.
+
+LOCK_EXPLICIT=${LATTICE_BUILD_LOCK+set}
+LOCK_DIR="${TMPDIR:-/tmp}"
+LOCK="${LATTICE_BUILD_LOCK:-${LOCK_DIR%/}/lattice-build.lock}"
+
+# Reads staged path names on stdin, one per line. Exit 0 means "the Rust gates
+# can see this commit".
+#
+# An EMPTY or blank-only list also exits 0, deliberately. A discovery that can be
+# silently emptied is a gate that skips itself, and here the two failure
+# directions are not symmetric: running the build when it was not needed wastes
+# minutes, while skipping it when it WAS needed lands unformatted code with no
+# signal that anything was skipped.
+needs_rust_gates() {
+    names=$(cat)
+    if ! printf '%s\n' "$names" | grep -q '[^[:space:]]'; then
+        return 0
+    fi
+    printf '%s\n' "$names" | grep -qE \
+        '\.rs$|(^|/)(Cargo\.(toml|lock)|rust-toolchain(\.toml)?|rustfmt\.toml|clippy\.toml)$|(^|/)\.cargo/config(\.toml)?$'
+}
+
+# Invoked by the flock wrapper below as a fresh process, which is why it is a
+# flag on this script rather than a shell function: flock runs a command, and a
+# command cannot be a function of the caller.
+if [ "${1:-}" = "--run-rust-gates" ]; then
+    if ! cargo fmt --all -- --check; then
+        echo "Format check failed. Run 'make fmt' to fix."
+        exit 1
+    fi
+    if ! cargo clippy --workspace --all-targets -- -D warnings; then
+        echo "Clippy check failed. Fix warnings before committing."
+        exit 1
+    fi
+    exit 0
+fi
+
+# --selftest exercises the decision against fixed inputs and exits. It runs no
+# cargo and takes no lock, so it is safe on a loaded machine and in CI.
+if [ "${1:-}" = "--selftest" ]; then
+    fail=0
+    check() {
+        if [ "$2" = "$3" ]; then printf '  PASS  %s\n' "$1"
+        else printf '  FAIL  %s: expected %s, got %s\n' "$1" "$2" "$3"; fail=1; fi
+    }
+    decide() { printf '%s' "$1" | { needs_rust_gates && echo rust || echo docs; }; }
+
+    for row in \
+        'src/lib.rs|rust' \
+        'crates/inference/src/model/qwen35/eval.rs|rust' \
+        'Cargo.toml|rust' \
+        'Cargo.lock|rust' \
+        'crates/tune/Cargo.toml|rust' \
+        'rust-toolchain.toml|rust' \
+        'rustfmt.toml|rust' \
+        'clippy.toml|rust' \
+        '.cargo/config.toml|rust' \
+        'README.md|docs' \
+        'docs/adr/ADR-058.md|docs' \
+        '.githooks/pre-commit|docs' \
+        'scripts/lint-docs.sh|docs' \
+        'notes/rustacean.md|docs' \
+        'src/rsync-notes.txt|docs' \
+        'src.rs.backup/readme.md|docs' \
+        ; do
+        want=${row#*|}
+        check "${row%|*}" "$want" "$(decide "${row%|*}")"
+    done
+    # A docs-only commit must stay docs even when it is large, and one Rust file
+    # anywhere in a large docs commit must flip it. Both directions, because a
+    # matcher that always says "rust" would pass every arm above.
+    check "many docs files stay docs" "docs" "$(decide 'a.md
+b.md
+c.txt')"
+    check "one .rs among docs flips to rust" "rust" "$(decide 'a.md
+b.md
+crates/x/src/y.rs')"
+    # The arm that protects the gate from itself.
+    check "EMPTY staged list runs the full build" "rust" "$(decide '')"
+    check "blank-only staged list runs the full build" "rust" "$(decide '
+
+')"
+    if [ "$fail" -eq 0 ]; then echo "all selftest arms passed"; else echo "SELFTEST FAILED"; fi
+    exit "$fail"
+fi
+
 echo "Running pre-commit checks..."
 
-# Tooling
 if ! cargo fmt --version >/dev/null 2>&1 || ! cargo clippy --version >/dev/null 2>&1; then
     echo "rustfmt or clippy is unavailable. Run 'make setup' to install both."
     exit 1
 fi
 
-# Format check
-if ! cargo fmt --all -- --check; then
-    echo "Format check failed. Run 'make fmt' to fix."
-    exit 1
+STAGED=$(git diff --cached --name-only --diff-filter=ACMRD) || STAGED=""
+
+if printf '%s' "$STAGED" | needs_rust_gates; then
+    if command -v flock >/dev/null 2>&1; then
+        echo "  Rust gates REQUIRED for these changes; waiting up to 1800s for $LOCK"
+        if flock -o -w 1800 -E 75 "$LOCK" "$0" --run-rust-gates; then
+            :
+        else
+            rc=$?
+            if [ "$rc" -eq 75 ]; then
+                echo "Did not get the build lock at $LOCK within 1800s. Holder:"
+                /usr/sbin/lsof "$LOCK" 2>/dev/null || lsof "$LOCK" 2>/dev/null || \
+                    echo "  (could not read the holder; lsof unavailable)"
+                exit 1
+            fi
+            exit "$rc"
+        fi
+    elif [ -n "$LOCK_EXPLICIT" ]; then
+        # Refusing rather than proceeding: someone named a lock, so something is
+        # being protected, and running unlocked would defeat it silently.
+        echo "LATTICE_BUILD_LOCK is set to $LOCK but no flock binary is on PATH."
+        echo "Install flock (util-linux) or unset LATTICE_BUILD_LOCK to build unlocked."
+        exit 1
+    else
+        echo "  Rust gates REQUIRED for these changes; no flock on PATH, running UNLOCKED"
+        "$0" --run-rust-gates
+    fi
+else
+    echo "  Rust gates SKIPPED: no .rs, Cargo, toolchain or lint-config file is staged"
 fi
 
-# Clippy
-if ! cargo clippy --workspace --all-targets -- -D warnings; then
-    echo "Clippy check failed. Fix warnings before committing."
-    exit 1
-fi
-
-# Doc lint
+# Runs on BOTH branches. A commit with no Rust in it is exactly the markdown case
+# this check exists for, so it must never ride on the skip above.
 ./scripts/lint-docs.sh
 
 echo "Pre-commit checks passed."

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -113,9 +113,15 @@ if printf '%s' "$STAGED" | needs_rust_gates; then
         else
             rc=$?
             if [ "$rc" -eq 75 ]; then
-                echo "Did not get the build lock at $LOCK within 1800s. Holder:"
+                echo "Did not get the build lock at $LOCK within 1800s."
+                # NOT "the holder": lsof reports every process with the lock file
+                # OPEN, and a waiter opens the file before it blocks in flock(2).
+                # Measured on the fleet lock: four flock processes listed, one
+                # holding. So this is a candidate list, and the oldest elapsed
+                # time is a hint, not the answer.
+                echo "Processes with $LOCK open (holder + waiters, in no order):"
                 /usr/sbin/lsof "$LOCK" 2>/dev/null || lsof "$LOCK" 2>/dev/null || \
-                    echo "  (could not read the holder; lsof unavailable)"
+                    echo "  (could not list them; lsof unavailable)"
                 exit 1
             fi
             exit "$rc"


### PR DESCRIPTION
## The problem

`.githooks/pre-commit` ran `cargo fmt --check` and `cargo clippy --workspace --all-targets`
on **every** commit, including markdown-only ones, and it took no lock. Two consequences on a
developer machine:

- a docs typo fix pays for a full workspace compile;
- two commits (or a commit and a build) can start full workspace compiles against the same
  target directory at the same time.

## The change

1. **Rust gates run only when Rust is staged.** A staged path counts if it is `*.rs`, or its
   basename is `Cargo.toml`, `Cargo.lock`, `rust-toolchain[.toml]`, `rustfmt.toml`,
   `clippy.toml`, or it lives at `.cargo/config[.toml]`. Otherwise the hook prints
   `Rust gates SKIPPED` and moves on.
2. **When they do run, they run under a lock.** `flock -o -w 1800` on `$LATTICE_BUILD_LOCK`,
   defaulting to `${TMPDIR:-/tmp}/lattice-build.lock` — a repo-neutral name, so the default
   costs nothing to anyone who does not opt in. Setting the variable joins a wider lane on a
   machine that serialises builds across repositories.
3. **Doc lint runs on both branches.** A commit with no Rust in it is exactly the case
   `scripts/lint-docs.sh` exists for, so it must not ride on the skip.
4. **`--selftest`** exercises the classifier and the lock policy: 20 arms, all green.

## Fail-closed points

- **An empty or unreadable staged list runs the FULL build.** `git diff --cached` failing, or
  returning nothing, must not be readable as "no Rust staged" — a discovery that can be
  silently emptied is a gate that skips itself. Two selftest arms cover this (`EMPTY staged
  list runs the full build`, `blank-only staged list runs the full build`).
- **`LATTICE_BUILD_LOCK` set with no `flock` on PATH is a refusal, not a fallback.** Someone
  naming a lock is protecting something; building unlocked would defeat it silently. With the
  variable unset and no `flock`, the hook warns and builds unlocked, which is the previous
  behaviour.
- **The timeout report lists candidates, not "the holder".** `lsof` names every process with
  the lock file open, and a waiter opens the file before it blocks in `flock(2)`; measured on a
  shared lock, four processes listed against one holder.

## One thing worth knowing before you use it

**Do not wrap `git commit` in an outer `flock` on the same lock name.** `flock -o` closes the
descriptor before exec, so the hook's inner `flock` does not inherit the hold and waits on its
own ancestor until the 1800s timeout. The hook is the lock's call site; nothing above it needs
to take the lock.

## Verification

- `bash .githooks/pre-commit --selftest` → 20 arms pass, 0 fail.
- Both commits on this branch were made with the new hook installed: each printed
  `Rust gates SKIPPED: no .rs, Cargo, toolchain or lint-config file is staged` and then ran the
  full doc lint (192 tracked Markdown files, plus the recursive-discovery, capability-matrix and
  absolute-path selftests).
