### PR TITLE
bench-compare: make full-gate calibration cover both crates, not embed alone

### DIFF
--- a/scripts/lib/bench-compare-impl.sh
+++ b/scripts/lib/bench-compare-impl.sh
@@ -52,10 +52,10 @@
 # measured and rendered — the informational section plus the
 # all-measurements table record every number — but classified informational,
 # so they cannot produce a FAIL verdict. This manifest is only the quick-noise
-# policy. Independently, the embed configuration calibration allowlist below
-# keeps every uncalibrated target/feature pair informational at BOTH
-# resolutions. A quick-mode embed result gates only if its exact configuration
-# is calibrated and its target is absent from the quick-noise manifest.
+# policy. Independently, the configuration calibration allowlist below keeps
+# every uncalibrated target/feature pair informational at BOTH resolutions, for
+# both crates. A quick-mode result gates only if its exact configuration is
+# calibrated and its target is absent from the quick-noise manifest.
 #
 # Criterion 0.5 permits `/` in group names and uses the same character to join
 # group/function/parameter in `--list`, so a flat listing cannot recover the
@@ -67,9 +67,10 @@
 # affect one another.
 #
 # --full disables the quick-noise manifest only. It does not grant an
-# uncalibrated embed configuration gating authority: exact default `simd` with
-# no feature override gates at full resolution, while any configuration absent
-# from the calibration allowlist remains informational. Every invocation
+# uncalibrated configuration gating authority in either crate: the exact
+# defaults (`lattice-embed:simd`, `lattice-inference:elementwise_cpu_bench`,
+# each with no feature override) gate at full resolution, while any
+# configuration absent from the calibration allowlist remains informational. Every invocation
 # brackets its measurements in ABBA order (base₁, head₁, head₂, base₂); the gate
 # combines the forward and reverse ratios in log space and widens the result by
 # the measured order-bias envelope. Report-only controls only whether the
@@ -472,9 +473,22 @@ BENCH_HEAD_BASELINE_NAME="compare-head"
 # executes. Additions require reviewed same-configuration A/A calibration and
 # threshold evidence under ADR-087 D3/D5; otherwise the target remains
 # informational at every resolution.
-embed_configuration_has_full_gate_calibration() {
+#
+# The allowlist is keyed by the FULL `<crate>:<target>|<features>` configuration and
+# applies to both crates. It used to be embed-only, and the reason it survived that way
+# is worth keeping: the driver that runs PR-time A/Bs passed group filters and nothing
+# else, so no caller could select another inference target and the asymmetry had no
+# instance. That is a statement about who was calling, not about what the gate would do
+# when someone did. Once the target and features became reachable, the first non-default
+# inference run at full resolution would have voted on thresholds nobody calibrated for
+# it -- and voting is the failure direction, because an uncalibrated PASS reads exactly
+# like a calibrated one.
+#
+# The reason stated above is not crate-specific. Neither is this now.
+configuration_has_full_gate_calibration() {
   case "$1|$2" in
-    'simd|') return 0 ;;
+    'lattice-embed:simd|') return 0 ;;
+    'lattice-inference:elementwise_cpu_bench|') return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -959,10 +973,19 @@ run_target_gate() {
     --order-control-baseline-name "$BENCH_HEAD_BASELINE_NAME"
   )
 
-  if [[ "$target" == lattice-embed:* ]] &&
-     ! embed_configuration_has_full_gate_calibration \
-         "${target#lattice-embed:}" "$CARGO_FEATURES_EMBED"; then
-    # A selected target that has not calibrated this gate is still useful
+  # The features that compiled THIS target, since the two crates carry separate
+  # selections and the allowlist is keyed on the pair. A target whose crate prefix is
+  # neither known one matches no allowlist entry and is therefore informational: an
+  # unrecognized configuration is the case with the least calibration behind it, so it
+  # is also the one that must not vote.
+  local target_features=""
+  case "$target" in
+    lattice-inference:*) target_features="$CARGO_FEATURES_INFERENCE" ;;
+    lattice-embed:*) target_features="$CARGO_FEATURES_EMBED" ;;
+  esac
+
+  if ! configuration_has_full_gate_calibration "$target" "$target_features"; then
+    # A selected configuration that has not calibrated this gate is still useful
     # measurement evidence, but cannot vote at either resolution.
     gate_args+=(--informational-target "$target")
   elif [ -n "$QUICK_FLAGS" ]; then

--- a/scripts/lib/bench-informational-targets.sh
+++ b/scripts/lib/bench-informational-targets.sh
@@ -7,9 +7,10 @@
 # therefore stays at the policy's real unit: the `<crate>:<bench-target>` key.
 # bench-compare gives each target its own CRITERION_HOME and passes that exact
 # key to perf-bench-gate.py; this helper only answers whether the target is in
