### PR TITLE
ci: cross-check that lattice-inference still builds for aarch64-apple-ios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -841,6 +841,83 @@ jobs:
       - name: workspace — check at MSRV (f16,metal-gpu, all targets)
         run: cargo check --workspace --features f16,metal-gpu --all-targets
 
+  # iOS cross-compilation cross-check. lattice-inference is expected to build
+  # for aarch64-apple-ios with `std,f16` and no default features. That property
+  # held when it was measured by hand, but nothing in CI held it, so the first
+  # dependency bump or `cfg` change to break it would have broken it silently.
+  #
+  # Scope, stated so a green check is not read as more than it is: this job
+  # COMPILES the library and attests the artifact's compile target. It links
+  # nothing, runs nothing on a device or a simulator, and tests no behaviour.
+  #
+  # The attestation is a whole-population check over the archive's Mach-O
+  # members, not a spot check on one of them, and both of its arms were
+  # measured before it was written. Against the iOS rlib: 256 object members,
+  # 256 carrying LC_VERSION_MIN_IPHONEOS, and no macOS platform load command.
+  # Against a host rlib built from the same tree with the same feature flags:
+  # zero iOS load commands and 257 macOS ones. (257 rather than 256 because
+  # otool also walks the `lib.rmeta` wrapper object, which carries no platform
+  # load command on the iOS side -- which is why the iOS arm counts `.o`
+  # members rather than every Mach-O header.) So a host build substituted for
+  # the iOS one fails this step instead of passing it.
+  #
+  # If a future toolchain encodes the iOS platform as LC_BUILD_VERSION
+  # platform 2 rather than LC_VERSION_MIN_IPHONEOS, this step fails loudly and
+  # the predicate wants widening. That direction is deliberate: the macOS
+  # branch below is what rejects a host build, and it holds under either
+  # encoding.
+  #
+  # Gated on the existing `code` selector rather than a narrower
+  # `crates/inference/**` one: the `changes` job's selector set is pinned
+  # statement-for-statement by tests/test_ci_changed_files.py, so minting a
+  # selector for a single job is a larger change than the narrowing buys.
+  ios-cross:
+    name: ios-cross (aarch64-apple-ios lib)
+    needs: changes
+    # macOS and not matrix-driven, so the oslist selector that defers `ci` and
+    # `feature-matrix` on drafts does not reach it. It carries the draft
+    # condition directly, the same way `msrv` above does. ci-gate's draft
+    # branch exits before it reads this job's result, so skipping here cannot
+    # produce a false green.
+    if: needs.changes.outputs.code == 'true' && github.event.pull_request.draft != true
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/rust-setup
+        with:
+          targets: aarch64-apple-ios
+          shared-key: ios-cross
+          cache-on-failure: true
+      - name: build lattice-inference for aarch64-apple-ios
+        run: |
+          cargo build -p lattice-inference --target aarch64-apple-ios \
+            --no-default-features --features std,f16 --lib
+      - name: assert the artifact targets iOS and not the host
+        run: |
+          RLIB=target/aarch64-apple-ios/debug/liblattice_inference.rlib
+          if [ ! -f "$RLIB" ]; then
+            echo "::error::$RLIB was not produced, so there is nothing to attest."
+            exit 1
+          fi
+          OBJECTS="$(ar t "$RLIB" | grep -c '\.o$' || true)"
+          IOS="$(otool -l "$RLIB" | grep -c 'LC_VERSION_MIN_IPHONEOS' || true)"
+          MACOS="$(otool -l "$RLIB" | grep -A2 'LC_BUILD_VERSION' \
+            | grep -c 'platform 1$' || true)"
+          echo "objects=$OBJECTS ios_load_commands=$IOS macos_load_commands=$MACOS"
+          if [ "$OBJECTS" -eq 0 ]; then
+            echo "::error::the archive holds no object members, so these counts attest nothing."
+            exit 1
+          fi
+          if [ "$MACOS" -ne 0 ]; then
+            echo "::error::$MACOS macOS platform load commands found in an artifact that must target iOS."
+            exit 1
+          fi
+          if [ "$IOS" -ne "$OBJECTS" ]; then
+            echo "::error::$IOS of $OBJECTS object members carry LC_VERSION_MIN_IPHONEOS; every one must."
+            exit 1
+          fi
+          echo "All $OBJECTS object members target iOS; no macOS platform load command present."
+
   # Supply-chain gate. licenses/bans/sources are deterministic and REQUIRED:
   # a green main cannot turn red without a manifest/lockfile change. Advisories
   # run separately as informational (continue-on-error) because fresh RUSTSEC
