### PR TITLE
build: gate the Rust files cargo fmt --all cannot reach

### DIFF
--- a/npm/lattice-embed-native/src/lib.rs
+++ b/npm/lattice-embed-native/src/lib.rs
@@ -73,256 +73,259 @@ use std::sync::Arc;
 #[napi(object)]
 #[allow(non_snake_case)]
 pub struct LoadOptions {
-  pub modelPath: String,
-  pub modelId: Option<String>,
-  pub normalize: Option<bool>,
+    pub modelPath: String,
+    pub modelId: Option<String>,
+    pub normalize: Option<bool>,
 }
 
 #[napi(object)]
 pub struct EmbeddingBatch {
-  pub data: Float32Array,
-  pub rows: u32,
-  pub dimensions: u32,
-  pub normalized: bool,
+    pub data: Float32Array,
+    pub rows: u32,
+    pub dimensions: u32,
+    pub normalized: bool,
 }
 
 #[napi]
 pub struct EmbeddingModel {
-  model: Arc<BertModel>,
-  dimension: u32,
+    model: Arc<BertModel>,
+    dimension: u32,
 }
 
 #[napi]
 impl EmbeddingModel {
-  #[napi(constructor)]
-  pub fn new(options: LoadOptions) -> Result<Self> {
-    Self::from_options(options)
-  }
+    #[napi(constructor)]
+    pub fn new(options: LoadOptions) -> Result<Self> {
+        Self::from_options(options)
+    }
 
-  #[napi(getter)]
-  pub fn dimension(&self) -> u32 {
-    self.dimension
-  }
+    #[napi(getter)]
+    pub fn dimension(&self) -> u32 {
+        self.dimension
+    }
 
-  /// Always `true` in this v0 binding; see the module doc comment's
-  /// "Known v0 limitation" section for why `normalize: false` is rejected
-  /// at load time rather than silently ignored here.
-  #[napi(getter)]
-  pub fn normalized(&self) -> bool {
-    true
-  }
+    /// Always `true` in this v0 binding; see the module doc comment's
+    /// "Known v0 limitation" section for why `normalize: false` is rejected
+    /// at load time rather than silently ignored here.
+    #[napi(getter)]
+    pub fn normalized(&self) -> bool {
+        true
+    }
 
-  #[napi]
-  pub fn embed_sync(&self, text: String) -> Result<Float32Array> {
-    validate_text(&text, 0)?;
-    let output = encode_one(&self.model, &text)?;
-    Ok(output.into())
-  }
+    #[napi]
+    pub fn embed_sync(&self, text: String) -> Result<Float32Array> {
+        validate_text(&text, 0)?;
+        let output = encode_one(&self.model, &text)?;
+        Ok(output.into())
+    }
 
-  #[napi]
-  pub fn embed(&self, text: String) -> Result<AsyncTask<EmbedTask>> {
-    validate_text(&text, 0)?;
-    Ok(AsyncTask::new(EmbedTask {
-      model: Arc::clone(&self.model),
-      text,
-    }))
-  }
+    #[napi]
+    pub fn embed(&self, text: String) -> Result<AsyncTask<EmbedTask>> {
+        validate_text(&text, 0)?;
+        Ok(AsyncTask::new(EmbedTask {
+            model: Arc::clone(&self.model),
+            text,
+        }))
+    }
 
-  #[napi]
-  pub fn embed_batch_sync(&self, texts: Vec<String>) -> Result<EmbeddingBatch> {
-    validate_texts(&texts)?;
-    let output = encode_many(&self.model, &texts, self.dimension)?;
-    Ok(output.into_napi())
-  }
+    #[napi]
+    pub fn embed_batch_sync(&self, texts: Vec<String>) -> Result<EmbeddingBatch> {
+        validate_texts(&texts)?;
+        let output = encode_many(&self.model, &texts, self.dimension)?;
+        Ok(output.into_napi())
+    }
 
-  #[napi]
-  pub fn embed_batch(&self, texts: Vec<String>) -> Result<AsyncTask<BatchTask>> {
-    validate_texts(&texts)?;
-    Ok(AsyncTask::new(BatchTask {
-      model: Arc::clone(&self.model),
-      texts,
-      dimension: self.dimension,
-    }))
-  }
+    #[napi]
+    pub fn embed_batch(&self, texts: Vec<String>) -> Result<AsyncTask<BatchTask>> {
+        validate_texts(&texts)?;
+        Ok(AsyncTask::new(BatchTask {
+            model: Arc::clone(&self.model),
+            texts,
+            dimension: self.dimension,
+        }))
+    }
 }
 
 impl EmbeddingModel {
-  fn from_options(options: LoadOptions) -> Result<Self> {
-    if options.modelPath.trim().is_empty() {
-      return Err(invalid_arg("FL_EMBED_BAD_OPTIONS", "modelPath must not be empty"));
-    }
+    fn from_options(options: LoadOptions) -> Result<Self> {
+        if options.modelPath.trim().is_empty() {
+            return Err(invalid_arg(
+                "FL_EMBED_BAD_OPTIONS",
+                "modelPath must not be empty",
+            ));
+        }
 
-    // `normalize: false` cannot be honored honestly in this v0 binding --
-    // see the module doc comment. Any other value (omitted, or explicitly
-    // `true`) proceeds; the engine always L2-normalizes regardless.
-    if options.normalize == Some(false) {
-      return Err(invalid_arg(
-        "FL_EMBED_BAD_OPTIONS",
-        "normalize: false is not supported in this v0 binding -- \
+        // `normalize: false` cannot be honored honestly in this v0 binding --
+        // see the module doc comment. Any other value (omitted, or explicitly
+        // `true`) proceeds; the engine always L2-normalizes regardless.
+        if options.normalize == Some(false) {
+            return Err(invalid_arg(
+                "FL_EMBED_BAD_OPTIONS",
+                "normalize: false is not supported in this v0 binding -- \
          BertModel::encode/encode_batch always L2-normalize their output \
          and there is no public non-normalizing path in lattice-inference \
          yet; omit `normalize` or set it to true",
-      ));
-    }
+            ));
+        }
 
-    let model_path = Path::new(&options.modelPath);
-    if !model_path.is_dir() {
-      return Err(invalid_arg(
-        "FL_EMBED_BAD_MODEL",
-        format!(
-          "modelPath does not exist or is not a directory: {}",
-          options.modelPath
-        ),
-      ));
-    }
+        let model_path = Path::new(&options.modelPath);
+        if !model_path.is_dir() {
+            return Err(invalid_arg(
+                "FL_EMBED_BAD_MODEL",
+                format!(
+                    "modelPath does not exist or is not a directory: {}",
+                    options.modelPath
+                ),
+            ));
+        }
 
-    // Family (-> pooling strategy) is resolved from an explicit `modelId`
-    // override if given, else from modelPath's final path component. Both
-    // go through the same `lattice_embed::EmbeddingModel::from_str`, the
-    // real production parser (case-insensitive, accepts display names,
-    // short names, and HuggingFace ids -- see crates/embed/src/model.rs).
-    let family_hint = options
-      .modelId
-      .as_deref()
-      .filter(|s| !s.trim().is_empty())
-      .map(|s| s.to_string())
-      .or_else(|| {
-        model_path
-          .file_name()
-          .and_then(|name| name.to_str())
-          .map(|s| s.to_string())
-      })
-      .ok_or_else(|| {
-        invalid_arg(
-          "FL_EMBED_BAD_MODEL",
-          "could not determine a model identifier from modelId or modelPath's \
+        // Family (-> pooling strategy) is resolved from an explicit `modelId`
+        // override if given, else from modelPath's final path component. Both
+        // go through the same `lattice_embed::EmbeddingModel::from_str`, the
+        // real production parser (case-insensitive, accepts display names,
+        // short names, and HuggingFace ids -- see crates/embed/src/model.rs).
+        let family_hint = options
+            .modelId
+            .as_deref()
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| s.to_string())
+            .or_else(|| {
+                model_path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(|s| s.to_string())
+            })
+            .ok_or_else(|| {
+                invalid_arg(
+                    "FL_EMBED_BAD_MODEL",
+                    "could not determine a model identifier from modelId or modelPath's \
            final path component",
-        )
-      })?;
+                )
+            })?;
 
-    let family = ModelFamily::from_str(&family_hint).map_err(|err| {
-      invalid_arg(
-        "FL_EMBED_BAD_MODEL",
-        format!("unrecognized model identifier \"{family_hint}\": {err}"),
-      )
-    })?;
+        let family = ModelFamily::from_str(&family_hint).map_err(|err| {
+            invalid_arg(
+                "FL_EMBED_BAD_MODEL",
+                format!("unrecognized model identifier \"{family_hint}\": {err}"),
+            )
+        })?;
 
-    let pooling = family.bert_pooling().ok_or_else(|| {
-      invalid_arg(
-        "FL_EMBED_BAD_MODEL",
-        format!(
-          "model family \"{family}\" is not a BERT-family encoder model; \
+        let pooling = family.bert_pooling().ok_or_else(|| {
+            invalid_arg(
+                "FL_EMBED_BAD_MODEL",
+                format!(
+                    "model family \"{family}\" is not a BERT-family encoder model; \
            this v0 native binding only supports BGE/E5/MiniLM-family models \
            (Qwen and remote-API models are out of scope)"
-        ),
-      )
-    })?;
+                ),
+            )
+        })?;
 