-# the reviewed quick-mode noise-demotion manifest. It does not decide whether
-# an embed target/feature pair has full-gate calibration; bench-compare's
-# independent configuration allowlist owns that policy at both resolutions.
+# the reviewed quick-mode noise-demotion manifest. It does not decide whether a
+# target/feature pair has full-gate calibration, for either crate;
+# bench-compare's independent configuration allowlist owns that policy at both
+# resolutions.
 #
 # `--print-targets` emits the normalized manifest for the selftest. The
 # `--is-informational <target>` predicate exits 0 for a listed target and 1 for
@@ -17,10 +18,11 @@
 # policy cannot silently broaden the informational set.
 #
 # FULL mode (`bench-compare.sh --full`, or `make bench-gate`) ignores THIS
-# quick-noise mechanism. It still consults bench-compare's independent embed
-# configuration calibration allowlist: exact default `simd` with no feature
-# override may gate, while uncalibrated target/feature pairs remain
-# informational. Classification is not enforcement — `bench-compare.sh`
+# quick-noise mechanism. It still consults bench-compare's independent
+# configuration calibration allowlist, which covers both crates: the exact
+# defaults `lattice-embed:simd` and `lattice-inference:elementwise_cpu_bench`,
+# each with no feature override, may gate, while every other target/feature pair
+# remains informational. Classification is not enforcement — `bench-compare.sh`
 # discards its gate's exit status unless the caller passes
 # --fail-on-regression, so a FAIL verdict becomes a non-zero exit only under
 # that flag or via `make bench-gate`. Both bench two selected targets rather

--- a/scripts/lib/bench-quick-informational-targets.txt
+++ b/scripts/lib/bench-quick-informational-targets.txt
@@ -6,18 +6,19 @@
 # scripts/lib/bench-informational-targets.sh (the production shell path) and
 # scripts/perf-bench-gate.py --selftest (the validator) both read THIS file.
 # There is no other copy of this quick-noise demoted-target set anywhere. The
-# independent embed configuration calibration allowlist lives in
-# bench-compare-impl.sh; it is not a second copy of this policy and applies at
-# both resolutions.
+# independent configuration calibration allowlist lives in
+# bench-compare-impl.sh, covers both crates, is not a second copy of this policy,
+# and applies at both resolutions.
 #
 # Semantics: in QUICK mode, every Criterion benchmark of a listed target is
 # reported informationally — fully measured, rendered in the report's
 # informational section and the all-measurements table, excluded only from
 # the gating verdict and exit code. FULL mode (`scripts/bench-compare.sh
 # --full`, or `make bench-gate` against the perf-baselines branch) ignores THIS
-# quick-noise manifest. Full resolution still consults the independent embed
-# configuration calibration allowlist: exact default `simd` with no feature
-# override is eligible to gate, while an uncalibrated target/feature pair stays
+# quick-noise manifest. Full resolution still consults the independent
+# configuration calibration allowlist: the exact defaults `lattice-embed:simd`
+# and `lattice-inference:elementwise_cpu_bench`, each with no feature override,
+# are eligible to gate, while any other target/feature pair stays
 # informational. (`--full` also honors bench-compare.sh's BENCH_GROUPS_*
 # filters, and neither path covers the workspace's full bench set.) Being
 # classified gating is not the same as being enforced: bench-compare.sh
@@ -32,11 +33,11 @@
 # on a regression, so it REPORTS. perf-postmerge-gate.yml runs
 # `bench-compare.sh --full --fail-on-regression` on perf-path merges,
 # against the merged commit's own parent, and fails on a confirmed
-# regression, so it ENFORCES. Under those jobs' default embed configuration,
+# regression, so it ENFORCES. Under those jobs' default configurations,
 # `simd` is therefore reported AND enforced at full resolution; this manifest
 # removes it only from the quick-mode gate. A target absent from this manifest
-# is not automatically gating: an embed configuration must also appear in the
-# independent calibration allowlist.
+# is not automatically gating: its configuration must also appear in the
+# independent calibration allowlist, in either crate.
 #
 # bench-compare keeps each target's Criterion data in a separate output root.
 # That target boundary is required: Criterion permits `/` in group names and

--- a/scripts/perf-bench-gate.py
+++ b/scripts/perf-bench-gate.py
@@ -57,8 +57,9 @@ every target in the run. Excessive order bias is the other exit-3 cause.
 Criterion output root and passes that root's exact key through --target. A
 reviewed caller policy may mark that same key informational: the quick-mode
 noise-demotion manifest does this for lattice-embed's `simd` target (#714),