@@ -1136,7 +1213,16 @@ jobs:
   # `app-binaries-gate` in app-binaries.yml.
   ci-gate:
     name: ci-gate
-    needs: [changes, ci, feature-matrix, msrv, semver-checks, decode-harness-unit-tests]
+    needs:
+      [
+        changes,
+        ci,
+        feature-matrix,
+        msrv,
+        ios-cross,
+        semver-checks,
+        decode-harness-unit-tests,
+      ]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -1147,9 +1233,10 @@ jobs:
           CI_RESULT="${{ needs.ci.result }}"
           FEATURE_MATRIX_RESULT="${{ needs.feature-matrix.result }}"
           MSRV_RESULT="${{ needs.msrv.result }}"
+          IOS_CROSS_RESULT="${{ needs.ios-cross.result }}"
           SEMVER_RESULT="${{ needs.semver-checks.result }}"
           DECODE_HARNESS_RESULT="${{ needs.decode-harness-unit-tests.result }}"
-          echo "changes=$CHANGES_RESULT code=$CODE ci=$CI_RESULT feature-matrix=$FEATURE_MATRIX_RESULT msrv=$MSRV_RESULT semver-checks=$SEMVER_RESULT decode-harness-unit-tests=$DECODE_HARNESS_RESULT"
+          echo "changes=$CHANGES_RESULT code=$CODE ci=$CI_RESULT feature-matrix=$FEATURE_MATRIX_RESULT msrv=$MSRV_RESULT ios-cross=$IOS_CROSS_RESULT semver-checks=$SEMVER_RESULT decode-harness-unit-tests=$DECODE_HARNESS_RESULT"
           if [ "$CHANGES_RESULT" != "success" ]; then
             echo "::error::change-detection did not succeed, failing closed."
             exit 1
@@ -1188,9 +1275,13 @@ jobs:
             echo "::error::msrv did not succeed (result=$MSRV_RESULT)."
             exit 1
           fi
+          if [ "$IOS_CROSS_RESULT" != "success" ]; then
+            echo "::error::ios-cross did not succeed (result=$IOS_CROSS_RESULT)."
+            exit 1
+          fi
           if [ "$SEMVER_RESULT" != "success" ]; then
             echo "::error::semver-checks did not succeed (result=$SEMVER_RESULT)."
             exit 1
           fi
-          echo "Code changed; ci, feature-matrix, msrv, semver-checks, and decode-harness-unit-tests all PASSED."
+          echo "Code changed; ci, feature-matrix, msrv, ios-cross, semver-checks, and decode-harness-unit-tests all PASSED."
           exit 0

