### PR TITLE
GDN module selection reaches the optimizer, so trained equals served

### DIFF
--- a/crates/inference/src/forward/metal_qwen35.rs
+++ b/crates/inference/src/forward/metal_qwen35.rs
@@ -3770,7 +3770,16 @@ mod inner {
         ) -> Result<(usize, usize), crate::error::InferenceError> {
             use crate::error::InferenceError;
 
-            if matches!(module, "in_proj_b" | "in_proj_a") {
+            // The refusal set is DERIVED from the servable set rather than spelled
+            // again here. Written out, this list was a second copy of a fact the
+            // trainers also hold, and two independently maintained copies of
+            // "which GDN modules can be served" drift silently: the adapter
+            // trains, the loss is minimised for a delta this kernel will never
+            // apply, and nothing says so until load. `crates/inference/src/
+            // lora_hook.rs` is the one copy; both ends read it.
+            if crate::lora_hook::GDN_LORA_MODULES.contains(&module)
+                && !crate::lora_hook::gdn_lora_module_is_servable(module)
+            {
                 if cfg.is_full_attention(layer_idx) {
                     return Err(InferenceError::Inference(format!(
                         "unknown LoRA module '{module}'"

--- a/crates/inference/src/lora_hook.rs
+++ b/crates/inference/src/lora_hook.rs
@@ -8,6 +8,48 @@
 
 use crate::model::qwen35_config::Qwen35Config;
 
+/// Every Gated DeltaNet projection a LoRA adapter can target, in the order the
+/// trainers emit them.
+///
+/// This is the geometry set: [`qwen35_projection_shape`] returns a shape for all
+/// five. Whether a given backend can APPLY one is a separate question, answered
+/// by [`GDN_LORA_MODULES_SERVABLE`].
+pub const GDN_LORA_MODULES: [&str; 5] = [
+    "in_proj_qkv",
+    "in_proj_z",
+    "in_proj_b",
+    "in_proj_a",
+    "out_proj",
+];
+
+/// The Gated DeltaNet projections the Metal forward can actually apply.
+///
+/// `in_proj_a` and `in_proj_b` are absent on purpose. Both are consumed inside
+/// the fused GDN recurrence kernel, which reads the base weights directly, so
+/// there is no post-projection row for a LoRA delta to be added to. That is a
+/// capability statement about the kernel, not a validation slip.
+///
+/// THIS EXISTS TO BE THE ONLY COPY. The trainers pick a module set and the Metal
+/// loader refuses one; when those two lists are written independently they drift,
+/// and the drift is silent until load time -- an adapter trains to completion and
+/// then cannot be served, with the loss having been minimised for a delta the
+/// server will never apply. A trainer that selects from this constant and a
+/// loader that refuses by this constant cannot disagree.
+///
+/// Widening this set is a kernel change, not an edit here: see the doc comment on
+/// `load_lora_adapter` in the Metal forward.
+pub const GDN_LORA_MODULES_SERVABLE: [&str; 3] = ["in_proj_qkv", "in_proj_z", "out_proj"];
+
+/// Whether `module` is a GDN projection the Metal forward can apply.
+///
+/// False for a non-GDN module name too, so callers that mean "is this GDN module
+/// servable" must already know they hold a GDN module name; [`GDN_LORA_MODULES`]
+/// is the membership test for that.
+#[must_use]
+pub fn gdn_lora_module_is_servable(module: &str) -> bool {
+    GDN_LORA_MODULES_SERVABLE.contains(&module)
+}
+
 /// Input and output dimensions for one LoRA-targetable linear projection.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct LoraProjectionShape {

--- a/crates/tune/src/bin/train_grad_full.rs
+++ b/crates/tune/src/bin/train_grad_full.rs
@@ -2,6 +2,7 @@
 
 use std::path::PathBuf;
 
+use lattice_tune::lora::train_core::GdnModuleSelection;
 use lattice_tune::train_support as train_common;
 use train_common::ArgView;
 use train_common::full_driver::{self, FullDriverConfig};
@@ -24,6 +25,11 @@ Options:
   --max-valid   <N>      Held-out valid.jsonl samples for eval, 0=off (default: 16)
   --log-every   <N>      Print NLL every N steps (default: 5)
   --save        <PATH>   Save trained adapter as a PEFT safetensors file (requires --features safetensors)
+  --gdn-modules <SET>    GDN projections to train: served|all (default: served).
+                         `served` is the set the Metal forward can load. `all`
+                         adds in_proj_a and in_proj_b, which the fused GDN
+                         recurrence kernel consumes: the adapter trains but the
+                         Metal loader refuses it. Use `all` only for CPU-path work.
   --gradcheck            Run finite-difference gradcheck instead of training
   --probe       <N>      Gradcheck entries probed per array per layer (default: 6)
   --fd-eps      <F>      Gradcheck central-difference step (default: 4e-3)
@@ -39,6 +45,19 @@ fn parse_config(argv: &ArgView<'_>) -> Result<FullDriverConfig, String> {
     if log_every == 0 {
         return Err("--log-every must be >= 1".to_string());
     }
+    // An unrecognised value is refused rather than silently defaulted. The whole
+    // point of the flag is that the wrong module set is invisible until load, and
+    // a typo that quietly selects the default would be exactly that failure with
+    // a flag on the command line to say it should not have happened.
+    let gdn_modules = match argv.arg("--gdn-modules").as_deref() {
+        None | Some("served") => GdnModuleSelection::Served,
+        Some("all") => GdnModuleSelection::All,
+        Some(other) => {
+            return Err(format!(
+                "--gdn-modules {other} is not a module set; expected `served` or `all`"
+            ));
+        }
+    };
     Ok(FullDriverConfig {
         model_dir: argv
             .arg("--model-dir")
@@ -94,6 +113,7 @@ fn parse_config(argv: &ArgView<'_>) -> Result<FullDriverConfig, String> {
             .unwrap_or(4e-3),
         save_path: argv.arg("--save"),
         a_init_amp: None,
+        gdn_modules,
     })
 }
 

--- a/crates/tune/src/bin/train_grad_layer23/main.rs
+++ b/crates/tune/src/bin/train_grad_layer23/main.rs
@@ -88,6 +88,8 @@ fn parse_config(argv: &ArgView<'_>) -> Result<FullDriverConfig, String> {
         probe: 6,
         fd_eps: 4e-3,
         save_path: argv.arg("--save"),
+        // Deprecated shim: no flag, and the default is the servable set.
+        gdn_modules: lattice_tune::lora::train_core::GdnModuleSelection::Served,
         a_init_amp: Some(LEGACY_A_INIT_AMP),
     })
 }

--- a/crates/tune/src/lora/train.rs
+++ b/crates/tune/src/lora/train.rs
@@ -13,9 +13,9 @@ use lattice_inference::model::qwen35::Qwen35Model;
 
 use crate::error::{Result, TuneError};
 use crate::lora::train_core::{
-    AdamConfig, Dims, GdnDims, GdnLoraParams, Head, LayerW, LoraParams, MixerKind, SeqCtx,
-    SlotLayout, TapeGeometry, TrainCtx, apply_adam_updates, apply_gdn_adam_updates, forward_full,
-    nll_and_grads, rand_fill, shifted,
+    AdamConfig, Dims, GdnDims, GdnLoraParams, GdnModuleSelection, Head, LayerW, LoraParams,
+    MixerKind, SeqCtx, SlotLayout, TapeGeometry, TrainCtx, apply_adam_updates,
+    apply_gdn_adam_updates, forward_full, nll_and_grads, rand_fill, shifted,
 };
 use crate::lora::{AdamState, LoraAdapter, LoraConfig, LoraLayer};
 
@@ -236,7 +236,7 @@ pub fn train_micro_lora(
     pairs: &[TrainingPair],
     config: &MicroLoraConfig,
 ) -> Result<LoraAdapter> {
-    train_micro_lora_impl(model, pairs, config, false)
+    train_micro_lora_impl(model, pairs, config, false, GdnModuleSelection::default())
 }
 
 /// Train GQA `q_proj`/`v_proj` LoRA weights, and — when `train_gdn` is
@@ -260,7 +260,35 @@ pub fn train_micro_lora_with_gdn(
     config: &MicroLoraConfig,
     train_gdn: bool,
 ) -> Result<LoraAdapter> {
-    train_micro_lora_impl(model, pairs, config, train_gdn)
+    train_micro_lora_impl(
+        model,
+        pairs,
+        config,
+        train_gdn,
+        GdnModuleSelection::default(),
+    )
+}
+
+/// As [`train_micro_lora_with_gdn`], with the GDN module set chosen explicitly.
+///
+/// The default is [`GdnModuleSelection::Served`], and this is the way to ask for
+/// [`GdnModuleSelection::All`]: five modules train, two of which the Metal
+/// forward refuses to load. Legitimate on the CPU path, which applies every
+/// projection, and required by the mutation control that proves the default set
+/// is doing something.
+///
+/// A sibling function rather than a fifth parameter on
+/// [`train_micro_lora_with_gdn`], for the same reason `train_gdn` itself is a
+/// sibling of [`train_micro_lora`]: changing an exported signature is a breaking
+/// change that `cargo-semver-checks` gates, and there is no major-version bump
+/// available this cycle.
+pub fn train_micro_lora_with_gdn_modules(
+    model: &Qwen35Model,
+    pairs: &[TrainingPair],
+    config: &MicroLoraConfig,
+    selection: GdnModuleSelection,
+) -> Result<LoraAdapter> {
+    train_micro_lora_impl(model, pairs, config, true, selection)
 }
 
 fn train_micro_lora_impl(
@@ -268,6 +296,7 @@ fn train_micro_lora_impl(
     pairs: &[TrainingPair],
     config: &MicroLoraConfig,
     train_gdn: bool,
+    gdn_modules: GdnModuleSelection,
 ) -> Result<LoraAdapter> {
     // Validate caller-controlled bounds before model access or allocation.
     let vocab_size = model.config().vocab_size;
@@ -484,7 +513,13 @@ fn train_micro_lora_impl(
         let (_nll, _n, grads, gdn_grads) = nll_and_grads(&fwd, &layers, &loras, &head, &train_ctx)?;
 
         apply_adam_updates(&mut adam, &mut loras, &grads, &train_ctx);
-        apply_gdn_adam_updates(&mut adam, &mut gdn_loras, &gdn_grads, &train_ctx);
+        apply_gdn_adam_updates(
+            &mut adam,
+            &mut gdn_loras,
+            &gdn_grads,
+            &train_ctx,
+            gdn_modules,
+        );
     }
 
     // Assemble LoraAdapter from trained slot params.
@@ -513,13 +548,10 @@ fn train_micro_lora_impl(
     }
     let mut target_modules = vec!["q_proj".to_string(), "v_proj".to_string()];
     if num_gdn_slots > 0 {
-        target_modules.extend([
-            "in_proj_qkv".to_string(),
-            "in_proj_z".to_string(),
-            "in_proj_b".to_string(),
-            "in_proj_a".to_string(),
-            "out_proj".to_string(),
-        ]);
+        // From the selection, never a literal: a hand-written list here would be a
+        // second copy of the servable-module set and would drift from the one the
+        // Metal loader refuses by.
+        target_modules.extend(gdn_modules.modules().iter().map(|m| (*m).to_string()));
         for (s, &li) in gdn_slot_layers.iter().enumerate() {
             let g = &gdn_loras[s];
             adapter_layers.insert(
@@ -542,30 +574,35 @@ fn train_micro_lora_impl(
                     rank,
                 },
             );
-            adapter_layers.insert(
-                (li, "in_proj_b".to_string()),
-                LoraLayer {
-                    a: g.a_b.clone(),
-                    b: g.b_b.clone(),
-                    d_in: dims.hidden,
-                    // beta is projected per VALUE head (matches the shipping
-                    // gdn_fused forward and the f16 weight loader), not per
-                    // key head (#792).
-                    d_out: gdn_dims.value_heads,
-                    rank,
-                },
-            );
-            adapter_layers.insert(
-                (li, "in_proj_a".to_string()),
-                LoraLayer {
-                    a: g.a_a.clone(),
-                    b: g.b_a.clone(),
-                    d_in: dims.hidden,
-                    // alpha is likewise projected per VALUE head.
-                    d_out: gdn_dims.value_heads,
-                    rank,
-                },
-            );
+            // Written only when they were TRAINED. Under the default they were
+            // never stepped, so `b_b`/`b_a` are still exactly zero and the layer
+            // would be an identity the loader refuses anyway.
+            if gdn_modules.trains_fused_kernel_projections() {
+                adapter_layers.insert(
+                    (li, "in_proj_b".to_string()),
+                    LoraLayer {
+                        a: g.a_b.clone(),
+                        b: g.b_b.clone(),
+                        d_in: dims.hidden,
+                        // beta is projected per VALUE head (matches the shipping
+                        // gdn_fused forward and the f16 weight loader), not per
+                        // key head (#792).
+                        d_out: gdn_dims.value_heads,
+                        rank,
+                    },
+                );
+                adapter_layers.insert(
+                    (li, "in_proj_a".to_string()),
+                    LoraLayer {
+                        a: g.a_a.clone(),
+                        b: g.b_a.clone(),
+                        d_in: dims.hidden,
+                        // alpha is likewise projected per VALUE head.
+                        d_out: gdn_dims.value_heads,
+                        rank,
+                    },
+                );
+            }
             adapter_layers.insert(
                 (li, "out_proj".to_string()),
                 LoraLayer {

--- a/crates/tune/src/lora/train_core.rs
+++ b/crates/tune/src/lora/train_core.rs
@@ -1086,13 +1086,74 @@ pub fn apply_adam_updates(
     }
 }
 
-/// Apply Adam updates to all ten factor arrays in each GDN LoRA slot.
+/// Which Gated DeltaNet projections a training run targets.
+///
+/// The trainers used to target all five unconditionally while the Metal forward
+/// accepts three, so an adapter could train to completion and then be refused at
+/// load -- and the loss it minimised included a delta the server would never
+/// apply. The selection therefore has to reach the OPTIMIZER, not just the
+/// writer: dropping the two modules at save time would leave the saved adapter
+/// different from the one the objective was computed for.
+///
+/// Both variants resolve their module names from `lattice_inference::lora_hook`,
+/// which is the only copy of "which GDN modules can be served".
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum GdnModuleSelection {
+    /// The set the Metal forward can apply, and the default.
+    ///
+    /// Default because the failure this guards is silent at train time and shows
+    /// up only at load, which is the worst place to learn about it -- after the
+    /// compute has been spent.
+    #[default]
+    Served,
+    /// All five GDN projections, including the two the fused recurrence kernel
+    /// consumes.
+    ///
+    /// Trains a delta the Metal forward cannot serve. Legitimate for CPU-path
+    /// work, which applies every projection, and it is the mutation control that
+    /// proves the default is doing something: under `All` the refusal returns and
+    /// `b_a`/`b_b` stop being zero.
+    All,
+}
+
+impl GdnModuleSelection {
+    /// The GDN module names this selection targets, in the trainers' emission order.
+    #[must_use]
+    pub fn modules(self) -> &'static [&'static str] {
+        match self {
+            Self::Served => &lattice_inference::lora_hook::GDN_LORA_MODULES_SERVABLE,
+            Self::All => &lattice_inference::lora_hook::GDN_LORA_MODULES,
+        }
+    }
+
+    /// Whether the fused-kernel projections `in_proj_a` and `in_proj_b` are trained.
+    ///
+    /// Named after what it decides rather than after the variant, because it is
+    /// read at the four `a_b/b_b/a_a/b_a` optimizer steps and at the two
+    /// `adapter_layers` inserts, and both sites are about those tensors.
+    #[must_use]
+    pub fn trains_fused_kernel_projections(self) -> bool {
+        matches!(self, Self::All)
+    }
+}
+
+/// Apply Adam updates to the GDN LoRA factor arrays selected by `selection`.
+///
+/// Under [`GdnModuleSelection::Served`] the `a_b`/`b_b`/`a_a`/`b_a` steps are
+/// skipped rather than stepped-and-discarded. That is what makes the omission
+/// from the saved adapter provably lossless: every `b_*` array is
+/// zero-initialised, so an unstepped module contributes an exactly-zero delta,
+/// and the adapter that is served is the adapter the loss was minimised for.
+/// Skipping also keeps those tensors out of `AdamState`, so no moment estimates
+/// accumulate for parameters nothing will read.
+///
 /// See [`docs/lora-core.md`](../../docs/lora-core.md#nll_and_grads) for the GDN slot layout.
 pub fn apply_gdn_adam_updates(
     adam: &mut AdamState,
     gdn_loras: &mut [GdnLoraParams],
     gdn_grads: &[GdnLoraParams],
     train: &TrainCtx<'_>,
+    selection: GdnModuleSelection,
 ) {
     let slot_layers = train.gdn_layers();
     let lr = train.learning_rate();
@@ -1120,10 +1181,12 @@ pub fn apply_gdn_adam_updates(
         step!(b_qkv, "b_qkv");
         step!(a_z, "a_z");
         step!(b_z, "b_z");
-        step!(a_b, "a_b");
-        step!(b_b, "b_b");
-        step!(a_a, "a_a");
-        step!(b_a, "b_a");
+        if selection.trains_fused_kernel_projections() {
+            step!(a_b, "a_b");
+            step!(b_b, "b_b");
+            step!(a_a, "a_a");
+            step!(b_a, "b_a");
+        }
         step!(a_out, "a_out");
         step!(b_out, "b_out");
     }
@@ -1176,6 +1239,201 @@ mod gdn_lora_tests {
         // rank so large that rank * hidden overflows usize on any platform.
         let err = GdnLoraParams::zeros(usize::MAX / 2, 16, &gd);
         assert!(err.is_err(), "overflowing rank*hidden should be rejected");
+    }
+
+    /// Run `f` with the `TrainCtx` the GDN optimizer arms share, on the 0.8B preset.
+    ///
+    /// A callback rather than a return, because `TrainCtx` borrows the geometry,
+    /// the config and the slot-layer slices it is built from; returning one would
+    /// hand back references to this function's locals.
+    fn with_gdn_train_ctx<R>(rank: usize, f: impl FnOnce(&TrainCtx<'_>) -> R) -> R {
+        let cfg = Qwen35Config::qwen35_0_8b();
+        let dims = Dims {
+            hidden: cfg.hidden_size,
+            vocab: cfg.vocab_size,
+            num_q_heads: cfg.num_attention_heads,
+            num_kv_heads: cfg.num_key_value_heads,
+            head_dim: cfg.head_dim,
+            rope_dim: cfg.rope_dim(),
+            inter: cfg.intermediate_size,
+            q_dim: cfg.full_q_dim(),
+            kv_dim: cfg.full_kv_dim(),
+            eps: cfg.rms_norm_eps,
+        };
+        let real_gdn_dims = GdnDims::from_cfg(&cfg);
+        assert!(
+            !cfg.is_full_attention(20),
+            "layer 20 must be GDN on the 0.8B preset"
+        );
+        let gqa_layers: [usize; 0] = [];
+        let gdn_layers = [20usize];
+        let train = TrainCtx::try_new(
+            TapeGeometry::new(&dims, &real_gdn_dims, &cfg),
+            rank,
+            (rank as f32) * 2.0,
+            SlotLayout::new(&gqa_layers, &gdn_layers),
+            AdamConfig::new(0.1, 0.9, 0.999, 1e-8),
+        )
+        .expect("valid TrainCtx");
+        f(&train)
+    }
+
+    /// Gradients large enough that a single Adam step cannot leave a parameter at
+    /// its zero init. Every one of the ten arrays is fed, so an array that does
+    /// not move did not move because it was SKIPPED.
+    fn all_ten_grads(rank: usize, hidden: usize, gd: &GdnDims) -> GdnLoraParams {
+        let mut g = GdnLoraParams::zeros(rank, hidden, gd).unwrap();
+        for arr in [
+            &mut g.a_qkv,
+            &mut g.b_qkv,
+            &mut g.a_z,
+            &mut g.b_z,
+            &mut g.a_b,
+            &mut g.b_b,
+            &mut g.a_a,
+            &mut g.b_a,
+            &mut g.a_out,
+            &mut g.b_out,
+        ] {
+            for (i, v) in arr.iter_mut().enumerate() {
+                *v = 0.05 * (i as f32 + 1.0);
+            }
+        }
+        g
+    }
+
+    /// THE ZERO PROOF. Three steps under the default selection, with a non-zero
+    /// gradient on every one of the ten arrays, and `b_a`/`b_b` are still exactly
+    /// `0.0` afterwards.
+    ///
+    /// This is what makes leaving `in_proj_a`/`in_proj_b` out of the saved adapter
+    /// LOSSLESS rather than approximate: a LoRA layer contributes
+    /// `scale * B @ (A @ x)`, `B` is zero-initialised, and an unstepped `B` stays
+    /// exactly zero, so the omitted module's delta is exactly zero -- not small.
+    /// The claim is measured on the tensors here rather than argued from control
+    /// flow, which is the only form that survives a refactor of the step macro.
+    #[test]
+    fn served_selection_leaves_the_fused_kernel_factors_exactly_zero() {
+        let gd = tiny_gdn_dims();
+        let hidden = 16;
+        let rank = 3;
+        let mut gdn_loras = vec![GdnLoraParams::zeros(rank, hidden, &gd).unwrap()];
+        let gdn_grads = vec![all_ten_grads(rank, hidden, &gd)];
+        with_gdn_train_ctx(rank, |train| {
+            let mut adam = AdamState::new();
+            for _ in 0..3 {
+                apply_gdn_adam_updates(
+                    &mut adam,
+                    &mut gdn_loras,
+                    &gdn_grads,
+                    train,
+                    GdnModuleSelection::Served,
+                );
+            }
+        });
+
+        let p = &gdn_loras[0];
+        for (name, arr) in [("b_b", &p.b_b), ("b_a", &p.b_a)] {
+            assert!(
+                arr.iter().all(|&v| v == 0.0),
+                "{name} must be exactly zero after 3 steps under Served, got {arr:?}"
+            );
+        }
+        for (name, arr) in [("a_b", &p.a_b), ("a_a", &p.a_a)] {
+            assert!(
+                arr.iter().all(|&v| v == 0.0),
+                "{name} must be untouched under Served, got {arr:?}"
+            );
+        }
+        // THE CONTROL, in the same arm: the four served arrays DID move under the
+        // same gradients. Without this the test would pass against an optimizer
+        // that stepped nothing at all.
+        for (name, arr) in [
+            ("a_qkv", &p.a_qkv),
+            ("b_qkv", &p.b_qkv),
+            ("a_out", &p.a_out),
+            ("b_out", &p.b_out),
+        ] {
+            assert!(
+                arr.iter().all(|&v| v != 0.0),
+                "{name} must have moved under Served, got {arr:?}"
+            );
+        }
+    }
+
+    /// THE MUTATION. Identical inputs under `All`, and the four fused-kernel
+    /// arrays move. This is what proves the arm above is measuring the selection
+    /// rather than a gradient that happened to be zero, a shape that happened to
+    /// be empty, or an optimizer that stepped nothing.
+    #[test]
+    fn all_selection_moves_the_fused_kernel_factors() {
+        let gd = tiny_gdn_dims();
+        let hidden = 16;
+        let rank = 3;
+        let mut gdn_loras = vec![GdnLoraParams::zeros(rank, hidden, &gd).unwrap()];
+        let gdn_grads = vec![all_ten_grads(rank, hidden, &gd)];
+        with_gdn_train_ctx(rank, |train| {
+            let mut adam = AdamState::new();
+            for _ in 0..3 {
+                apply_gdn_adam_updates(
+                    &mut adam,
+                    &mut gdn_loras,
+                    &gdn_grads,
+                    train,
+                    GdnModuleSelection::All,
+                );
+            }
+        });
+
+        let p = &gdn_loras[0];
+        for (name, arr) in [
+            ("a_b", &p.a_b),
+            ("b_b", &p.b_b),
+            ("a_a", &p.a_a),
+            ("b_a", &p.b_a),
+        ] {
+            assert!(
+                arr.iter().all(|&v| v != 0.0),
+                "{name} must move under All, got {arr:?}"
+            );
+        }
+    }
+
+    /// THE SET PROOF. The default selection names only modules the Metal forward
+    /// can apply, and it reads them from the inference crate's constant rather
+    /// than from a list maintained here.
+    #[test]
+    fn served_selection_is_exactly_the_modules_metal_can_load() {
+        use lattice_inference::lora_hook::{
+            GDN_LORA_MODULES, GDN_LORA_MODULES_SERVABLE, gdn_lora_module_is_servable,
+        };
+
+        assert_eq!(
+            GdnModuleSelection::Served.modules(),
+            GDN_LORA_MODULES_SERVABLE.as_slice()
+        );
+        assert_eq!(
+            GdnModuleSelection::All.modules(),
+            GDN_LORA_MODULES.as_slice()
+        );
+        assert!(GdnModuleSelection::default() == GdnModuleSelection::Served);
+
+        for m in GdnModuleSelection::Served.modules() {
+            assert!(
+                gdn_lora_module_is_servable(m),
+                "Served names {m}, which the Metal forward refuses"
+            );
+        }
+        // And the difference is exactly the two fused-kernel projections, so this
+        // arm fails if either constant grows a module the other does not know.
+        let excluded: Vec<&str> = GDN_LORA_MODULES
+            .iter()
+            .copied()
+            .filter(|m| !gdn_lora_module_is_servable(m))
+            .collect();
+        assert_eq!(excluded, vec!["in_proj_b", "in_proj_a"]);
+        assert!(!GdnModuleSelection::Served.trains_fused_kernel_projections());
+        assert!(GdnModuleSelection::All.trains_fused_kernel_projections());
     }
 
     #[test]
@@ -1232,7 +1490,13 @@ mod gdn_lora_tests {
         .expect("valid TrainCtx");
 
         let mut adam = AdamState::new();
-        apply_gdn_adam_updates(&mut adam, &mut gdn_loras, &gdn_grads, &train);
+        apply_gdn_adam_updates(
+            &mut adam,
+            &mut gdn_loras,
+            &gdn_grads,
+            &train,
+            GdnModuleSelection::All,
+        );
 
         // Adam moves params opposite the gradient sign: positive grad -> param
         // decreases from its zero init; negative grad -> param increases.

--- a/crates/tune/src/train_support/full_driver.rs
+++ b/crates/tune/src/train_support/full_driver.rs
@@ -9,9 +9,9 @@ use rayon::prelude::*;
 
 use crate::lora::AdamState;
 use crate::lora::train_core::{
-    AdamConfig, Dims, GdnDims, GdnLoraParams, Head, LayerW, LoraParams, MixerKind, SeqCtx,
-    SlotLayout, TOP_LAYER, TapeGeometry, TrainCtx, apply_adam_updates, apply_gdn_adam_updates,
-    eval_chain_nll, forward_full, nll_and_grads, rand_fill, shifted,
+    AdamConfig, Dims, GdnDims, GdnLoraParams, GdnModuleSelection, Head, LayerW, LoraParams,
+    MixerKind, SeqCtx, SlotLayout, TOP_LAYER, TapeGeometry, TrainCtx, apply_adam_updates,
+    apply_gdn_adam_updates, eval_chain_nll, forward_full, nll_and_grads, rand_fill, shifted,
 };
 
 use super::{Sample, load_jsonl, verify_tbv};
@@ -195,6 +195,12 @@ pub struct FullDriverConfig {
     /// Fixed A-factor amplitude for compatibility callers; `None` uses the
     /// full trainer's `1 / sqrt(hidden)` initialization.
     pub a_init_amp: Option<f32>,
+    /// Which GDN projections to train and save.
+    ///
+    /// [`GdnModuleSelection::Served`] is the default everywhere a caller does not
+    /// say otherwise, because an adapter carrying the other two cannot be loaded
+    /// by the Metal forward and nothing says so until load time.
+    pub gdn_modules: GdnModuleSelection,
 }
 
 /// Numeric evidence returned by the shared driver.
@@ -501,6 +507,7 @@ pub fn run(config: FullDriverConfig) -> Result<FullDriverOutcome, Box<dyn std::e
         fd_eps,
         save_path,
         a_init_amp,
+        gdn_modules,
     } = config;
 
     if first_layer > TOP_LAYER {
@@ -1107,7 +1114,13 @@ pub fn run(config: FullDriverConfig) -> Result<FullDriverOutcome, Box<dyn std::e
         };
 
         apply_adam_updates(&mut adam, &mut loras, &grads, &train_ctx);
-        apply_gdn_adam_updates(&mut adam, &mut gdn_loras, &gdn_grads, &train_ctx);
+        apply_gdn_adam_updates(
+            &mut adam,
+            &mut gdn_loras,
+            &gdn_grads,
+            &train_ctx,
+            gdn_modules,
+        );
         train_step_secs += tone.elapsed().as_secs_f64();
 
         if step % log_every == 0 || step == steps {
@@ -1199,13 +1212,10 @@ epilogue re-scoring {epilogue_score_secs:.1}s"
             }
             let mut target_modules = vec!["q_proj".to_string(), "v_proj".to_string()];
             if num_gdn_slots > 0 {
-                target_modules.extend([
-                    "in_proj_qkv".to_string(),
-                    "in_proj_z".to_string(),
-                    "in_proj_b".to_string(),
-                    "in_proj_a".to_string(),
-                    "out_proj".to_string(),
-                ]);
+                // The list comes from the selection, never from a literal here: a
+                // hand-written list is a second copy of the servable-module set and
+                // drifts from the one the Metal loader refuses by.
+                target_modules.extend(gdn_modules.modules().iter().map(|m| (*m).to_string()));
                 // GDN LoRA (surface-B, ported from lattice PR #202). All five
                 // module names are recognised by `LoraAdapter::validate_against`
                 // (crates/tune/src/lora/mod.rs, inference-hook feature).
@@ -1231,30 +1241,35 @@ epilogue re-scoring {epilogue_score_secs:.1}s"
                             rank,
                         },
                     );
-                    adapter_layers.insert(
-                        (li, "in_proj_b".to_string()),
-                        LoraLayer {
-                            a: g.a_b.clone(),
-                            b: g.b_b.clone(),
-                            d_in: dims.hidden,
-                            // beta is projected per VALUE head (matches the
-                            // shipping gdn_fused forward and the f16 weight
-                            // loader), not per key head (#792).
-                            d_out: gdn_dims.value_heads,
-                            rank,
-                        },
-                    );
-                    adapter_layers.insert(
-                        (li, "in_proj_a".to_string()),
-                        LoraLayer {
-                            a: g.a_a.clone(),
-                            b: g.b_a.clone(),
-                            d_in: dims.hidden,
-                            // alpha is likewise projected per VALUE head.
-                            d_out: gdn_dims.value_heads,
-                            rank,
-                        },
-                    );
+                    // Written only when they were TRAINED. Under the default they
+                    // were never stepped, so `b_b`/`b_a` are still exactly zero and
+                    // the layer would be an identity the loader refuses anyway.
+                    if gdn_modules.trains_fused_kernel_projections() {
+                        adapter_layers.insert(
+                            (li, "in_proj_b".to_string()),
+                            LoraLayer {
+                                a: g.a_b.clone(),
+                                b: g.b_b.clone(),
+                                d_in: dims.hidden,
+                                // beta is projected per VALUE head (matches the
+                                // shipping gdn_fused forward and the f16 weight
+                                // loader), not per key head (#792).
+                                d_out: gdn_dims.value_heads,
+                                rank,
+                            },
+                        );
+                        adapter_layers.insert(
+                            (li, "in_proj_a".to_string()),
+                            LoraLayer {
+                                a: g.a_a.clone(),
+                                b: g.b_a.clone(),
+                                d_in: dims.hidden,
+                                // alpha is likewise projected per VALUE head.
+                                d_out: gdn_dims.value_heads,
+                                rank,
+                            },
+                        );
+                    }
                     adapter_layers.insert(
                         (li, "out_proj".to_string()),
                         LoraLayer {
@@ -1318,6 +1333,7 @@ mod run_bounds_tests {
             fd_eps: 1e-3,
             save_path: None,
             a_init_amp: None,
+            gdn_modules: GdnModuleSelection::default(),
         }
     }
 

--- a/crates/tune/tests/layer23_golden_bridge.rs
+++ b/crates/tune/tests/layer23_golden_bridge.rs
@@ -256,6 +256,13 @@ fn compatibility_shim_matches_legacy_layer23_golden() {
         fd_eps: 4e-3,
         save_path: None,
         a_init_amp: Some(0.02),
+        // `All`, not the default, and deliberately: this test's subject is the
+        // shared driver reproducing the LEGACY layer-23 path, which predates any
+        // module selection and trained every GDN projection. Pinning `All` keeps
+        // the comparison about the driver. If layer 23 carries no GDN slot in this
+        // fixture the choice is inert, which is also fine -- what it must never be
+        // is a silent change to what is being compared.
+        gdn_modules: lattice_tune::lora::train_core::GdnModuleSelection::All,
     })
     .unwrap();
     let worst_relative_error = gradcheck


### PR DESCRIPTION
## The mismatch

The full LoRA trainer trained and saved **five** GDN modules per slot. The Metal
forward accepts **three**: `expected_lora_shape` refuses `in_proj_a` and
`in_proj_b` because the fused GDN recurrence kernel consumes them, so there is no
post-projection row for a LoRA delta to be added to. That refusal is a capability
statement about the kernel, not a validation slip.

The consequence is that an adapter could train to completion and then fail to
load, and the run's measured gain was not a gain anyone could serve.

## Why the selection reaches the optimizer rather than the writer

Gradients flowed into all ten GDN factor arrays. If the two modules are trained
and then dropped at save time, the saved adapter is not the adapter the loss was
minimised for — the objective saw a delta the server will never apply.

So `GdnModuleSelection` is threaded to `apply_gdn_adam_updates`, and under the
default the `a_b`/`b_b`/`a_a`/`b_a` steps are **skipped** rather than
stepped-and-discarded. Every `b_*` array is zero-initialised and a LoRA layer
contributes `scale * B @ (A @ x)`, so an unstepped module's delta is *exactly*
zero, not small. That is what makes the omission from the saved adapter lossless
rather than an approximation. Skipping also keeps those tensors out of
`AdamState`, so no moment estimates accumulate for parameters nothing reads.

## One copy of the servable set

`lora_hook.rs` gains `GDN_LORA_MODULES`, `GDN_LORA_MODULES_SERVABLE` and
`gdn_lora_module_is_servable`, and the Metal loader's refusal is derived from
them instead of spelling `matches!(module, "in_proj_b" | "in_proj_a")` a second
time. Two independently maintained copies of "which GDN modules can be served"
drift silently, because the disagreement is invisible until load. Behaviour at
that site is unchanged: the same two modules are refused with the same message,
and both existing tests of that refusal still pass.

`LoraAdapter::validate_against` continues to accept all five on purpose — the
trainer validates geometry, the backend declares capability — so an adapter built
with `all` is a valid adapter that Metal refuses. That split is now documented
where the constants live.

## Scope: four sites, not three

The optimizer is the narrowest waist this change passes through, so its caller
list is the population:

```
apply_gdn_adam_updates
  train_support/full_driver.rs   the full trainer
  lora/train.rs                  train_micro_lora_impl — a second production trainer
  lora/train_core.rs             tests
```

`train_micro_lora_impl` stepped all ten arrays and built the same five-module
list, and gets the same treatment. It is reached through a new
`train_micro_lora_with_gdn_modules` sibling rather than a fifth parameter on the
exported `train_micro_lora_with_gdn`, because `cargo-semver-checks`'
signature gate covers this crate and there is no major bump available this cycle
— the same constraint that made `train_gdn` a sibling function in the first
place.

`train_grad_full` gains `--gdn-modules served|all`, default `served`. An
unrecognised value is **refused**, not silently defaulted: a typo that quietly
selected the default would be exactly the failure this flag exists to prevent,
with a flag on the command line saying it should not have happened.

`layer23_golden_bridge` pins `all` deliberately — its subject is the shared
driver reproducing the legacy layer-23 path, which predates any selection, and a
silent change to what is being compared would be worse than an inert pin.

## Arms

```
cargo test -p lattice-tune --features train-backward     rc 0
  lib 358 passed / 0 failed / 1 ignored; every integration target rc 0
cargo test -p lattice-inference --lib lora               rc 0
  38 passed / 0 failed / 1 ignored / 2836 filtered out
cargo fmt --all -- --check                               rc 0
cargo clippy --workspace --all-targets -- -D warnings    rc 0, zero warnings
```

Three new arms, none of which need a checkpoint on disk:

- **The zero proof.** Three steps under the default with a non-zero, non-uniform
  gradient on all ten arrays; `b_b` and `b_a` are still exactly `0.0` and
  `a_b`/`a_a` are untouched. The four served arrays are asserted to *have* moved
  in the same arm, so it cannot pass against an optimizer that stepped nothing.
- **The mutation.** Identical inputs under `all`, and the four fused-kernel
  arrays move.
- **The set proof.** The default selection equals the servable constant, every
  name it yields passes `gdn_lora_module_is_servable`, and the complement inside
  the full set is exactly `["in_proj_b", "in_proj_a"]` — that last assertion is
  what fails if either constant grows a module the other does not know.

Reverse-applied to check the arms are not decoration. Registered before running:
exactly one arm should redden. Deleting the optimizer's selection guard and
nothing else:

```
served_selection_leaves_the_fused_kernel_factors_exactly_zero ... FAILED
all_selection_moves_the_fused_kernel_factors ... ok
served_selection_is_exactly_the_modules_metal_can_load ... ok
apply_gdn_adam_updates_moves_nonzero_grad_params ... ok
test result: FAILED. 11 passed; 1 failed
```

Source restored byte-identical afterwards.

## bench-compare disposition

A declared bench target reaches the change, so this is a measured disposition rather than a waiver.
An earlier version of this description claimed no bench reaches it; that claim came from a caller
search under `crates/*/src`, which is not the population the rule names.

**Population searched.** All 25 declared `[[bench]]` targets in `crates/inference`, verified 1:1
against the files in `benches/`. Seven carry `required-features`. Exactly one reaches the changed
line: `benches/metal_decode_bench.rs:235` calls `state.load_lora_adapter(...)` inside the `b.iter`
closure of `metal_decode_q4/forward_step/lora_rank8`, and `load_lora_adapter` is
`expected_lora_shape`'s only production caller — a grep over `crates/` returns the definition, that
caller, the crate's own tests, and one doc-comment mention in `metal_qwen35/mtp_weights.rs`. The
target is gated `cfg(all(target_os = "macos", feature = "metal-gpu"))` with
`required-features = ["metal-gpu", "f16"]`.

**Numbers.** ABBA on an idle Apple-silicon host under the machine-wide bench-window lock, base
`9d7044ffdf` (the merge base, so the delta is exactly this one commit) vs head `58777b99f3`, both
arms built before any measurement so no compile lands between them. Criterion `[lo, point, hi]`,
1275 iterations in each of the four arms:

| order | ref  | time                                   |
|-------|------|----------------------------------------|
| A1    | base | `[9.0415 ms  9.3093 ms  9.5927 ms]`    |
| B1    | head | `[9.0419 ms  9.3054 ms  9.5897 ms]`    |
| B2    | head | `[9.0311 ms  9.2980 ms  9.5840 ms]`    |
| A2    | base | `[9.0237 ms  9.2903 ms  9.5759 ms]`    |

Head mean of points 9.3017 ms against base 9.2998 ms: **+0.02%**. The number that decides how to
read that is the order envelope, not the ratio: the base arm alone drifts **-0.20%** from A1 to A2
across the session, ten times the head-vs-base difference and in the opposite direction, and every
arm's own 95% interval spans about ±3% of its point. **No measurable change.**

**What this arm can and cannot resolve, stated because the ratio alone would overclaim.** The
changed line runs 150 times per adapter load on this checkpoint (6 full-attention layers × 7 modules
+ 18 GDN layers × 6 modules), and the group reloads the adapter on its `pos > 500` branch, so about
two loads land inside each arm's 1275 measured iterations. Roughly 300 executions of the changed
line against 11.9 s of GPU decode. Taking the observed session drift as the resolution floor, this
measurement cannot see a per-call cost below roughly 80 µs. The change adds a handful of `&str`
comparisons per call. So the run establishes that nothing gross regressed on the only path that
reaches it, and it cannot bound the change's own cost — that residual is real and is the reason for
saying it here rather than presenting the table as a clean bill.

**Build inputs are identical between the arms.** `git diff --name-only base...head` over
`Cargo.toml`, `Cargo.lock`, `build.rs`, `crates/inference/benches/**` and the bench harness is
empty; all eight changed files are crate sources.

**Why this was not run through `bench-compare.sh`.** It cannot be. The harness holds
`/tmp/lion-metal-gpu-test.lock` for the measured command, and `metal_decode_bench` acquires that same
lock itself inside `load_q4_state` (`measurement::gpu_test_lock`), so the bench queues on its own
supervisor for 30 minutes and then panics about a wedged run elsewhere. Measured and filed as #1517,
with the lock table, the stack, and the six targets it affects. The arms above therefore take only
the bench-window lock and let the binary own the GPU lock, which is the same serialization by a
different holder.

The target's Q4-QuaRot checkpoint prerequisite was absent on the bench host and was regenerated with
`quantize_quarot` (`--seed 0xCAFE_BABE_DEAD_BEEF`, matching the repository's artifact job;
`Forward-equiv: max_abs=7.461e-14` against a 1e-5 tolerance). That prerequisite is load-bearing for
the honesty of the run, not only its execution: with the checkpoint absent, `bench_metal_decode_q4`
prints `SKIP:` and emits no groups at all, so an A/B in that state returns an empty comparison that
reads exactly like a clean one.

## Out of scope

Changing the fused GDN recurrence kernel so `in_proj_a`/`in_proj_b` become
servable. That is a real feature with a parity requirement of its own.