-and the embed target/feature calibration allowlist does it at either resolution
-for selected configurations that have not calibrated the gate. Every result in
+and the target/feature calibration allowlist -- which covers both crates -- does
+it at either resolution for selected configurations that have not calibrated the
+gate. Every result in
 an informational root is still measured and reported, but excluded from the
 FAIL/WARN verdict and exit code. This classifier validates exact target identity;
 the caller owns the policy decision to withhold gating authority.

--- a/tests/test_bench_compare_measurement.py
+++ b/tests/test_bench_compare_measurement.py
@@ -531,6 +531,27 @@ def _add_embeddings_bench_source(root):
     )
 
 
+def _add_inference_bench_source(root):
+    # The cargo fixtures key on the CRATE (`-p lattice-inference`), not the target name, so
+    # they fabricate rms_norm for every inference target. The selected source therefore
+    # declares that group for the harness's declared-vs-measured reconciliation step, exactly
+    # as the embed helper above does.
+    path = root / "crates" / "inference" / "benches" / "f16_convert_bench.rs"
+    path.write_text('let mut group = c.benchmark_group("rms_norm");\n')
+    subprocess.run(
+        [*GIT, "-C", str(root), "add", "-f", str(path)], check=True
+    )
+    subprocess.run(
+        [*GIT, "-C", str(root), "commit", "-qm", "add f16_convert_bench fixture"],
+        check=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+        },
+    )
+
+
 def _captured_embed_argv(path):
     invocations = [shlex.split(line) for line in path.read_text().splitlines()]
     return [
@@ -1577,6 +1598,97 @@ class BenchCompareMeasurementGuard(unittest.TestCase):
             f"full gate\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
         )
         self.assertIn("**ℹ️ 1 informational**", result.stdout)