--- a/tests/test_ci_changed_files.py
+++ b/tests/test_ci_changed_files.py
@@ -645,6 +645,7 @@ def _run_required_gate(
     workflow: Path,
     gate_id: str,
     selector_values: dict[str, str],
+    result_values: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     contents = workflow.read_text(encoding="utf-8")
     step = _workflow_step(_workflow_job(contents, gate_id), "Resolve gate")
@@ -661,7 +662,8 @@ def _run_required_gate(
         if expression.startswith(selector_prefix):
             return selector_values.get(expression.removeprefix(selector_prefix), "")
         if expression.startswith("needs.") and expression.endswith(".result"):
-            return "success"
+            job = expression.removeprefix("needs.").removesuffix(".result")
+            return (result_values or {}).get(job, "success")
         if expression == "github.event.pull_request.draft":
             return "false"
         if expression == "github.event_name":
@@ -1921,6 +1923,54 @@ class RequiredGateSelectorTests(unittest.TestCase):
                 )
 
                 self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_required_gates_fail_when_any_needed_job_did_not_succeed(
+        self,
+    ) -> None:
+        """Every job a gate declares in `needs` must be read by its script.
+
+        A gate that lists a job but never inspects its result is decorative:
+        the job can turn red, or be deleted outright, and the required check
+        stays green. So this walks the declared `needs` of each gate rather
+        than a hand-written list of jobs -- a hand-written list would go stale
+        the same way the gate script it is meant to protect would.
+
+        `changes` is excluded because the gates read it through its selector
+        outputs, which the sibling tests above already cover.
+        """
+        for workflow, gate_id, selectors in self._CASES:
+            declared = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+            needs = declared["jobs"][gate_id]["needs"]
+            self.assertIsInstance(needs, list)
+            upstream = [job for job in needs if job != "changes"]
+            self.assertNotEqual(upstream, [])
+
+            for job in upstream:
+                with self.subTest(workflow=workflow.name, job=job):
+                    result = _run_required_gate(
+                        workflow,
+                        gate_id,
+                        {selector: "true" for selector in selectors},
+                        {job: "failure"},
+                    )
+
+                    self.assertNotEqual(
+                        result.returncode,
+                        0,
+                        f"{gate_id} passed while {job} reported failure:\n"
+                        f"{result.stdout}\n{result.stderr}",
+                    )
+                    # A non-zero exit alone would also be produced by an
+                    # unrelated shell error -- an undefined variable under
+                    # `set -u`, say -- so require the gate's own deliberate
+                    # refusal. The gates label upstream jobs by prose rather
+                    # than by job id, so the id itself is not assertable here.
+                    self.assertIn(
+                        "::error::",
+                        f"{result.stdout}\n{result.stderr}",
+                        f"{gate_id} exited non-zero without refusing:\n"
+                        f"{result.stdout}\n{result.stderr}",
+                    )
 
     def test_required_gates_accept_explicit_positive_selector_outputs(
         self,


### PR DESCRIPTION
## What

Adds `ios-cross`, a CI job that builds `lattice-inference` for
`aarch64-apple-ios` and attests that the artifact it produced really targets
iOS, and wires it into `ci-gate`.

```
cargo build -p lattice-inference --target aarch64-apple-ios \
  --no-default-features --features std,f16 --lib
```

## Why now

The crate is expected to compile for that target with `std,f16` and no default
features. That property held when it was measured by hand, but nothing in CI
held it, so the first dependency bump or `cfg` change to break it would have
broken it silently, and the breakage would have surfaced to whoever tried to
embed the crate rather than to the change that caused it.

## Scope, stated so a green check is not read as more than it is

This job **compiles the library and attests the artifact's compile target**.
It links nothing, runs nothing on a device or a simulator, and tests no
behaviour. A green check here is evidence about the compile target and nothing
else.

## The attestation, and the measurement behind it

The check walks the whole archive rather than sampling one member, and both of
its directions were measured before it was written.

| arm | object members | `LC_VERSION_MIN_IPHONEOS` | macOS platform load commands |
|---|---|---|---|
| iOS rlib | 256 | 256 | 0 |
| host rlib, same tree, same feature flags | 256 | 0 | 257 |

The macOS side counts 257 rather than 256 because `otool` also walks the
`lib.rmeta` wrapper object, which carries no platform load command on the iOS
side. That asymmetry is why the iOS arm compares against the count of `.o`
members rather than against every Mach-O header `otool` reports.

So a host build standing in for the iOS one fails this step rather than
passing it, which is the substitution the step exists to reject.

**The absolute counts are environment-dependent, and the predicate is
deliberately not.** Those two rows were measured locally, where `cargo` defaults
to incremental compilation. This job's first CI run reported
`objects=16 ios_load_commands=16 macos_load_commands=0`, because
`Swatinem/rust-cache` sets `CARGO_INCREMENTAL=0` when it is unset and the dev
profile's codegen-unit count differs between the two. Measured on one machine,
same command, only that variable changed:

| `CARGO_INCREMENTAL` | object members | `LC_VERSION_MIN_IPHONEOS` |
|---|---|---|
| 1 | 256 | 256 |
| 0 | 16 | 16 |

The step asserts `ios == objects`, not `objects == 256`, so it holds under both.
A literal count there would have failed its own first CI run.

## The step's branches were exercised, using the shipped text

The script was extracted from this workflow file programmatically and run
against fixtures, rather than a retyped copy of it being run:

| fixture | expected | result |
|---|---|---|
| iOS rlib | pass | `rc=0`, `objects=256 ios_load_commands=256 macos_load_commands=0` |
| host rlib in the iOS slot | fail | `rc=1`, `257 macOS platform load commands found in an artifact that must target iOS` |
| artifact absent | fail | `rc=1`, `... was not produced, so there is nothing to attest` |
| archive holding no object members | fail | `rc=1`, `the archive holds no object members, so these counts attest nothing` |

The last row is the one that matters for honesty rather than for correctness:
without that branch an object-free archive reports `0 of 0` and reads as a
clean pass.

## The gate wiring is made load-bearing by a test

A gate that lists a job in `needs` but never reads its result is decorative —
the job can turn red, or be deleted, and the required check stays green.

`test_required_gates_fail_when_any_needed_job_did_not_succeed` walks each
gate's **declared** `needs` rather than a hand-written job list, forces one
upstream job at a time to `failure`, and requires the gate to refuse with its
own `::error::` rather than merely exiting non-zero.

Mutation check: deleting the new `ios-cross` branch from `ci-gate`'s script
makes this the **only** one of the suite's 74 arms that reddens, and it reddens
with the diagnostic you would want —

```
ci-gate passed while ios-cross reported failure:
changes=success code=true ci=success feature-matrix=success msrv=success ios-cross=failure ...
Code changed; ci, feature-matrix, msrv, ios-cross, semver-checks, and decode-harness-unit-tests all PASSED.
```

Every pre-existing arm substitutes `success` for every upstream result, so none
of them could have seen it. The mutation was applied and reverted with a `cmp`
assertion on each side.

## Two things this does not do, said plainly

**It is gated on `code`, not on `crates/inference/**`.** The narrower selector
is what I had recommended when I left this box unchecked. It is not what this
PR does: the `changes` job's selector set is pinned statement-for-statement by
`tests/test_ci_changed_files.py`, so minting a selector for a single job means
editing the trusted-prologue grammar that guard enforces — a larger and riskier
change than the narrowing buys. The cost of the wider gate is that the job runs
on every code-touching PR; see the timing below for what that costs.

**Nothing pins that `ios-cross` is in `ci-gate`'s `needs` at all.** The new test
proves a gate reads every job it declares, not that it declares this one.
Removing `ios-cross` from `needs` would leave the suite green. That is a
pre-existing property of this gate family — it is equally true of `msrv` — and
closing it would mean asserting a rule the workflow does not hold, since five
jobs here deliberately run outside the gate.

## Cost

A cold build of this configuration — fresh `CARGO_TARGET_DIR`, 75 crates
compiled — took **10.8 s wall / 45 s user** on an Apple-silicon machine, for a
598 MB target directory. The feature flags prune most of the dependency tree,
so this is a small job rather than a full-workspace one. A hosted macOS runner
is slower than that machine, and the job also carries a toolchain install and
cache restore, so treat the number as the shape of the cost rather than as a
prediction of the check's duration.

## Forward risk, and the direction it fails

If a future toolchain encodes the iOS platform as `LC_BUILD_VERSION platform 2`
instead of `LC_VERSION_MIN_IPHONEOS`, this step fails loudly and the predicate
wants widening. That direction is deliberate. The macOS branch is what rejects
a host build, it runs first, and it holds under either encoding.

## Gates run

- `actionlint` 1.7.12 (the version this repo pins) with `shellcheck` 0.11.0 on
  `PATH`: clean. Verified the invocation was live in both dimensions — an
  invalid `runs-on` label and an unquoted variable in the new step's script
  were each reported when injected, and neither is present in what ships.
- `tests/test_ci_changed_files.py`: 74 passed (73 before this change).
- The workflow parses under `yaml.safe_load`, and `ci-gate`'s resolved `needs`
  reads back as `[changes, ci, feature-matrix, msrv, ios-cross, semver-checks,
  decode-harness-unit-tests]`.

Refs #1456