-    let mut model = BertModel::from_directory(model_path).map_err(|err| {
-      invalid_arg(
-        "FL_EMBED_BAD_MODEL",
-        format!("failed to load model from {}: {err}", options.modelPath),
-      )
-    })?;
-    model.set_pooling(pooling);
+        let mut model = BertModel::from_directory(model_path).map_err(|err| {
+            invalid_arg(
+                "FL_EMBED_BAD_MODEL",
+                format!("failed to load model from {}: {err}", options.modelPath),
+            )
+        })?;
+        model.set_pooling(pooling);
 
-    let dimension = u32::try_from(model.dimensions()).map_err(|_| {
-      invalid_arg(
-        "FL_EMBED_BAD_MODEL",
-        "model dimension does not fit in a u32",
-      )
-    })?;
+        let dimension = u32::try_from(model.dimensions()).map_err(|_| {
+            invalid_arg(
+                "FL_EMBED_BAD_MODEL",
+                "model dimension does not fit in a u32",
+            )
+        })?;
 
-    Ok(Self {
-      model: Arc::new(model),
-      dimension,
-    })
-  }
+        Ok(Self {
+            model: Arc::new(model),
+            dimension,
+        })
+    }
 }
 
 pub struct LoadModelTask {
-  options: LoadOptions,
+    options: LoadOptions,
 }
 
 #[napi]
 impl Task for LoadModelTask {
-  type Output = EmbeddingModel;
-  type JsValue = EmbeddingModel;
+    type Output = EmbeddingModel;
+    type JsValue = EmbeddingModel;
 
-  fn compute(&mut self) -> Result<Self::Output> {
-    EmbeddingModel::from_options(self.options.clone())
-  }
+    fn compute(&mut self) -> Result<Self::Output> {
+        EmbeddingModel::from_options(self.options.clone())
+    }
 
-  fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
-    Ok(output)
-  }
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output)
+    }
 }
 
 #[napi]
 pub fn load_model_sync(options: LoadOptions) -> Result<EmbeddingModel> {
-  EmbeddingModel::from_options(options)
+    EmbeddingModel::from_options(options)
 }
 
 #[napi]
 pub fn load_model(options: LoadOptions) -> Result<AsyncTask<LoadModelTask>> {
-  Ok(AsyncTask::new(LoadModelTask { options }))
+    Ok(AsyncTask::new(LoadModelTask { options }))
 }
 
 pub struct EmbedTask {
-  model: Arc<BertModel>,
-  text: String,
+    model: Arc<BertModel>,
+    text: String,
 }
 
 #[napi]
 impl Task for EmbedTask {
-  type Output = Vec<f32>;
-  type JsValue = Float32Array;
+    type Output = Vec<f32>;
+    type JsValue = Float32Array;
 
-  fn compute(&mut self) -> Result<Self::Output> {
-    encode_one(&self.model, &self.text)
-  }
+    fn compute(&mut self) -> Result<Self::Output> {
+        encode_one(&self.model, &self.text)
+    }
 
-  fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
-    Ok(output.into())
-  }
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output.into())
+    }
 }
 
 pub struct BatchTask {
-  model: Arc<BertModel>,
-  texts: Vec<String>,
-  dimension: u32,
+    model: Arc<BertModel>,
+    texts: Vec<String>,
+    dimension: u32,
 }
 
 #[napi]
 impl Task for BatchTask {
-  type Output = BatchOutput;
-  type JsValue = EmbeddingBatch;
+    type Output = BatchOutput;
+    type JsValue = EmbeddingBatch;
 
-  fn compute(&mut self) -> Result<Self::Output> {
-    encode_many(&self.model, &self.texts, self.dimension)
-  }
+    fn compute(&mut self) -> Result<Self::Output> {
+        encode_many(&self.model, &self.texts, self.dimension)
+    }
 
-  fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
-    Ok(output.into_napi())
-  }
+    fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
+        Ok(output.into_napi())
+    }
 }
 
 pub struct BatchOutput {
-  data: Vec<f32>,
-  rows: u32,
-  dimensions: u32,
-  normalized: bool,
+    data: Vec<f32>,
+    rows: u32,
+    dimensions: u32,
+    normalized: bool,
 }
 
 impl BatchOutput {
-  fn into_napi(self) -> EmbeddingBatch {
-    EmbeddingBatch {
-      data: self.data.into(),
-      rows: self.rows,
-      dimensions: self.dimensions,
-      normalized: self.normalized,
+    fn into_napi(self) -> EmbeddingBatch {
+        EmbeddingBatch {
+            data: self.data.into(),
+            rows: self.rows,
+            dimensions: self.dimensions,
+            normalized: self.normalized,
+        }
     }
-  }
 }
 
 /// Encodes a single text through the real engine. `BertModel::encode` is
@@ -331,9 +334,9 @@ impl BatchOutput {
 /// `self`, so concurrent calls through the same `Arc<BertModel>` (e.g. many
 /// in-flight `embed()` AsyncTasks on napi's worker pool) never race.
 fn encode_one(model: &BertModel, text: &str) -> Result<Vec<f32>> {
-  model
-    .encode(text)
-    .map_err(|err| invalid_arg("FL_EMBED_BAD_MODEL", format!("encode failed: {err}")))
+    model
+        .encode(text)
+        .map_err(|err| invalid_arg("FL_EMBED_BAD_MODEL", format!("encode failed: {err}")))
 }
 
 /// Encodes a batch through the real engine's fused batched forward path
@@ -345,84 +348,84 @@ fn encode_one(model: &BertModel, text: &str) -> Result<Vec<f32>> {
 /// actual per-row output length and this wrapper's own bookkeeping, not a
 /// value this function assumes.
 fn encode_many(model: &BertModel, texts: &[String], dimension: u32) -> Result<BatchOutput> {
-  let text_refs: Vec<&str> = texts.iter().map(String::as_str).collect();
-  let rows_out = model
-    .encode_batch(&text_refs)
-    .map_err(|err| invalid_arg("FL_EMBED_BAD_MODEL", format!("encode_batch failed: {err}")))?;
+    let text_refs: Vec<&str> = texts.iter().map(String::as_str).collect();
+    let rows_out = model
+        .encode_batch(&text_refs)
+        .map_err(|err| invalid_arg("FL_EMBED_BAD_MODEL", format!("encode_batch failed: {err}")))?;
 
-  let rows = u32::try_from(rows_out.len()).map_err(|_| {
-    invalid_arg(
-      "FL_EMBED_BAD_BATCH",
-      "batch has more rows than can be represented as u32",
-    )
-  })?;
+    let rows = u32::try_from(rows_out.len()).map_err(|_| {
+        invalid_arg(
+            "FL_EMBED_BAD_BATCH",
+            "batch has more rows than can be represented as u32",
+        )
+    })?;
 
-  let mut data = Vec::with_capacity(rows_out.len() * dimension as usize);
-  for row in &rows_out {
-    data.extend_from_slice(row);
-  }
+    let mut data = Vec::with_capacity(rows_out.len() * dimension as usize);
+    for row in &rows_out {
+        data.extend_from_slice(row);
+    }
 
-  Ok(BatchOutput {
-    data,
-    rows,
-    dimensions: dimension,
-    normalized: true,
-  })
+    Ok(BatchOutput {
+        data,
+        rows,
+        dimensions: dimension,
+        normalized: true,
+    })
 }
 
 fn validate_text(text: &str, index: usize) -> Result<()> {
-  if text.is_empty() {
-    return Err(invalid_arg(
-      "FL_EMBED_EMPTY_INPUT",
-      format!("text at index {index} must not be empty"),
-    ));
-  }
+    if text.is_empty() {
+        return Err(invalid_arg(
+            "FL_EMBED_EMPTY_INPUT",
+            format!("text at index {index} must not be empty"),
+        ));
+    }
 
-  // Mirrors the production enforcement point
-  // (`crates/embed/src/service/native.rs`, `if text.len() > MAX_TEXT_BYTES`):
-  // `str::len()` is UTF-8 BYTE length, not `chars().count()`, so a
-  // multi-byte string near the boundary is accepted/rejected identically
-  // by this binding and by `NativeEmbeddingService`/`CachedEmbeddingService`.
-  if text.len() > MAX_TEXT_BYTES {
-    return Err(invalid_arg(
-      "FL_EMBED_INPUT_TOO_LARGE",
-      format!(
-        "text at index {index} is {} bytes, exceeding the maximum of {MAX_TEXT_BYTES} bytes",
-        text.len()
-      ),
-    ));
-  }
+    // Mirrors the production enforcement point
+    // (`crates/embed/src/service/native.rs`, `if text.len() > MAX_TEXT_BYTES`):
+    // `str::len()` is UTF-8 BYTE length, not `chars().count()`, so a
+    // multi-byte string near the boundary is accepted/rejected identically
+    // by this binding and by `NativeEmbeddingService`/`CachedEmbeddingService`.
+    if text.len() > MAX_TEXT_BYTES {
+        return Err(invalid_arg(
+            "FL_EMBED_INPUT_TOO_LARGE",
+            format!(
+                "text at index {index} is {} bytes, exceeding the maximum of {MAX_TEXT_BYTES} bytes",
+                text.len()
+            ),
+        ));
+    }
 
-  Ok(())
+    Ok(())
 }
 
 fn validate_texts(texts: &[String]) -> Result<()> {
-  if texts.is_empty() {
-    return Err(invalid_arg(
-      "FL_EMBED_BAD_BATCH",
-      "texts must contain at least one item",
-    ));
-  }
+    if texts.is_empty() {
+        return Err(invalid_arg(
+            "FL_EMBED_BAD_BATCH",
+            "texts must contain at least one item",
+        ));
+    }
 
-  // Checked before per-item validation below so an oversized batch fails
-  // fast on item count alone, without walking every item first.
-  if texts.len() > DEFAULT_MAX_BATCH_SIZE {
-    return Err(invalid_arg(
-      "FL_EMBED_BAD_BATCH",
-      format!(
-        "batch has {} items, exceeding the maximum of {DEFAULT_MAX_BATCH_SIZE}",
-        texts.len()
-      ),
-    ));
-  }
+    // Checked before per-item validation below so an oversized batch fails
+    // fast on item count alone, without walking every item first.
+    if texts.len() > DEFAULT_MAX_BATCH_SIZE {
+        return Err(invalid_arg(
+            "FL_EMBED_BAD_BATCH",
+            format!(
+                "batch has {} items, exceeding the maximum of {DEFAULT_MAX_BATCH_SIZE}",
+                texts.len()
+            ),
+        ));
+    }
 
-  for (index, text) in texts.iter().enumerate() {
-    validate_text(text, index)?;
-  }
+    for (index, text) in texts.iter().enumerate() {
+        validate_text(text, index)?;
+    }
 
-  Ok(())
+    Ok(())
 }
 
 fn invalid_arg(code: &str, message: impl AsRef<str>) -> Error {
-  Error::new(Status::InvalidArg, format!("{code}: {}", message.as_ref()))
+    Error::new(Status::InvalidArg, format!("{code}: {}", message.as_ref()))
 }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -12,6 +12,12 @@ export LATTICE_REQUIRE_FIXTURES
 echo "=== Format Check ==="
 cargo fmt --all -- --check
 
+# `cargo fmt --all` covers workspace members only, so a tracked .rs outside every
+# member is formatted by nothing. This names that set and rustfmt-checks it.
+echo "=== Rust Format Coverage ==="
+./scripts/lint-rust-fmt-coverage.sh --selftest
+./scripts/lint-rust-fmt-coverage.sh
+
 echo "=== Clippy ==="
 cargo clippy --workspace -- -D warnings
 

--- a/scripts/lint-rust-fmt-coverage.sh
+++ b/scripts/lint-rust-fmt-coverage.sh
@@ -1,0 +1,263 @@
+#!/bin/sh
+# Every tracked .rs file must be reached by a formatting gate.
+#
+# `cargo fmt --all` formats WORKSPACE MEMBERS. Measured on this repo: appending a
+# deliberately misformatted fn to crates/inference/src/lib.rs makes
+# `cargo fmt --all -- --check` exit 1 and name the file, while the identical
+# mutation in npm/lattice-embed-native/src/lib.rs exits 0 and names nothing --
+# that package is not in the members list. So "we run cargo fmt --all" and "every
+# Rust file we ship is formatted" are different claims, and the gap between them
+# is silent: nothing tells the gate the file exists.
+#
+# This closes it by enumeration. Every tracked *.rs outside every workspace member
+# must be listed in scripts/rust-fmt-coverage.allow with a reason, and every listed
+# file is then run through `rustfmt --check` here. The allowlist is a gate, not an
+# exemption -- an entry buys the file a rustfmt run, it does not buy it a pass.
+#
+# Usage: scripts/lint-rust-fmt-coverage.sh [--selftest]
+
+set -eu
+
+ALLOW_REL="scripts/rust-fmt-coverage.allow"
+
+# --- decision logic, kept free of I/O so the selftest can drive it directly ---
+
+# uncovered_files <members-newline-list> <files-newline-list>
+# Prints the files that lie under no member directory. Path-boundary safe: the
+# member `crates/inference` does not cover `crates/inference-extra/src/x.rs`.
+uncovered_files() {
+    _members=$1
+    _files=$2
+    printf '%s\n' "$_files" | while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        _hit=no
+        for d in $_members; do
+            case "$f" in
+                "$d"/*) _hit=yes; break ;;
+            esac
+        done
+        [ "$_hit" = no ] && printf '%s\n' "$f"
+    done
+    return 0
+}
+
+# A row is: <path> <edition> <reason...>. The edition is stated per row rather
+# than derived from the nearest Cargo.toml, because for these files the nearest
+# manifest is not the one they are built under: scripts/microlora/dsl_validator.rs
+# sits under a 2024-edition workspace and is compiled by its generator in an
+# ephemeral 2021-edition crate. Checking it at 2024 would reorder its imports away
+# from the only edition it ever compiles in.
+ALLOW_EDITIONS="2015 2018 2021 2024"
+
+# allow_paths <allowlist-text>: paths from an allowlist, comments and blanks out.
+allow_paths() {
+    printf '%s\n' "$1" | sed 's/#.*//' | awk 'NF { print $1 }'
+}
+
+# allow_edition <allowlist-text> <path>
+allow_edition() {
+    printf '%s\n' "$1" | sed 's/#.*//' | awk -v p="$2" '$1 == p { print $2; exit }'
+}
+
+# allow_bad_rows <allowlist-text>: rows missing an edition, a reason, or naming an
+# edition rustfmt would not take.
+allow_bad_rows() {
+    printf '%s\n' "$1" | sed 's/#.*//' | awk -v eds="$ALLOW_EDITIONS" '
+        NF > 0 {
+            if (NF < 3) { print $1; next }
+            ok = 0
+            n = split(eds, e, " ")
+            for (i = 1; i <= n; i++) if ($2 == e[i]) ok = 1
+            if (!ok) print $1
+        }'
+}
+
+# allow_dupes <allowlist-text>
+allow_dupes() {
+    allow_paths "$1" | sort | uniq -d
+}
+
+# --- selftest ---------------------------------------------------------------
+
+selftest() {
+    _fail=0
+    arm() { # arm <name> <got> <want>
+        if [ "$2" = "$3" ]; then
+            echo "  PASS  $1"
+        else
+            echo "  FAIL  $1"
+            echo "        got  [$2]"
+            echo "        want [$3]"
+            _fail=1
+        fi
+    }
+
+    M='crates/inference
+crates/embed'
+
+    arm "a file under a member is covered" \
+        "$(uncovered_files "$M" 'crates/inference/src/lib.rs')" ""
+    arm "a file under no member is uncovered" \
+        "$(uncovered_files "$M" 'scripts/x/y.rs')" "scripts/x/y.rs"
+    arm "a member name is not a substring match" \
+        "$(uncovered_files "$M" 'crates/inference-extra/src/x.rs')" \
+        "crates/inference-extra/src/x.rs"
+    arm "the member directory itself is not a file under it" \
+        "$(uncovered_files "$M" 'crates/inference')" "crates/inference"
+    arm "mixed input separates cleanly" \
+        "$(uncovered_files "$M" 'crates/embed/src/a.rs
+npm/p/src/b.rs
+crates/inference/src/c.rs')" "npm/p/src/b.rs"
+
+    A='# a comment line
+scripts/x.rs   2021  not a workspace member, built out of tree
+
+npm/p/src/b.rs 2024  shipped via npm, package is outside the workspace'
+    arm "allowlist skips comments and blanks" \
+        "$(allow_paths "$A")" "scripts/x.rs
+npm/p/src/b.rs"
+    arm "the row states the edition" \
+        "$(allow_edition "$A" 'npm/p/src/b.rs')" "2024"
+    arm "an unlisted path has no edition" \
+        "$(allow_edition "$A" 'nope.rs')" ""
+    arm "a row with only a path is rejected" \
+        "$(allow_bad_rows 'scripts/x.rs')" "scripts/x.rs"
+    arm "a row with an edition but no reason is rejected" \
+        "$(allow_bad_rows 'scripts/x.rs 2021')" "scripts/x.rs"
+    arm "a complete row is not rejected" \
+        "$(allow_bad_rows 'scripts/x.rs 2021 because reasons')" ""
+    arm "an edition rustfmt would not take is rejected" \
+        "$(allow_bad_rows 'scripts/x.rs 2020 because reasons')" "scripts/x.rs"
+    arm "a trailing comment is not a reason" \
+        "$(allow_bad_rows 'scripts/x.rs 2021 # because reasons')" "scripts/x.rs"
+    arm "duplicate entries are caught" \
+        "$(allow_dupes 'a.rs 2021 one
+a.rs 2021 two')" "a.rs"
+    arm "distinct entries are not duplicates" \
+        "$(allow_dupes 'a.rs 2021 one
+b.rs 2021 two')" ""
+
+    # rustfmt really rejects a misformatted file, and really passes a clean one:
+    # without this pair the allowlist could be gating with a dead instrument.
+    _t=$(mktemp -d)
+    printf 'fn main() {\n    let x = 1;\n    println!("{x}");\n}\n' > "$_t/clean.rs"
+    printf 'fn  main( ){let x=1;println!("{x}");}\n' > "$_t/dirty.rs"
+    rustfmt --check --edition 2021 "$_t/clean.rs" >/dev/null 2>&1 && _c=0 || _c=$?
+    rustfmt --check --edition 2021 "$_t/dirty.rs" >/dev/null 2>&1 && _d=0 || _d=$?
+    rm -rf "$_t"
+    arm "rustfmt passes a clean file" "$_c" "0"
+    arm "rustfmt rejects a misformatted file (instrument is alive)" \
+        "$([ "$_d" -ne 0 ] && echo nonzero || echo zero)" "nonzero"
+
+    # The edition column changes the verdict, so it is not decoration: the 2024
+    # style edition sorts `Value` ahead of `json`, the 2021 one does not.
+    _t2=$(mktemp -d)
+    printf 'use serde_json::{json, Value};\n\nfn main() {\n    let _ = (json!(1), Value::Null);\n}\n' > "$_t2/ed.rs"
+    rustfmt --check --edition 2021 "$_t2/ed.rs" >/dev/null 2>&1 && _e21=0 || _e21=$?
+    rustfmt --check --edition 2024 "$_t2/ed.rs" >/dev/null 2>&1 && _e24=0 || _e24=$?
+    rm -rf "$_t2"
+    arm "the same file is clean under edition 2021" "$_e21" "0"
+    arm "and not clean under edition 2024 (the column decides)" \
+        "$([ "$_e24" -ne 0 ] && echo nonzero || echo zero)" "nonzero"
+
+    if [ "$_fail" -eq 0 ]; then
+        echo "lint-rust-fmt-coverage: selftest OK"
+        return 0
+    fi
+    echo "lint-rust-fmt-coverage: SELFTEST FAILED"
+    return 1
+}
+
+# --- main -------------------------------------------------------------------
+
+if [ "${1:-}" = "--selftest" ]; then
+    selftest
+    exit $?
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+
+command -v cargo >/dev/null 2>&1 || { echo "lint-rust-fmt-coverage: cargo is required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "lint-rust-fmt-coverage: jq is required" >&2; exit 1; }
+command -v rustfmt >/dev/null 2>&1 || { echo "lint-rust-fmt-coverage: rustfmt is required (run 'make setup')" >&2; exit 1; }
+
+MEMBERS=$(cargo metadata --no-deps --offline --format-version 1 \
+    | jq -r '.packages[].manifest_path' \
+    | sed "s|^$PWD/||; s|/Cargo\.toml$||" \
+    | sort -u)
+[ -n "$MEMBERS" ] || { echo "lint-rust-fmt-coverage: cargo metadata named no workspace member" >&2; exit 1; }
+
+FILES=$(git ls-files -- '*.rs')
+[ -n "$FILES" ] || { echo "lint-rust-fmt-coverage: no tracked .rs files found; refusing to pass on an empty enumeration" >&2; exit 1; }
+
+# A path with whitespace would split silently in the loops above. None exists
+# today; refuse rather than mis-enumerate if one ever lands.
+if printf '%s\n' "$FILES" | grep -q '[[:space:]]'; then
+    echo "lint-rust-fmt-coverage: a tracked .rs path contains whitespace; this check cannot enumerate it safely" >&2
+    printf '%s\n' "$FILES" | grep '[[:space:]]' >&2
+    exit 1
+fi
+
+UNCOVERED=$(uncovered_files "$MEMBERS" "$FILES")
+
+ALLOW_TEXT=""
+[ -f "$ALLOW_REL" ] && ALLOW_TEXT=$(cat "$ALLOW_REL")
+
+status=0
+
+BAD=$(allow_bad_rows "$ALLOW_TEXT")
+if [ -n "$BAD" ]; then
+    echo "$ALLOW_REL: these rows are not '<path> <edition> <reason>' with a known edition:"
+    printf '  %s\n' $BAD
+    status=1
+fi
+
+DUPES=$(allow_dupes "$ALLOW_TEXT")
+if [ -n "$DUPES" ]; then
+    echo "$ALLOW_REL: duplicate entries:"
+    printf '  %s\n' $DUPES
+    status=1
+fi
+
+ALLOWED=$(allow_paths "$ALLOW_TEXT")
+
+for f in $UNCOVERED; do
+    listed=no
+    for a in $ALLOWED; do
+        [ "$f" = "$a" ] && listed=yes && break
+    done
+    if [ "$listed" = no ]; then
+        echo "$f is a tracked Rust file that no workspace member owns, so 'cargo fmt --all' never sees it."
+        echo "  Put it under a workspace member, or add a '<path> <edition> <reason>' row to $ALLOW_REL."
+        status=1
+    fi
+done
+
+for a in $ALLOWED; do
+    if [ ! -f "$a" ]; then
+        echo "$ALLOW_REL: $a is listed but does not exist; remove the row."
+        status=1
+        continue
+    fi
+    still=no
+    for f in $UNCOVERED; do
+        [ "$f" = "$a" ] && still=yes && break
+    done
+    if [ "$still" = no ]; then
+        echo "$ALLOW_REL: $a is now owned by a workspace member and is covered by 'cargo fmt --all'; remove the row."
+        status=1
+        continue
+    fi
+    ed=$(allow_edition "$ALLOW_TEXT" "$a")
+    if ! rustfmt --check --edition "$ed" "$a"; then
+        echo "$a is not rustfmt-clean (edition $ed). Run: rustfmt --edition $ed $a"
+        status=1
+    fi
+done
+
+n_allowed=$(printf '%s\n' "$ALLOWED" | awk 'NF' | wc -l | tr -d ' ')
+n_files=$(printf '%s\n' "$FILES" | wc -l | tr -d ' ')
+if [ "$status" -eq 0 ]; then
+    echo "lint-rust-fmt-coverage: $n_files tracked .rs files, $n_allowed outside the workspace and rustfmt-checked here"
+fi
+exit "$status"

--- a/scripts/rust-fmt-coverage.allow
+++ b/scripts/rust-fmt-coverage.allow
@@ -1,0 +1,12 @@
+# Tracked Rust files that no workspace member owns.
+#
+# Row format: <path> <edition> <reason...>
+#
+# The edition is stated per row, not inherited from the nearest Cargo.toml,
+# because for an out-of-tree file the nearest manifest is not the one it is
+# compiled under. Being listed here is not an exemption:
+# scripts/lint-rust-fmt-coverage.sh runs `rustfmt --check` on every row, which is
+# the coverage `cargo fmt --all` cannot give these files.
+
+npm/lattice-embed-native/build.rs   2024  napi module published to npm from its own manifest, deliberately outside the workspace so the published crate resolves its own dependency tree
+npm/lattice-embed-native/src/lib.rs 2024  napi module published to npm from its own manifest, see the row above

--- a/tests/test_bench_measurement_supervision.py
+++ b/tests/test_bench_measurement_supervision.py
@@ -105,6 +105,7 @@ EXPLICIT_SCRIPT_EXCLUSIONS = frozenset(
         "scripts/lib/quiet-probe.py",
         "scripts/perf-policy.toml",
         "scripts/perf_governor.README.md",
+        "scripts/rust-fmt-coverage.allow",
     }
     | INTERNAL_OR_TEST
 )


### PR DESCRIPTION
## The gap, measured rather than reasoned about

`cargo fmt --all` formats **workspace members**. `npm/lattice-embed-native` is a real package with
its own manifest, shipped to npm, and it is not in the members list — so nothing formats it, and
nothing said so.

Two arms, registered before running, rolled back by inverse mutation with digests checked after:

| arm | mutation | `cargo fmt --all -- --check` |
|---|---|---|
| control | identical misformatted fn appended to `crates/inference/src/lib.rs` | **rc 1**, names the file |
| subject | the same fn appended to `npm/lattice-embed-native/src/lib.rs` | **rc 0**, names nothing |

So "we run `cargo fmt --all`" and "every Rust file we ship is formatted" are different claims. The
file has in fact never been formatted: it is 2-space-indented throughout.

## What this adds

`scripts/lint-rust-fmt-coverage.sh` enumerates every tracked `*.rs` outside every workspace member.
Each must carry a row in `scripts/rust-fmt-coverage.allow`:

```
<path> <edition> <reason...>
```

and every row is then run through `rustfmt --check` **here**. The row buys the file a rustfmt run;
it does not buy it an exemption. Rows that have gone stale — the path is gone, or a workspace member
now owns it — fail rather than linger.

**Why the edition is on the row.** For exactly these files the nearest `Cargo.toml` is not the
manifest they are built under, so deriving it would check some files against an edition they never
compile in. A selftest pair proves the column decides the verdict rather than decorating it: the
same fixture is clean at edition 2021 and not clean at 2024, because the 2024 style edition sorts
`Value` ahead of `json`.

**Fail-closed points.** An empty tracked-file list, an empty member list from `cargo metadata`, or a
tracked path containing whitespace are each a refusal, not a pass. Member matching is
path-boundary-safe, so `crates/inference` does not cover `crates/inference-extra/src/x.rs`.

Wired into `scripts/ci.sh`, which the required CI job runs, next to the format check it completes.

## The reformat

`npm/lattice-embed-native/src/lib.rs` is reformatted at edition 2024 (the edition its own manifest
declares). Under `git diff --ignore-all-space` the entire change reduces to **one call split across
lines with a trailing comma added**; everything else is indentation. `npm-prebuild` builds that
crate on any PR touching `npm/**`, so the compile proof is CI's rather than an assertion here.

## Verification

- `scripts/lint-rust-fmt-coverage.sh --selftest` → **19 arms, 0 failures**.
- Four mutations against the real check, each with its expected arm registered before the run:

| mutation | result |
|---|---|
| drop the `src/lib.rs` row from the allowlist | rc 1, "no workspace member owns" naming that file |
| revert the reformat with the row present | rc 1, "not rustfmt-clean (edition 2024)" |
| list a file a member already owns | rc 1, "now owned … remove the row" |
| list a path that does not exist | rc 1, "listed but does not exist" |

Restored control after each: rc 0, `483 tracked .rs files, 2 outside the workspace and
rustfmt-checked here`.
