### PR TITLE
build: run the fmt-coverage check from the pre-commit hook too

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -144,4 +144,10 @@ fi
 # this check exists for, so it must never ride on the skip above.
 ./scripts/lint-docs.sh
 
+# Also on both branches, and for the same reason in reverse: this one is about
+# the Rust files the workspace gates cannot see, so a commit that skipped those
+# gates is precisely when it still needs to run. It needs rustfmt and one
+# `cargo metadata` read (measured 0.15s), never a build.
+./scripts/lint-rust-fmt-coverage.sh
+
 echo "Pre-commit checks passed."


### PR DESCRIPTION
`scripts/ci.sh` already runs `scripts/lint-rust-fmt-coverage.sh`, so CI catches an unformatted
out-of-workspace Rust file. The hook is where it costs nothing to catch it earlier: one
`cargo metadata` read (measured 0.15s) plus a rustfmt pass over a handful of files, never a build.

It sits beside `./scripts/lint-docs.sh` on the hook's **always-run** branch, for the mirror of the
doc lint's reason: this check is about the Rust files the workspace gates cannot see, so a commit
that skipped those gates is exactly when it still has to run.

## Verification

Two arms, registered before running, with only `.githooks/pre-commit` staged (no Rust, so the hook
takes its skip path):

| arm | result |
|---|---|
| allowlist row removed | `Rust gates SKIPPED`, doc lint passes, then the coverage check names the file — **rc 1** |
| allowlist intact | same skip, `483 tracked .rs files, 2 outside the workspace and rustfmt-checked here` — **rc 0** |

The refusal happens on the skip path, which is the property worth having: an unformatted file
outside the workspace is refused without compiling the workspace to find out.