### PR TITLE
ci: run the GDN module-selection guards instead of only compiling them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,35 @@ jobs:
           grep -Eq '^test result: ok\. [1-9][0-9]* passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' "$log"
       - name: tune — train-backward (compile tests)
         run: cargo test -p lattice-tune --features train-backward --no-run
+      # That step compiles the train-backward surface and executes none of it,
+      # which is the whole gap for the GDN module-selection guards added in #1516.
+      # `crates/tune/src/lora/mod.rs` declares `pub mod train_core;` under
+      # `#[cfg(feature = "train-backward")]` while tune's defaults are
+      # `["std", "sqlite"]`, so `cargo test --workspace` never compiles that file
+      # and the step above never runs it: the arms proving a `Served` adapter's
+      # frozen factors stay exactly zero, and that the servable set is the one the
+      # Metal loader accepts, were enforced by nothing. Same treatment as the
+      # `validate_against`, `mixture` and `simulated-teacher` steps. Placed
+      # immediately after the compile step so the lib test binary is already built:
+      # the six tests are self-contained (synthetic dims and gradients, no
+      # checkpoint, no filesystem) and executed in 0.00s locally, so what this adds
+      # to the job is the assertions below, not build time.
+      - name: tune — GDN module selection guards (build + run)
+        run: |
+          log="${RUNNER_TEMP:-/tmp}/gdn-module-selection-tests.log"
+          if cargo test -p lattice-tune --lib --features train-backward \
+            gdn_lora_tests >"$log" 2>&1
+          then
+            cat "$log"
+          else
+            status=$?
+            cat "$log"
+            exit "$status"
+          fi
+          grep -q 'test lora::train_core::gdn_lora_tests::served_selection_leaves_the_fused_kernel_factors_exactly_zero ... ok' "$log"
+          grep -q 'test lora::train_core::gdn_lora_tests::served_selection_is_exactly_the_modules_metal_can_load ... ok' "$log"
+          grep -q 'test lora::train_core::gdn_lora_tests::all_selection_moves_the_fused_kernel_factors ... ok' "$log"
+          grep -Eq '^test result: ok\. [1-9][0-9]* passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' "$log"
       # The `mixture` feature gates the experimental online router-refit module
       # (crates/tune/src/lora/router_update.rs) behind lattice-fann/online-router.
       # It is off by default, so the required `ci` job never compiles or RUNS its


### PR DESCRIPTION
#1516 added three guards that keep a trained LoRA adapter equal to a servable one:

- `served_selection_leaves_the_fused_kernel_factors_exactly_zero` — after Adam steps under `Served`, the two unservable GDN modules' `b_*` factors are exactly `0.0`, and the four served arrays are asserted to have moved in the same arm, so it cannot pass against an optimizer that stepped nothing.
- `served_selection_is_exactly_the_modules_metal_can_load` — the complement of the servable set inside `GDN_LORA_MODULES` is exactly `["in_proj_b", "in_proj_a"]`, which is what goes red if either constant grows a module the other does not know.
- `all_selection_moves_the_fused_kernel_factors` — the opt-out path still trains all five.

They live in `crates/tune/src/lora/train_core.rs`. `crates/tune/src/lora/mod.rs:29-30` declares `pub mod train_core;` under `#[cfg(feature = "train-backward")]`, and tune's defaults are `["std", "sqlite"]`. So `cargo test --workspace` never compiles that file, and the one step that does compile it — `tune — train-backward (compile tests)` — passes `--no-run`. Nothing in CI executed them.

That is the trap this job's own header comment already describes for `safetensors`-gated code ("two real LoRA save/load bugs shipped in `safetensors`-gated code that default CI never built"), and the treatment is the one three neighbouring steps already use: `validate_against`, `mixture` and `simulated-teacher` are each built **and run** here for exactly this reason.

## What the step costs

It is placed immediately after the compile step, with the same package and the same feature set, so the lib test binary is already built when it runs. Measured locally:

```
running 6 tests
test lora::train_core::gdn_lora_tests::gdn_lora_params_zeros_shapes_match_gdn_dims ... ok
test lora::train_core::gdn_lora_tests::gdn_lora_params_zeros_rejects_overflowing_rank ... ok
test lora::train_core::gdn_lora_tests::served_selection_is_exactly_the_modules_metal_can_load ... ok
test lora::train_core::gdn_lora_tests::apply_gdn_adam_updates_moves_nonzero_grad_params ... ok
test lora::train_core::gdn_lora_tests::all_selection_moves_the_fused_kernel_factors ... ok
test lora::train_core::gdn_lora_tests::served_selection_leaves_the_fused_kernel_factors_exactly_zero ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 353 filtered out; finished in 0.00s
```

All six are self-contained: synthetic dimensions and gradients, no checkpoint and no filesystem. The module is not a checkpoint-dependent surface, so this does not import a new asset requirement into CI.

## The assertions, and proof they can go red

A step that runs tests and reads only the exit code is satisfied by a filter that selects nothing. The step names each guard by its full test path and requires a non-zero passed count with zero ignored, so a renamed test, an emptied filter, or a truncated log fails closed.

Arms registered before running, then reconciled one by one:

| log fed to the assertions | expected | observed |
|---|---|---|
| the real passing run above | pass | exit 0 |
| same log, one arm rewritten `... ok` → `... FAILED` | red on that arm's grep | exit on grep 1 |
| same log, summary rewritten to `0 passed` | red on the count guard | exit on the count guard |
| empty log | red | exit on grep 1 |

Both mutated logs were confirmed to differ from the original with `cmp -s` before being read, so neither arm was scored against an unmutated file.

## Scope

One file, one added step and its comment. No job added, no gate wiring changed — `feature-matrix` is already in `ci-gate`'s `needs`. No source or test file is touched, so the guards this enforces are exactly the ones #1516 merged.