+
+    def test_uncalibrated_inference_target_is_informational_at_every_resolution(self):
+        """A non-default inference target cannot vote at full resolution either.
+
+        The allowlist used to test ``lattice-embed:*`` only, so at full resolution an
+        inference target outside the calibrated set reached neither demotion path and
+        voted on thresholds nobody calibrated for it. That had no instance while the
+        PR-time driver could pass group filters and nothing else; it acquired one the
+        moment the target and features became reachable.
+
+        Mutation-sensitive: restore the ``[[ "$target" == lattice-embed:* ]] &&``
+        guard on the calibration branch and the fabricated inference regression exits
+        1 at full resolution.
+        """
+        for flags, resolution in (([], "quick"), (["--full"], "full")):
+            with self.subTest(resolution=resolution):
+                with tempfile.TemporaryDirectory() as temporary:
+                    order_file = Path(temporary) / "order.txt"
+                    result = _run(
+                        [*flags, "--fail-on-regression"],
+                        stub_cargo=ORDER_BALANCE_CARGO,
+                        extra_env={
+                            "BENCHES_INFERENCE": "f16_convert_bench",
+                            "STUB_ORDER_FILE": str(order_file),
+                            "STUB_INFERENCE_SCENARIO": "true-regression",
+                            "STUB_EMBED_SCENARIO": "stable",
+                        },
+                        setup=_add_inference_bench_source,
+                    )
+                self.assertEqual(
+                    result.returncode, 0,
+                    f"uncalibrated {resolution} inference target voted on a regression\n"
+                    f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+                )
+                self.assertIn("**ℹ️ 1 informational**", result.stdout)
+                self.assertNotIn("gate reported a confirmed regression", result.stderr)
+
+    def test_feature_changed_default_inference_target_is_not_calibrated(self):
+        """Calibration binds target AND features on the inference side too.
+
+        Same target, different compiled binary: the features are chosen before any
+        benchmark function runs, so the calibrated pair's thresholds say nothing about
+        this one.
+        """
+        with tempfile.TemporaryDirectory() as temporary:
+            order_file = Path(temporary) / "order.txt"
+            result = _run(
+                ["--full", "--fail-on-regression"],
+                stub_cargo=ORDER_BALANCE_CARGO,
+                extra_env={
+                    "CARGO_FEATURES_INFERENCE": "bench-internals",
+                    "STUB_ORDER_FILE": str(order_file),
+                    "STUB_INFERENCE_SCENARIO": "true-regression",
+                    "STUB_EMBED_SCENARIO": "stable",
+                },
+            )
+        self.assertEqual(
+            result.returncode, 0,
+            "a feature-modified elementwise_cpu_bench inherited the default "
+            f"instrument's full gate\nstdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}",
+        )
+        self.assertIn("**ℹ️ 1 informational**", result.stdout)
+
+    def test_default_inference_configuration_still_votes_at_full_resolution(self):
+        """The arm that fails if the generalization demoted everything.
+
+        Widening an allowlist to cover a second crate has an obvious failure mode in
+        the safe-looking direction: classify the default pair as uncalibrated too and
+        every assertion above passes while the gate stops gating. This is the same
+        fixture as the two arms above with the default target and no features, and it
+        must exit 1.
+        """
+        with tempfile.TemporaryDirectory() as temporary:
+            order_file = Path(temporary) / "order.txt"
+            result = _run(
+                ["--full", "--fail-on-regression"],
+                stub_cargo=ORDER_BALANCE_CARGO,
+                extra_env={
+                    "STUB_ORDER_FILE": str(order_file),
+                    "STUB_INFERENCE_SCENARIO": "true-regression",
+                    "STUB_EMBED_SCENARIO": "stable",
+                },
+            )
+        self.assertEqual(
+            result.returncode, 1,
+            "the default inference configuration stopped voting\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        self.assertIn("gate reported a confirmed regression", result.stderr)
+        self.assertNotIn("**ℹ️ 1 informational**", result.stdout)
 
 
 class _FailOnEmptyTestProgram(unittest.TestProgram):


### PR DESCRIPTION
Closes #1513.

The full-resolution calibration allowlist tested `lattice-embed:*` and nothing
else, so a `lattice-inference:` target outside the default pair reached neither
demotion path and voted on the gate with no calibration behind its thresholds.

## The gap is at both resolutions, not only at full

The issue describes it as a full-resolution problem, which is where it matters
most — that is where the enforcing job runs, and where no fallback exists at all.
But the quick-mode manifest does not cover the inference side either:
`inference_bench` appears in `bench-quick-informational-targets.txt` zero times,
and an unlisted target is not demoted. So pre-fix, a non-default inference
configuration voted at **both** resolutions. The mutation control below shows the
quick arm failing, which is how this was found rather than assumed.

## Why it survived, and why it stops being safe now

No caller could select another inference target: the driver that runs PR-time
A/Bs passed group filters and nothing else. The branch was **unreachable**, not
correct. It became reachable when the target and its features became
selectable — and the failure direction is the quiet one, because an uncalibrated
PASS reads exactly like a calibrated PASS.

## The fix

One allowlist, keyed on the whole `<crate>:<target>|<features>` configuration and
consulted for every target, instead of two mechanisms that have to be kept in
step. Calibrated today:

| configuration | may gate |
|---|---|
| `lattice-embed:simd`, no feature override | yes |
| `lattice-inference:elementwise_cpu_bench`, no feature override | yes |
| anything else, either crate | informational at every resolution |

A target whose crate prefix is neither known one matches no entry and is
informational: an unrecognized configuration has the least calibration behind it,
so it is the one that must not vote.

The allowlist's own stated reason was never crate-specific — *choosing another
target or feature selection changes the instrument before any benchmark function
executes*. Only the implementation was. Five doc sites called it the "embed
configuration calibration allowlist" in prose that readers act on
(`bench-compare-impl.sh`, `bench-informational-targets.sh`,
`bench-quick-informational-targets.txt`, `perf-bench-gate.py`); all five are
corrected here rather than left behind as local copies of a policy that moved.

## Arms, and the mutations that make them load-bearing

Three new arms, matching the acceptance criteria in the issue:

1. a non-default inference target is informational at **both** resolutions;
2. the same target with different features is not calibrated, since features are
   chosen before any benchmark function runs;
3. **the default inference configuration still votes at full resolution** — the
   arm against this change's own safe-looking failure, where demoting everything
   makes arms 1 and 2 pass while the gate quietly stops gating.

| mutation | result |
|---|---|
| restore the `[[ "$target" == lattice-embed:* ]] &&` guard | arms 1 and 2 red (3 counting both subtests); embed arms and arm 3 stay green |
| drop the inference default from the allowlist | arm 3 red |

Reported honestly: run against the whole file, the second mutation also reddens
three pre-existing enforcing-mode arms, so arm 3 is not the only thing that
detects it. It is the one that *names* the failure rather than reporting it as an
unrelated regression assertion.

Each mutation was applied to the working tree and reverted, with the restored
file's sha256 checked against the committed blob.

## Verification

- `pytest tests/test_bench_compare_measurement.py` — **35 passed, 10 subtests**.
- `scripts/perf-bench-gate.py --selftest` — **PASS**.
- `bench-informational-targets.sh --print-targets` — unchanged (`lattice-embed:simd`).

No behaviour change for any run that gates today: both defaults keep voting.
