### PR TITLE
feat(microlora): score DSL argument validity, groundedness, and gate-log receipts

### DIFF
--- a/scripts/microlora/build_gate_receipts.py
+++ b/scripts/microlora/build_gate_receipts.py
@@ -31,14 +31,35 @@ import gate_log_receipt as G  # noqa: E402
 
 EXTS = {".log", ".out", ".txt", ".nohup"}
 
+# A log-shaped EXTENSION is not a log, and these two exclusions were found by looking at
+# rows whose content spanned the train/held-out boundary rather than by inspecting the
+# filter.
+#
+# `fixtures/` -- ten rows, six of them classified `cargo`, and they are THIS EXTRACTOR'S OWN
+# test fixtures (`ci-log-ansi-zero.txt`, `real-arm-a-healthy.txt`). Training on the fixtures
+# that define the correct answer is self-contamination, and it is invisible in any summary
+# that reports only class counts. Also caught here: `merges.txt`, a checked-out tokenizer
+# vocabulary sitting in a workspace, which is not captured output at all.
+#
+# MIN_BYTES -- 45 rows are empty or near-empty captures (an `stderr.log` with nothing in it).
+# They are honestly captured output and `unknown` is the honest answer for them, so this is
+# a stated population choice rather than a correctness fix: degenerate rows carry no signal,
+# they are byte-identical to each other, and they were over half of all duplicate content.
+EXCLUDE_PATH_PARTS = {"fixtures"}
+MIN_BYTES = 9
+
 
 def rows_for(root: pathlib.Path, max_bytes: int):
     for f in sorted(root.rglob("*")):
         if not f.is_file() or f.suffix not in EXTS:
             continue
+        if EXCLUDE_PATH_PARTS & set(f.parts):
+            continue
         try:
             raw = f.read_bytes()
         except OSError:
+            continue
+        if len(raw) < MIN_BYTES:
             continue
         truncated = len(raw) > max_bytes
         text = raw[:max_bytes].decode("utf-8", errors="replace")
@@ -65,11 +86,109 @@ def rows_for(root: pathlib.Path, max_bytes: int):
         yield f, receipt, truncated
 
 
+# THE POPULATION, NAMED, because the count invites a false reading. This corpus is
+# *captured stdout/stderr of commands this seat ran, stored under the logs root with a
+# log-shaped extension*. It is NOT "gate logs": measured on 1110 files, 780 are not cargo
+# output at all, and there is no path-based provenance partition to recover one -- 174
+# directories, 32 of them mixed, and the purest gate-producer directory still holds 4
+# non-cargo files. So the population is the sweep, and the two things that were wrong were
+# the NAME and the BALANCE. This function fixes the balance; the name is fixed above.
+def dedupe_by_content(rows):
+    """Drop rows whose bytes duplicate an earlier row, keeping the first path in sort order.
+
+    Found by measurement, not by review: before this ran, 10 content hashes spanned the
+    train/held-out boundary and 14 of 219 held-out rows were byte-identical to a training
+    row. A held-out score over those rows is a memorisation test wearing a generalisation
+    label, and nothing in a class-count summary shows it. Path-disjointness -- which the
+    partition does guarantee -- is not content-disjointness.
+    """
+    seen, kept = set(), []
+    for r in sorted(rows, key=lambda r: r["log_path"]):
+        h = r["receipt"]["log"]["value"]["sha256"]
+        if h in seen:
+            continue
+        seen.add(h)
+        kept.append(r)
+    return kept, len(rows) - len(kept)
+
+
+def partition(rows, holdout_frac: float):
+    """Split by a stable hash of the log path, so the partition does not depend on read order.
+
+    Deliberately NOT random-by-index: re-running after a new log lands would reshuffle an
+    index-based split and silently move rows across the boundary, which is the leakage
+    `check_split_integrity.py` exists to catch. Hashing the path pins each file to one
+    side for its lifetime.
+    """
+    train, held = [], []
+    for r in rows:
+        h = int(G.hashlib.sha256(r["log_path"].encode("utf-8")).hexdigest()[:8], 16)
+        (held if (h % 10_000) < holdout_frac * 10_000 else train).append(r)
+    return train, held
+
+
+def klass(row) -> str:
+    return "cargo" if G.is_known(row["receipt"]["format"]) else "unknown"
+
+
+def downsample(rows, seed: int):
+    """Equalise the two format classes by discarding majority rows, with a fixed seed.
+
+    Returns (kept, discarded_count). The discard is RETURNED rather than merely performed
+    because a balancing step that does not report what it threw away has changed the
+    population without saying so, which is the defect this function exists to fix.
+    """
+    import random
+    by = collections.defaultdict(list)
+    for r in rows:
+        by[klass(r)].append(r)
+    if not by["cargo"] or not by["unknown"]:
+        return rows, 0
+    n = min(len(by["cargo"]), len(by["unknown"]))
+    rng = random.Random(seed)
+    kept = []
+    for c in ("cargo", "unknown"):
+        pool = sorted(by[c], key=lambda r: r["log_path"])
+        kept.extend(pool if len(pool) == n else rng.sample(pool, n))
+    return sorted(kept, key=lambda r: r["log_path"]), len(rows) - len(kept)
+
+
+def split_report(train, held, discarded: int, pre_train: int) -> dict:
+    """Counts with denominators, plus the number any headline accuracy must beat.
+
+    ALWAYS-ABSTAIN BASELINE. On a set that is 70% `unknown`, a model that answers `unknown`
+    to everything scores 70%. Reporting accuracy without that number beside it makes doing
+    nothing look like learning, so the baseline is emitted as a field of the split itself
+    rather than left for a scorer to remember.
+    """
+    def dist(rows):
+        d = collections.Counter(klass(r) for r in rows)
+        return {"n": len(rows), "cargo": d["cargo"], "unknown": d["unknown"]}
+    e = dist(held)
+    base = max(e["cargo"], e["unknown"]) / e["n"] if e["n"] else None
+    return {
+        "population": ("captured stdout/stderr of commands this seat ran, under the logs root "
+                       "with a log-shaped extension -- NOT a set of gate logs"),
+        "train": {**dist(train), "rows_before_balance": pre_train, "discarded_by_balance": discarded},
+        "holdout": {**e, "prevalence_preserved": True,
+                    "always_abstain_accuracy": base,
+                    "note": ("the held-out split keeps the natural mix because that is what a "
+                             "caller hands the model; any accuracy below always_abstain_accuracy "
+                             "is worse than answering 'unknown' to everything")},
+    }
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--logs-root", type=pathlib.Path)
     ap.add_argument("--out", type=pathlib.Path)
     ap.add_argument("--max-bytes", type=int, default=2_000_000)
+    ap.add_argument("--split-out", type=pathlib.Path,
+                    help="also write train.jsonl/holdout.jsonl and a split report here")
+    ap.add_argument("--holdout-frac", type=float, default=0.2)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--balance", choices=("none", "downsample"), default="downsample",
+                    help="balance the TRAIN split only; the held-out split keeps natural prevalence")
     ap.add_argument("--self-test", action="store_true")
     a = ap.parse_args()
     if a.self_test:
@@ -92,6 +211,25 @@ def main() -> int:
             n += 1
             fh.write(json.dumps({"log_path": str(f), "receipt": receipt}, sort_keys=True) + "\n")
 
+    if a.split_out:
+        rows = [json.loads(ln) for ln in (a.out / "receipts.jsonl").read_text(encoding="utf-8").splitlines() if ln]
+        rows, dup_dropped = dedupe_by_content(rows)
+        train, held = partition(rows, a.holdout_frac)
+        pre = len(train)
+        if a.balance == "downsample":
+            train, discarded = downsample(train, a.seed)
+        else:
+            discarded = 0
+        a.split_out.mkdir(parents=True, exist_ok=True)
+        for name, part in (("train.jsonl", train), ("holdout.jsonl", held)):
+            with (a.split_out / name).open("w", encoding="utf-8") as fh:
+                for r in part:
+                    fh.write(json.dumps(r, sort_keys=True) + "\n")
+        rep = split_report(train, held, discarded, pre)
+        rep["duplicate_content_rows_dropped"] = dup_dropped
+        (a.split_out / "split_report.json").write_text(json.dumps(rep, indent=2, sort_keys=True))
+        print(json.dumps({"split": rep}, indent=2, sort_keys=True))
+
     summary = {"rows": n, "distribution": dict(dist), "truncated_rows": truncs,
                "malformed_rows": len(malformed), "malformed": malformed[:20],
                "max_bytes": a.max_bytes, "logs_root": str(a.logs_root)}
@@ -110,13 +248,24 @@ def _self_test() -> int:
         (root / "a.log").write_text("   Compiling x v0.1.0\ntest result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.0s\n")
         (root / "b.log").write_text("watching CI, ALL GREEN\n")
         (root / "c.log").write_text("")
+        (root / "fixtures").mkdir()
+        (root / "fixtures" / "golden.log").write_text("   Compiling x v0.1.0\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.0s\n")
         (root / "skip.md").write_text("test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.0s\n")
         got = {f.name: (r, t) for f, r, t in rows_for(root, 1_000_000)}
         cases.append(("only log-shaped extensions are read; a .md quoting a result is NOT a gate log",
-                      set(got) == {"a.log", "b.log", "c.log"}))
+                      set(got) == {"a.log", "b.log"}))
+        cases.append(("a file under fixtures/ is excluded even though it IS cargo output",
+                      "golden.log" not in got))
         cases.append(("a real cargo log reports format", got["a.log"][0]["format"]["value"] == "cargo-test"))
         cases.append(("a CI-watcher log does NOT claim cargo format", not G.is_known(got["b.log"][0]["format"])))
-        cases.append(("an empty log does NOT claim cargo format", not G.is_known(got["c.log"][0]["format"])))
+        # c.log is empty. It used to enter the dataset as a degenerate `unknown` row; under
+        # MIN_BYTES it is excluded at the builder. The extractor's own answer for empty input
+        # is unchanged and is covered by gate_log_receipt.py's self-test -- this case asserts
+        # the BUILDER's exclusion, which is a different claim and is the one that moved.
+        cases.append(("a sub-MIN_BYTES capture is excluded, not carried as a degenerate row",
+                      "c.log" not in got))
+        cases.append(("a non-empty NON-cargo capture is still kept and still answers unknown",
+                      "b.log" in got and not G.is_known(got["b.log"][0]["format"])))
         cases.append(("every field is two-shaped on every row",
                       all(("value" in v) ^ ("unknown" in v) for _, (r, _) in got.items() for v in r.values())))
         big = root / "big.log"
@@ -136,6 +285,51 @@ def _self_test() -> int:
         whole = {f.name: (r, t) for f, r, t in rows_for(root, 10_000_000)}
         cases.append(("...and the same log read WHOLE does report its outcome",
                       whole["okbig.log"][0]["outcome"]["value"] == "ok"))
+    # --- split machinery -------------------------------------------------------
+    # A synthetic corpus with a DELIBERATE skew (18 unknown : 6 cargo), because a balanced
+    # fixture would let a no-op downsample pass every case below.
+    mk = lambda i, cargo: {"log_path": f"/x/{i:03d}.log",
+                           "receipt": {"format": (G.value("cargo-test") if cargo else G.unknown("no marker"))}}
+    corpus = [mk(i, i % 4 == 0) for i in range(24)]
+    dd = [mk(0, True), mk(1, False), mk(2, True)]
+    for r in dd:
+        r["receipt"]["log"] = G.value({"sha256": "AA" if r["log_path"].endswith("000.log") else "BB"})
+    dd[2]["receipt"]["log"] = G.value({"sha256": "AA"})
+    kept, dropped = dedupe_by_content(dd)
+    cases.append(("duplicate content is dropped, keeping the first path", dropped == 1 and len(kept) == 2))
+    cases.append(("...and the SURVIVING row is the first path, not an arbitrary one",
+                  [r["log_path"] for r in kept] == ["/x/000.log", "/x/001.log"]))
+    uniq = [mk(9, True), mk(8, False)]
+    for i, r in enumerate(uniq):
+        r["receipt"]["log"] = G.value({"sha256": f"U{i}"})
+    cases.append(("dedupe drops nothing when every row is distinct", dedupe_by_content(uniq)[1] == 0))
+    tr, hd = partition(corpus, 0.25)
+    cases.append(("train and held-out share no row",
+                  not ({r["log_path"] for r in tr} & {r["log_path"] for r in hd})))
+    cases.append(("the partition covers the corpus", len(tr) + len(hd) == len(corpus)))
+    raw_hd = collections.Counter(klass(r) for r in hd)
+    bal, disc = downsample(tr, 0)
+    cases.append(("balancing equalises the TRAIN classes",
+                  collections.Counter(klass(r) for r in bal)["cargo"]
+                  == collections.Counter(klass(r) for r in bal)["unknown"]))
+    cases.append(("the discard count is the rows actually dropped", disc == len(tr) - len(bal)))
+    cases.append(("balancing DID drop something on a skewed corpus, so the case above is live",
+                  disc > 0))
+    rep = split_report(bal, hd, disc, len(tr))
+    cases.append(("the held-out split is untouched by balancing",
+                  (rep["holdout"]["cargo"], rep["holdout"]["unknown"]) == (raw_hd["cargo"], raw_hd["unknown"])))
+    base = rep["holdout"]["always_abstain_accuracy"]
+    cases.append(("the always-abstain baseline is the held-out majority rate",
+                  base is None or abs(base - max(raw_hd.values()) / sum(raw_hd.values())) < 1e-9))
+    # The docstring's whole claim: adding a file must not move an existing file's side.
+    grown = corpus + [mk(900 + i, i % 2 == 0) for i in range(7)]
+    tr2, hd2 = partition(grown, 0.25)
+    before = {r["log_path"]: "h" for r in hd} | {r["log_path"]: "t" for r in tr}
+    after = {r["log_path"]: "h" for r in hd2} | {r["log_path"]: "t" for r in tr2}
+    cases.append(("adding rows moves no existing row across the boundary",
+                  all(after[k] == v for k, v in before.items())))
+    cases.append(("...and the growth fixture really did add rows", len(grown) > len(corpus)))
+
     bad = [n for n, ok in cases if not ok]
     for n, ok in cases:
         print(f"  {'ok  ' if ok else 'FAIL'}  {n}")

--- a/scripts/microlora/build_gate_receipts.py
+++ b/scripts/microlora/build_gate_receipts.py
@@ -50,6 +50,18 @@ def rows_for(root: pathlib.Path, max_bytes: int):
         receipt["command"] = G.unknown("a gate log does not record the invocation that produced it; pass --command")
         receipt["source_hash"] = G.unknown("a gate log does not record the ref it was produced from; pass --source-hash")
         receipt["executed_generated_command"] = G.value(False)
+        if truncated:
+            # `outcome` is an ALL-quantified claim over the log's binaries -- "ok" means
+            # every one of them said ok. Truncation removes binaries from view, so the
+            # quantifier can no longer be established and the field must not carry a
+            # value. Measured on a real 4.6MB CI log whose run CONCLUSION was failure:
+            # the first 2MB contained 260 passing binaries and no failing one, so the
+            # truncated read said "ok" about a run that failed. The counts stay, because
+            # they are sums over the `test result:` lines actually read, which is what
+            # they are in every log; only the universal claim is withdrawn.
+            receipt["outcome"] = G.unknown(
+                f"log truncated at {max_bytes} of {len(raw)} bytes; binaries after the cut "
+                "are unread, so 'every binary was ok' cannot be established")
         yield f, receipt, truncated
 
 
@@ -114,6 +126,16 @@ def _self_test() -> int:
                       small["big.log"][1] is True and small["big.log"][0]["log"]["value"]["truncated"] is True))
         cases.append(("a truncated read does not invent counts",
                       not G.is_known(small["big.log"][0]["passed"])))
+        okbig = root / "okbig.log"
+        okbig.write_text("   Compiling x v0.1.0\n"
+                         "test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.0s\n"
+                         + "filler\n" * 200)
+        cut = {f.name: (r, t) for f, r, t in rows_for(root, 120)}
+        cases.append(("a truncated log does NOT claim outcome ok, because 'all ok' needs all",
+                      cut["okbig.log"][1] is True and not G.is_known(cut["okbig.log"][0]["outcome"])))
+        whole = {f.name: (r, t) for f, r, t in rows_for(root, 10_000_000)}
+        cases.append(("...and the same log read WHOLE does report its outcome",
+                      whole["okbig.log"][0]["outcome"]["value"] == "ok"))
     bad = [n for n, ok in cases if not ok]
     for n, ok in cases:
         print(f"  {'ok  ' if ok else 'FAIL'}  {n}")

--- a/scripts/microlora/build_gate_receipts.py
+++ b/scripts/microlora/build_gate_receipts.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Build a (gate log -> structured receipt) dataset from real gate logs.
+
+The logs themselves are local build/CI artifacts and never enter the repo; this script
+is the reproducible path from them to the dataset, and it records what it read.
+
+WHY THE DISTRIBUTION IS REPORTED AND NOT JUST THE COUNT. The receipt's `format` field is
+derived, so a corpus of logs that are not cargo output yields rows whose answer is
+`unknown`. That is the CORRECT answer, and it is also a training hazard: a set dominated
+by one answer teaches that answer. The split is printed so the skew is visible before
+anyone trains on it, rather than discovered afterwards as a model that always abstains.
+
+TRUNCATION IS DECLARED. Files above --max-bytes are read to the cap and the row records
+`truncated: true`, because a receipt derived from a partial log can miss a later
+`test result:` line, and a row that hides that is indistinguishable from a complete one.
+
+Usage:
+    uv run python scripts/microlora/build_gate_receipts.py --logs-root DIR --out DIR \
+        [--max-bytes 2000000] [--self-test]
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+import gate_log_receipt as G  # noqa: E402
+
+EXTS = {".log", ".out", ".txt", ".nohup"}
+
+
+def rows_for(root: pathlib.Path, max_bytes: int):
+    for f in sorted(root.rglob("*")):
+        if not f.is_file() or f.suffix not in EXTS:
+            continue
+        try:
+            raw = f.read_bytes()
+        except OSError:
+            continue
+        truncated = len(raw) > max_bytes
+        text = raw[:max_bytes].decode("utf-8", errors="replace")
+        receipt = G.parse_cargo_test_log(text)
+        receipt["log"] = G.value({"path": str(f), "bytes": len(raw),
+                                  "sha256": G.hashlib.sha256(raw).hexdigest()[:16],
+                                  "truncated": truncated})
+        receipt["exit_code"] = G.rc_from_log(text)
+        receipt["command"] = G.unknown("a gate log does not record the invocation that produced it; pass --command")
+        receipt["source_hash"] = G.unknown("a gate log does not record the ref it was produced from; pass --source-hash")
+        receipt["executed_generated_command"] = G.value(False)
+        yield f, receipt, truncated
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--logs-root", type=pathlib.Path)
+    ap.add_argument("--out", type=pathlib.Path)
+    ap.add_argument("--max-bytes", type=int, default=2_000_000)
+    ap.add_argument("--self-test", action="store_true")
+    a = ap.parse_args()
+    if a.self_test:
+        return _self_test()
+    if not a.logs_root or not a.out:
+        ap.error("--logs-root and --out are required")
+
+    a.out.mkdir(parents=True, exist_ok=True)
+    dist = collections.Counter()
+    malformed, truncs, n = [], 0, 0
+    with (a.out / "receipts.jsonl").open("w", encoding="utf-8") as fh:
+        for f, receipt, truncated in rows_for(a.logs_root, a.max_bytes):
+            bad = [k for k, v in receipt.items() if not (("value" in v) ^ ("unknown" in v))]
+            if bad:
+                malformed.append((str(f), bad))
+            dist["cargo" if G.is_known(receipt["format"]) else "unknown-format"] += 1
+            if G.is_known(receipt["outcome"]):
+                dist[f"outcome={receipt['outcome']['value']}"] += 1
+            truncs += int(truncated)
+            n += 1
+            fh.write(json.dumps({"log_path": str(f), "receipt": receipt}, sort_keys=True) + "\n")
+
+    summary = {"rows": n, "distribution": dict(dist), "truncated_rows": truncs,
+               "malformed_rows": len(malformed), "malformed": malformed[:20],
+               "max_bytes": a.max_bytes, "logs_root": str(a.logs_root)}
+    (a.out / "summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True))
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    # A malformed row means a field was neither value nor unknown, which is the one
+    # invariant this dataset exists to uphold. Refuse rather than ship it.
+    return 3 if malformed else 0
+
+
+def _self_test() -> int:
+    import tempfile
+    cases = []
+    with tempfile.TemporaryDirectory() as d:
+        root = pathlib.Path(d)
+        (root / "a.log").write_text("   Compiling x v0.1.0\ntest result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.0s\n")
+        (root / "b.log").write_text("watching CI, ALL GREEN\n")
+        (root / "c.log").write_text("")
+        (root / "skip.md").write_text("test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.0s\n")
+        got = {f.name: (r, t) for f, r, t in rows_for(root, 1_000_000)}
+        cases.append(("only log-shaped extensions are read; a .md quoting a result is NOT a gate log",
+                      set(got) == {"a.log", "b.log", "c.log"}))
+        cases.append(("a real cargo log reports format", got["a.log"][0]["format"]["value"] == "cargo-test"))
+        cases.append(("a CI-watcher log does NOT claim cargo format", not G.is_known(got["b.log"][0]["format"])))
+        cases.append(("an empty log does NOT claim cargo format", not G.is_known(got["c.log"][0]["format"])))
+        cases.append(("every field is two-shaped on every row",
+                      all(("value" in v) ^ ("unknown" in v) for _, (r, _) in got.items() for v in r.values())))
+        big = root / "big.log"
+        big.write_text("x" * 50 + "\ntest result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.0s\n")
+        small = {f.name: (r, t) for f, r, t in rows_for(root, 10)}
+        cases.append(("truncation is DECLARED on the row, not silent",
+                      small["big.log"][1] is True and small["big.log"][0]["log"]["value"]["truncated"] is True))
+        cases.append(("a truncated read does not invent counts",
+                      not G.is_known(small["big.log"][0]["passed"])))
+    bad = [n for n, ok in cases if not ok]
+    for n, ok in cases:
+        print(f"  {'ok  ' if ok else 'FAIL'}  {n}")
+    if bad:
+        print(f"SELF-TEST FAILED: {len(bad)} case(s)", file=sys.stderr)
+        return 3
+    print(f"self-test OK  {len(cases)} cases")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/microlora/gate_log_receipt.py
+++ b/scripts/microlora/gate_log_receipt.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Turn a gate log into a structured receipt in which ABSENCE IS A VALUE.
+
+The failure mode this exists to prevent is a receipt that silently omits what it could
+not determine. A consumer reading such a receipt cannot distinguish "the gate reported
+zero failures" from "nothing in this log told me about failures", and those two states
+disagree in the direction that matters: the second one reads as success.
+
+So every field in a receipt is one of two shapes, never missing:
+
+    {"value": 0}
+    {"unknown": "no rc marker in the log; the runner did not echo one"}
+
+and `require()` lets a caller name the fields it refuses to proceed without.
+
+WHAT A CARGO TEST LOG CAN AND CANNOT ANSWER, measured against a real run rather than
+assumed (40 `test result:` lines from one `cargo test -p lattice-inference` invocation):
+
+  determinable   passed, failed, ignored, measured, filtered_out, per-binary breakdown
+  NOT in the log the exact command, the exit code, the source hash
+                 -- unless the runner echoed them, which is a property of the runner,
+                 not of cargo. Mine echoes CLIPPY_RC/TEST_RC; most do not.
+
+Two aggregations are deliberately NOT performed:
+
+1. `ignored` and `filtered_out` are both "did not run" and they are NOT summed into a
+   single `skipped`. `#[ignore]` is a property of the test; filtered-out is a property
+   of the invocation's filter. A single number hides which one moved, and the whole
+   point of a receipt is to survive someone asking that later.
+2. `measured` is reported as measured, never normalised away. It is 0 for every test
+   binary because it is a bench field, and a receipt that drops always-zero fields is
+   one schema change away from dropping a field that stopped being always-zero.
+
+THE CASE THAT LOOKS LIKE NOTHING. A binary that ran with no matching tests emits
+`0 passed; 0 failed; 0 filtered out`, and a binary that never built emits no line at
+all. Both contribute zero to every total. The receipt therefore carries `binaries`, a
+count of `test result:` lines, so a consumer can see the difference between "ran 12
+binaries, all empty" and "ran 0 binaries". Totals alone cannot express it.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+EXIT_OK, EXIT_USAGE, EXIT_REFUSED, EXIT_INCOMPLETE = 0, 2, 3, 4
+
+_RESULT = re.compile(
+    r"^test result: (?P<outcome>\w+)\. (?P<passed>\d+) passed; (?P<failed>\d+) failed; "
+    r"(?P<ignored>\d+) ignored; (?P<measured>\d+) measured; (?P<filtered_out>\d+) filtered out",
+    re.M,
+)
+_RC = re.compile(r"^(?P<name>[A-Z][A-Z0-9_]*_RC)=(?P<rc>-?\d+)\s*$", re.M)
+
+COUNTERS = ("passed", "failed", "ignored", "measured", "filtered_out")
+
+
+def value(v):
+    return {"value": v}
+
+
+def unknown(why: str):
+    return {"unknown": why}
+
+
+def is_known(field: dict) -> bool:
+    return "value" in field
+
+
+def parse_cargo_test_log(text: str) -> dict:
+    """Receipt fields derivable from the log text alone."""
+    rows = [m.groupdict() for m in _RESULT.finditer(text)]
+    receipt: dict = {"format": value("cargo-test"), "binaries": value(len(rows))}
+
+    if not rows:
+        # Empty is not clean. A log with no result lines answers nothing about counts,
+        # and returning zeros here would manufacture a passing receipt out of a failed
+        # read -- the exact shape this file exists to prevent.
+        for name in COUNTERS:
+            receipt[name] = unknown("no `test result:` line in the log; counts are unread, not zero")
+        receipt["executed"] = unknown("no `test result:` line in the log")
+        receipt["outcome"] = unknown("no `test result:` line in the log")
+        return receipt
+
+    for name in COUNTERS:
+        receipt[name] = value(sum(int(r[name]) for r in rows))
+    receipt["executed"] = value(receipt["passed"]["value"] + receipt["failed"]["value"])
+    outcomes = {r["outcome"] for r in rows}
+    receipt["outcome"] = value("ok" if outcomes == {"ok"} else "FAILED")
+    receipt["per_binary"] = value([{k: int(r[k]) for k in COUNTERS} | {"outcome": r["outcome"]} for r in rows])
+    return receipt
+
+
+def rc_from_log(text: str) -> dict:
+    """Exit codes only exist in a log if the RUNNER echoed them. Absence is not zero."""
+    found = {m.group("name"): int(m.group("rc")) for m in _RC.finditer(text)}
+    if not found:
+        return unknown("no NAME_RC=<int> marker in the log; cargo does not echo its own "
+                       "exit code, so this is a property of the runner and absent here")
+    return value(found)
+
+
+def build(log_path: Path, command: str | None, source_hash: str | None) -> dict:
+    text = log_path.read_text(errors="replace")
+    receipt = parse_cargo_test_log(text)
+    receipt["log"] = value({"path": str(log_path), "bytes": len(text.encode()),
+                            "sha256": hashlib.sha256(text.encode()).hexdigest()[:16]})
+    receipt["exit_code"] = rc_from_log(text)
+    receipt["command"] = value(command) if command else unknown(
+        "not recoverable from a cargo test log; pass --command with the invocation you ran")
+    receipt["source_hash"] = value(source_hash) if source_hash else unknown(
+        "not recoverable from a cargo test log; pass --source-hash with the ref you built")
+    receipt["executed_generated_command"] = value(False)
+    return receipt
+
+
+def require(receipt: dict, names: list[str]) -> list[str]:
+    """Field names the caller demanded that the receipt could not determine."""
+    return [n for n in names if n not in receipt or not is_known(receipt[n])]
+
+
+def _self_test() -> int:
+    cases = []
+
+    full = ("test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2875 filtered out; finished in 0.04s\n"
+            "test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out; finished in 0.00s\n"
+            "CLIPPY_RC=0\n")
+    r = parse_cargo_test_log(full)
+    cases.append(("two binaries counted", r["binaries"]["value"] == 2))
+    cases.append(("passed summed", r["passed"]["value"] == 10))
+    cases.append(("filtered_out summed, NOT merged into a skipped total",
+                  r["filtered_out"]["value"] == 2889 and "skipped" not in r))
+    cases.append(("ignored kept separate from filtered_out", r["ignored"]["value"] == 0))
+    cases.append(("executed excludes ignored and filtered", r["executed"]["value"] == 10))
+    cases.append(("rc parsed when the runner echoed it", rc_from_log(full)["value"] == {"CLIPPY_RC": 0}))
+
+    # The arm that matters: an empty read must not produce a clean receipt.
+    empty = parse_cargo_test_log("warning: unrelated\n")
+    cases.append(("empty log -> counts UNKNOWN, not 0", not is_known(empty["passed"])))
+    cases.append(("empty log -> binaries is a known 0, which is the discriminator",
+                  empty["binaries"]["value"] == 0))
+    cases.append(("empty log -> outcome UNKNOWN, never 'ok'", not is_known(empty["outcome"])))
+    cases.append(("no rc marker -> UNKNOWN, not 0", not is_known(rc_from_log("no markers here"))))
+
+    # Ran-but-empty vs never-built: identical totals, different `binaries`.
+    ran_empty = parse_cargo_test_log(
+        "test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n")
+    cases.append(("ran-with-no-tests and never-built have equal totals",
+                  ran_empty["passed"].get("value") == 0 and not is_known(empty["passed"])))
+    cases.append(("...and are separated ONLY by binaries",
+                  ran_empty["binaries"]["value"] == 1 and empty["binaries"]["value"] == 0))
+
+    # A failing binary anywhere makes the receipt's outcome FAILED.
+    mixed = parse_cargo_test_log(
+        "test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s\n"
+        "test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s\n")
+    cases.append(("one FAILED binary makes the whole outcome FAILED", mixed["outcome"]["value"] == "FAILED"))
+
+    # THE INVARIANT THE WHOLE FILE RESTS ON, and it was untested until a real log crashed a
+    # reader: every field is two-shaped. `format` was a bare string here, so a consumer
+    # written against the documented schema hit a type error on the first real receipt.
+    # A rule the module states and does not check is a comment.
+    def two_shaped(rec):
+        return [k for k, v in rec.items()
+                if not (isinstance(v, dict) and (("value" in v) ^ ("unknown" in v)))]
+    cases.append(("every field two-shaped: full log", two_shaped(r) == []))
+    cases.append(("every field two-shaped: empty log", two_shaped(empty) == []))
+    cases.append(("a field is never BOTH value and unknown",
+                  two_shaped({"x": {"value": 1, "unknown": "y"}}) == ["x"]))
+
+    cases.append(("require() names the undetermined fields",
+                  require({"a": value(1), "b": unknown("x")}, ["a", "b", "c"]) == ["b", "c"]))
+
+    bad = 0
+    for label, ok in cases:
+        bad += not ok
+        print(f"  {'ok  ' if ok else 'FAIL'}  {label}")
+    if bad:
+        print(f"SELF-TEST FAILED: {bad} case(s)", file=sys.stderr)
+        return EXIT_INCOMPLETE
+    print(f"self-test OK  {len(cases)} cases")
+    return EXIT_OK
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--log", type=Path)
+    ap.add_argument("--command", help="the exact invocation; a cargo log does not contain it")
+    ap.add_argument("--source-hash", help="the ref/sha built; a cargo log does not contain it")
+    ap.add_argument("--require", default="", help="comma-separated fields to refuse without")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return _self_test()
+    if not args.log:
+        ap.error("--log or --self-test is required")
+
+    receipt = build(args.log, args.command, args.source_hash)
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+
+    demanded = [f.strip() for f in args.require.split(",") if f.strip()]
+    missing = require(receipt, demanded)
+    if missing:
+        print(f"INCOMPLETE: required field(s) undetermined: {missing}", file=sys.stderr)
+        return EXIT_INCOMPLETE
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/microlora/gate_log_receipt.py
+++ b/scripts/microlora/gate_log_receipt.py
@@ -57,6 +57,37 @@ _RC = re.compile(r"^(?P<name>[A-Z][A-Z0-9_]*_RC)=(?P<rc>-?\d+)\s*$", re.M)
 
 COUNTERS = ("passed", "failed", "ignored", "measured", "filtered_out")
 
+# CI logs are the same cargo output wearing a wrapper. `gh run view --log` emits
+# "<job>\t<step>\t<ISO8601Z> <content>" and cargo colours its own output, so every
+# line-anchored pattern below misses on a CI log while matching the identical local log.
+# Measured: four real CI runs carrying 100, 0, 100 and 1263 marker lines by an unanchored
+# grep were all read as "not cargo output" before this existed.
+# Both spellings. `gh run view --log` writes the escape in CARET NOTATION -- the two
+# ASCII characters "^" and "[", not byte 0x1b -- so a pattern written for the real
+# control character matches nothing and the log reads as "not cargo output".
+# Measured on a real CI log: 0 bytes of 0x1b, 1738 literal "^[" sequences.
+_ANSI = re.compile(r"(?:\x1b|\^\[)\[[0-9;]*[A-Za-z]")
+_TS = re.compile(r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z ")
+
+
+def strip_log_decoration(text: str) -> str:
+    """Reduce a CI-wrapped log to the bytes the tool actually wrote.
+
+    Conservative on purpose: the tab-separated prefix is removed ONLY when the final
+    field starts with an ISO timestamp, so a raw log whose line merely contains a tab
+    is left alone. Stripping unconditionally would silently eat real content.
+    """
+    out = []
+    for line in text.split("\n"):
+        line = _ANSI.sub("", line)
+        if "\t" in line:
+            tail = line.rsplit("\t", 1)[-1]
+            if _TS.match(tail):
+                line = tail
+        out.append(_TS.sub("", line, count=1))
+    return "\n".join(out)
+
+
 # Evidence that this log is cargo output at all. A cargo run that executed ZERO test
 # binaries still emits these, so requiring one does not cost the `binaries` discriminator
 # below; it costs only the logs that were never cargo output in the first place.
@@ -78,6 +109,7 @@ def is_known(field: dict) -> bool:
 
 def parse_cargo_test_log(text: str) -> dict:
     """Receipt fields derivable from the log text alone."""
+    text = strip_log_decoration(text)
     rows = [m.groupdict() for m in _RESULT.finditer(text)]
 
     # `format` is DERIVED, never assumed. Asserting "cargo-test" over a log that is not

--- a/scripts/microlora/gate_log_receipt.py
+++ b/scripts/microlora/gate_log_receipt.py
@@ -57,6 +57,12 @@ _RC = re.compile(r"^(?P<name>[A-Z][A-Z0-9_]*_RC)=(?P<rc>-?\d+)\s*$", re.M)
 
 COUNTERS = ("passed", "failed", "ignored", "measured", "filtered_out")
 
+# Evidence that this log is cargo output at all. A cargo run that executed ZERO test
+# binaries still emits these, so requiring one does not cost the `binaries` discriminator
+# below; it costs only the logs that were never cargo output in the first place.
+_CARGO_MARKER = re.compile(
+    r"^(?: *(?:Compiling|Running|Finished|Fresh|Doc-tests)\b|test result:|error\[E)", re.M)
+
 
 def value(v):
     return {"value": v}
@@ -73,7 +79,22 @@ def is_known(field: dict) -> bool:
 def parse_cargo_test_log(text: str) -> dict:
     """Receipt fields derivable from the log text alone."""
     rows = [m.groupdict() for m in _RESULT.finditer(text)]
-    receipt: dict = {"format": value("cargo-test"), "binaries": value(len(rows))}
+
+    # `format` is DERIVED, never assumed. Asserting "cargo-test" over a log that is not
+    # cargo output is the worst field to get wrong, because it is the one a consumer reads
+    # to decide how to interpret every other field. Measured on a 29-file corpus of real
+    # gate logs: 28 carried no cargo marker at all, so the assumed value was wrong far more
+    # often than it was right, and a 0-byte file claimed a format with no bytes to claim it
+    # from.
+    if _CARGO_MARKER.search(text):
+        receipt: dict = {"format": value("cargo-test"), "binaries": value(len(rows))}
+    else:
+        why = ("no cargo output marker (Compiling/Running/Finished/Doc-tests/test result:) "
+               "in this log, so it is not established as cargo output")
+        # `binaries` goes with it. The count of `test result:` lines only MEANS a count of
+        # test binaries inside a cargo log; outside one it is a count of a string that
+        # happens to be absent, which is not the same fact and must not read as "ran none".
+        receipt = {"format": unknown(why), "binaries": unknown(why)}
 
     if not rows:
         # Empty is not clean. A log with no result lines answers nothing about counts,
@@ -110,9 +131,9 @@ def build(log_path: Path, command: str | None, source_hash: str | None) -> dict:
                             "sha256": hashlib.sha256(text.encode()).hexdigest()[:16]})
     receipt["exit_code"] = rc_from_log(text)
     receipt["command"] = value(command) if command else unknown(
-        "not recoverable from a cargo test log; pass --command with the invocation you ran")
+        "a gate log does not record the invocation that produced it; pass --command")
     receipt["source_hash"] = value(source_hash) if source_hash else unknown(
-        "not recoverable from a cargo test log; pass --source-hash with the ref you built")
+        "a gate log does not record the ref it was produced from; pass --source-hash")
     receipt["executed_generated_command"] = value(False)
     return receipt
 
@@ -140,18 +161,32 @@ def _self_test() -> int:
     # The arm that matters: an empty read must not produce a clean receipt.
     empty = parse_cargo_test_log("warning: unrelated\n")
     cases.append(("empty log -> counts UNKNOWN, not 0", not is_known(empty["passed"])))
-    cases.append(("empty log -> binaries is a known 0, which is the discriminator",
-                  empty["binaries"]["value"] == 0))
     cases.append(("empty log -> outcome UNKNOWN, never 'ok'", not is_known(empty["outcome"])))
     cases.append(("no rc marker -> UNKNOWN, not 0", not is_known(rc_from_log("no markers here"))))
 
-    # Ran-but-empty vs never-built: identical totals, different `binaries`.
+    # A log with no cargo marker is not cargo output, and the receipt must not claim it is.
+    # `format` is the field a consumer reads to decide how to interpret the rest, so an
+    # assumed value here mis-frames every other field at once.
+    cases.append(("non-cargo log -> format UNKNOWN, never claimed as cargo-test",
+                  not is_known(empty["format"])))
+    cases.append(("non-cargo log -> binaries UNKNOWN, because a missing string is not a count",
+                  not is_known(empty["binaries"])))
+    cases.append(("a 0-byte log claims no format at all",
+                  not is_known(parse_cargo_test_log("")["format"])))
+
+    # Ran-but-empty vs never-built: identical totals, different `binaries`. BOTH sides are
+    # real cargo logs -- a cargo run that built and ran no test binary still emits its own
+    # markers -- so deriving `format` above costs this discriminator nothing.
     ran_empty = parse_cargo_test_log(
         "test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n")
+    never_built = parse_cargo_test_log(
+        "   Compiling lattice-inference v0.1.0\n    Finished test profile in 4.21s\n")
+    cases.append(("a cargo log that ran NO binary still reports format",
+                  never_built["format"]["value"] == "cargo-test"))
     cases.append(("ran-with-no-tests and never-built have equal totals",
-                  ran_empty["passed"].get("value") == 0 and not is_known(empty["passed"])))
-    cases.append(("...and are separated ONLY by binaries",
-                  ran_empty["binaries"]["value"] == 1 and empty["binaries"]["value"] == 0))
+                  ran_empty["passed"].get("value") == 0 and not is_known(never_built["passed"])))
+    cases.append(("...and are separated ONLY by binaries, both known",
+                  ran_empty["binaries"]["value"] == 1 and never_built["binaries"]["value"] == 0))
 
     # A failing binary anywhere makes the receipt's outcome FAILED.
     mixed = parse_cargo_test_log(

--- a/scripts/microlora/score_dsl_args.py
+++ b/scripts/microlora/score_dsl_args.py
@@ -1,0 +1,518 @@
+#!/usr/bin/env python3
+"""Score generated khive DSL for ARGUMENT validity, beyond parser acceptance.
+
+WHY THIS EXISTS. `dsl_validator.rs` runs the real parser: syntax, AST round-trip, canonical
+reparse. It emits `executed: false` and it is right to. But it cannot know what a verb's
+arguments are called, so `memory.recall(q="...")` validates perfectly and then fails at
+runtime, because the parameter is `query`. Parser acceptance is a weaker property than
+callability, and an adapter trained against the weaker one learns to emit plausible-looking
+commands that do not run.
+
+WHAT IT DOES NOT DO. It never executes a generated command, and it never contacts a server.
+It reads the captured verb schemas and compares names. That is the whole mechanism.
+
+THE ONE DESIGN RULE THAT MATTERS, and it decides whether this thing is worth having:
+ABSENCE IS NOT PERMISSION. A verb with no captured schema is REFUSED, never passed. The
+capture distinguishes the two cases and that is what makes the rule enforceable: all 98
+captured verbs carry an explicit `params` list, and the 8 parameterless ones carry an
+explicit EMPTY list. So "takes nothing" is a positive fact in the data, while "not captured"
+is a missing file. A scorer that treated a missing schema as "no constraints" would pass
+every hallucinated verb in the corpus and report a flattering number.
+
+Verdicts: PASS, FAIL, REFUSED. All three are reachable; `--self-test` proves it rather than
+asserting it, because a scorer that can only emit one verdict is not measuring anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+# No baked-in paths. Every tracked script beside this one takes its inputs as explicit
+# flags, and a default pointing into a dated local workspace resolves on exactly one
+# machine while reading, in a public tree, as though it were a repository location.
+# Making them required also removes the shape of the bug this file already had once:
+# a self-test that read a module default instead of the flag it was handed reported
+# "OK verbs=98" while pointed at an empty directory.
+
+EXIT_PASS, EXIT_USAGE, EXIT_REFUSED, EXIT_FAIL = 0, 2, 3, 4
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for block in iter(lambda: fh.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def _find_params(obj):
+    """The captured schemas nest `params` at a depth that is not contractual, so search."""
+    if isinstance(obj, dict):
+        if isinstance(obj.get("params"), list):
+            return obj["params"]
+        for value in obj.values():
+            found = _find_params(value)
+            if found is not None:
+                return found
+    elif isinstance(obj, list):
+        for value in obj:
+            found = _find_params(value)
+            if found is not None:
+                return found
+    return None
+
+
+class Schemas:
+    """The captured verb schemas, with their identity.
+
+    The fingerprint is over the manifest's (name, sha256) pairs, not over a timestamp: a date
+    says when a capture was taken, a fingerprint says WHICH capture a score came from, and only
+    the second one survives the capture being retaken.
+    """
+
+    def __init__(self, schema_dir: Path, manifest_path: Path | None):
+        self.dir = schema_dir
+        self.verbs: dict[str, dict] = {}
+        self.fingerprint = "unverified"
+        self.drift: list[str] = []
+
+        for path in sorted(schema_dir.glob("*.json")):
+            if path.name.startswith("_"):
+                continue
+            params = _find_params(json.loads(path.read_text()))
+            if params is None:
+                # No params KEY at all is a broken capture, not a parameterless verb.
+                self.drift.append(f"{path.name}: no params key")
+                continue
+            self.verbs[path.stem] = {
+                "known": {p["name"] for p in params if "name" in p},
+                "required": {p["name"] for p in params if p.get("required") and "name" in p},
+                "types": {p["name"]: p.get("type") for p in params if "name" in p},
+            }
+
+        if manifest_path and manifest_path.exists():
+            manifest = json.loads(manifest_path.read_text())
+            pairs = []
+            for entry in manifest.get("files", []):
+                pairs.append((entry["name"], entry["sha256"]))
+                actual = schema_dir / entry["name"]
+                if not actual.exists():
+                    self.drift.append(f"{entry['name']}: missing")
+                elif _sha256(actual) != entry["sha256"]:
+                    self.drift.append(f"{entry['name']}: hash mismatch")
+            digest = hashlib.sha256()
+            for name, sha in sorted(pairs):
+                digest.update(f"{name}:{sha}\n".encode())
+            self.fingerprint = digest.hexdigest()[:16]
+
+
+
+# The capture's type vocabulary is NOT normalized: 15 distinct strings for 415 params, with
+# `bool`/`boolean`, `array of string`/`array<string>`, `array of object`/`array<object>` and
+# `number`/`float` each naming one thing two ways. A checker keying on raw spellings would
+# silently mis-handle whichever spelling it did not anticipate, so everything is normalized first.
+# Anything NOT in this map is reported `unchecked` and counted -- never passed, never failed.
+_TYPE_NORMAL = {
+    "string": "string", "uuid": "string",
+    "integer": "integer",
+    "number": "number", "float": "number",
+    "boolean": "boolean", "bool": "boolean",
+    "object": "object",
+    "array": "array", "array of string": "array", "array<string>": "array",
+    "array of uuid": "array", "array of object": "array", "array<object>": "array",
+    # deliberately absent: "string | array<string>" -- a union this checker will not guess at.
+}
+
+
+def check_arg_type(wire_arg, declared: str | None) -> str:
+    """ok | mismatch | unchecked. `unchecked` is a first-class outcome, not a quiet pass."""
+    norm = _TYPE_NORMAL.get((declared or "").strip())
+    if norm is None:
+        return "unchecked"
+    if not isinstance(wire_arg, dict):
+        return "unchecked"
+    kind = wire_arg.get("kind")
+    if kind == "prev_ref":
+        # A $prev reference's runtime type is unknowable without executing, and this never executes.
+        return "unchecked"
+    if kind == "array":
+        return "ok" if norm == "array" else "mismatch"
+    if kind == "object":
+        return "ok" if norm == "object" else "mismatch"
+    if kind != "value":
+        return "unchecked"
+    value = wire_arg.get("value")
+    if isinstance(value, bool):
+        actual = "boolean"          # before int: bool is an int subclass in Python
+    elif isinstance(value, int):
+        actual = "integer"
+    elif isinstance(value, float):
+        actual = "number"
+    elif isinstance(value, str):
+        actual = "string"
+    elif isinstance(value, list):
+        actual = "array"
+    elif isinstance(value, dict):
+        actual = "object"
+    else:
+        return "unchecked"
+    if norm == "number" and actual == "integer":
+        return "ok"                 # an integer is an acceptable number
+    return "ok" if actual == norm else "mismatch"
+
+
+
+# --- axis 3: groundedness -------------------------------------------------------------
+# A literal can be well-named and well-typed and still be invented. session.export(
+# id="00000000-0000-0000-0000-000000000000") passes both earlier axes and names nothing.
+# Type checking is structurally blind to this, so it needs its own axis.
+#
+# The decision boundary is measured, not assumed. Over the 917-row reference test split,
+# all 1837 string literals in reference completions are grounded in their own prompt:
+# 79.0% verbatim, 12.5% as base64 of prompt text (blob.put payloads), 8.5% as nested DSL
+# whose inner literals are grounded (schedule.schedule action strings). Zero residual.
+# A zero reference-violation rate is what makes "ungrounded" decidable rather than a
+# threshold someone has to pick.
+#
+# HONESTY BOUND ON THAT NUMBER: this dataset is synthetic (dsl-final-audit.json records
+# 4201 rows, real_rows=1). A 100% groundedness rate is partly a property of the generator
+# that produced prompt/completion pairs from shared material, not a discovered law of the
+# task. It licenses "an ungrounded literal is a hallucination ON THIS DATASET" and does
+# not license a claim about held-out human-written prompts.
+
+_B64 = re.compile(r"^[A-Za-z0-9+/]{16,}={0,2}$")
+_INNER_ESCAPED = re.compile(r'\\"([^"\\]*)\\"')
+_INNER_PLAIN = re.compile(r'"([^"]*)"')
+_OPISH = re.compile(r"^[a-z_][a-z0-9_.]*\(.*\)$", re.S)
+_SCHEMA_ISH = re.compile(r"[a-z][a-z0-9_.:-]*|[\d:T+\-]+")
+
+
+def ground_value(value: str, prompt: str) -> str:
+    """verbatim | base64 | nested-dsl | UNGROUNDED."""
+    if not value:
+        return "verbatim"
+    if value in prompt:
+        return "verbatim"
+    if _B64.match(value):
+        try:
+            if base64.b64decode(value, validate=True).decode("utf-8") in prompt:
+                return "base64"
+        except (binascii.Error, UnicodeDecodeError):
+            pass
+    # Nested DSL arrives in TWO representations and a rule written for one is inert on the
+    # other. In raw completion text the inner quotes are JSON-escaped (\\"); in a parsed arg
+    # value they are plain ("). The first version of this matched only the escaped form, so
+    # it silently found nothing on parsed input and reported 87 of 917 REFERENCE rows as
+    # ungrounded -- gold data, wrong by construction. Both forms are matched here, and only
+    # for values that are actually shaped like an op, so an ordinary string that happens to
+    # contain quotes is not granted a recovery path it has not earned.
+    inner = [g for g in _INNER_ESCAPED.findall(value) if g]
+    if not inner and _OPISH.match(value):
+        inner = [g for g in _INNER_PLAIN.findall(value) if g]
+    if inner and all(g in prompt or _SCHEMA_ISH.fullmatch(g) for g in inner):
+        return "nested-dsl"
+    return "UNGROUNDED"
+
+
+def _wire_strings(wire_arg):
+    """Every string literal an arg carries, unwrapping the validator's wire shape."""
+    if isinstance(wire_arg, str):
+        yield wire_arg
+    elif isinstance(wire_arg, dict):
+        if wire_arg.get("kind") == "prev_ref":
+            return              # $prev.id refers to a sibling op, never to the prompt
+        v = wire_arg.get("value", wire_arg)
+        if v is not wire_arg:
+            yield from _wire_strings(v)
+    elif isinstance(wire_arg, list):
+        for item in wire_arg:
+            yield from _wire_strings(item)
+
+
+def score_groundedness(op: dict, prompt: str) -> dict:
+    hits, ungrounded = {}, []
+    for name, wire_arg in (op.get("args") or {}).items():
+        for value in _wire_strings(wire_arg):
+            verdict = ground_value(value, prompt)
+            hits[verdict] = hits.get(verdict, 0) + 1
+            if verdict == "UNGROUNDED":
+                ungrounded.append({"arg": name, "value": value[:120]})
+    return {"recovery": hits, "ungrounded": ungrounded}
+
+def score_op(op: dict, schemas: Schemas, prompt: str | None = None) -> dict:
+    verb = op.get("tool")
+    args = set((op.get("args") or {}).keys())
+    entry = schemas.verbs.get(verb)
+    if entry is None:
+        return {
+            "verb": verb,
+            "verdict": "REFUSED",
+            "reason": f"verb {verb!r} is not in the capture, so its arguments cannot be judged; "
+            "absence of a schema is not permission",
+        }
+    unknown = sorted(args - entry["known"])
+    missing = sorted(entry["required"] - args)
+
+    mismatched, unchecked = [], []
+    for name, wire_arg in (op.get("args") or {}).items():
+        if name in unknown:
+            continue                # already failing on the name; the type is moot
+        outcome = check_arg_type(wire_arg, entry["types"].get(name))
+        if outcome == "mismatch":
+            mismatched.append(name)
+        elif outcome == "unchecked":
+            unchecked.append(name)
+
+    # Groundedness is only evaluated when a prompt was supplied. With no prompt the axis
+    # reports not_evaluated and never contributes a PASS: a check that did not run is not
+    # a check that passed, and reporting it as absent is the only way a reader can tell.
+    if prompt is None:
+        ground = {"status": "not_evaluated"}
+        ungrounded = []
+    else:
+        ground = score_groundedness(op, prompt)
+        ground["status"] = "evaluated"
+        ungrounded = ground["ungrounded"]
+
+    if unknown or missing or mismatched or ungrounded:
+        return {
+            "verb": verb,
+            "verdict": "FAIL",
+            "unknown_args": unknown,
+            "missing_required": missing,
+            "type_mismatches": sorted(mismatched),
+            "unchecked_args": sorted(unchecked),
+            "groundedness": ground,
+        }
+    return {
+        "verb": verb,
+        "verdict": "PASS",
+        "arg_count": len(args),
+        "unchecked_args": sorted(unchecked),
+        "groundedness": ground,
+    }
+
+
+def score_row(row: dict, schemas: Schemas, prompt: str | None = None) -> dict:
+    if not row.get("ok"):
+        return {"verdict": "FAIL", "reason": "parser rejected the completion", "ops": []}
+    ops = [score_op(op, schemas, prompt) for op in row.get("ops", [])]
+    if not ops:
+        return {"verdict": "REFUSED", "reason": "no ops in a parser-accepted row", "ops": []}
+    verdicts = {o["verdict"] for o in ops}
+    # FAIL dominates REFUSED: a row with a known-bad argument is bad whatever else it contains.
+    overall = "FAIL" if "FAIL" in verdicts else ("REFUSED" if "REFUSED" in verdicts else "PASS")
+    return {"verdict": overall, "ops": ops}
+
+
+def _self_test(schema_dir: Path, manifest: Path) -> int:
+    """Prove all three verdicts are reachable. A one-verdict scorer measures nothing.
+
+    Takes the schema dir as an ARGUMENT rather than reading the module default. The first
+    version hardcoded the default, so `--self-test --schema-dir <empty>` printed
+    "self-test OK ... verbs=98" and exited 0 while pointed at an empty directory -- an
+    inert control that reported success, which is the worst failure shape available.
+    """
+    schemas = Schemas(schema_dir, manifest)
+    if not schemas.verbs:
+        print("SELF-TEST REFUSED: no schemas loaded", file=sys.stderr)
+        return EXIT_REFUSED
+
+    cases = [
+        ("correct arg name", {"ok": True, "ops": [{"tool": "memory.recall", "args": {"query": "x"}}]}, "PASS"),
+        ("the q-vs-query bug", {"ok": True, "ops": [{"tool": "memory.recall", "args": {"q": "x"}}]}, "FAIL"),
+        ("explicit-empty verb, no args", {"ok": True, "ops": [{"tool": "stats", "args": {}}]}, "PASS"),
+        ("explicit-empty verb, given an arg", {"ok": True, "ops": [{"tool": "stats", "args": {"limit": 1}}]}, "FAIL"),
+        ("hallucinated verb", {"ok": True, "ops": [{"tool": "memory.teleport", "args": {"x": 1}}]}, "REFUSED"),
+        ("missing required arg", {"ok": True, "ops": [{"tool": "memory.recall", "args": {"limit": 5}}]}, "FAIL"),
+        ("parser already rejected", {"ok": False}, "FAIL"),
+        ("FAIL dominates REFUSED", {"ok": True, "ops": [
+            {"tool": "memory.recall", "args": {"q": "x"}},
+            {"tool": "memory.teleport", "args": {}}]}, "FAIL"),
+        # Wire-shaped cases: the validator emits {"kind": ..., "value": ...}, and only these
+        # exercise type checking. The plain-args cases above leave types `unchecked` by design,
+        # so without these the type path would be entirely untested while the suite read green.
+        ("wire shape, correct type", {"ok": True, "ops": [
+            {"tool": "memory.recall", "args": {"query": {"kind": "value", "value": "x"}}}]}, "PASS"),
+        ("wire shape, integer given a string", {"ok": True, "ops": [
+            {"tool": "memory.recall", "args": {
+                "query": {"kind": "value", "value": "x"},
+                "limit": {"kind": "value", "value": "banana"}}}]}, "FAIL"),
+        ("prev_ref is unchecked, not failed", {"ok": True, "ops": [
+            {"tool": "memory.recall", "args": {
+                "query": {"kind": "prev_ref", "path": "$prev.id"}}}]}, "PASS"),
+        # Groundedness with NO prompt: must not fail, and must not silently claim to have
+        # checked. The verdict here proves only that the axis stays out of the way.
+        ("no prompt, axis not evaluated", {"ok": True, "ops": [
+            {"tool": "memory.recall", "args": {
+                "query": {"kind": "value", "value": "anything at all"}}}]}, "PASS"),
+    ]
+    bad = 0
+    for label, row, want in cases:
+        got = score_row(row, schemas)["verdict"]
+        ok = got == want
+        bad += not ok
+        print(f"  {'ok  ' if ok else 'FAIL'}  {label:34s} want {want:8s} got {got}")
+
+    # The groundedness axis needs its own block because it takes a second input. The pair
+    # below is DISCRIMINATING by construction: identical op, identical schema, one literal
+    # changed, opposite verdicts. A fixture where both arms pass would test nothing -- the
+    # earlier version of this file's W1 control had exactly that defect.
+    real_id = "36d8a874-a02a-5cee-b47b-99e5fd60654e"
+    fake_id = "00000000-0000-0000-0000-000000000000"
+    prompt = f"Write the request ops for this task: Export stored session {real_id} as markdown."
+    pair = [
+        ("grounded id + prompt", real_id, "PASS"),
+        ("hallucinated id + same prompt", fake_id, "FAIL"),
+    ]
+    for label, ident, want in pair:
+        row = {"ok": True, "ops": [{"tool": "session.export", "args": {
+            "id": {"kind": "value", "value": ident},
+            "format": {"kind": "value", "value": "markdown"}}}]}
+        got = score_row(row, schemas, prompt)["verdict"]
+        ok = got == want
+        bad += not ok
+        print(f"  {'ok  ' if ok else 'FAIL'}  {label:34s} want {want:8s} got {got}")
+
+    # And the mutation control on the axis itself: the SAME hallucinated row must PASS when
+    # no prompt is supplied, which proves the FAIL above came from groundedness and not
+    # from some other axis reacting to the changed literal.
+    row = {"ok": True, "ops": [{"tool": "session.export", "args": {
+        "id": {"kind": "value", "value": fake_id},
+        "format": {"kind": "value", "value": "markdown"}}}]}
+    got = score_row(row, schemas)["verdict"]
+    ok = got == "PASS"
+    bad += not ok
+    print(f"  {'ok  ' if ok else 'FAIL'}  {'same row, axis off -> PASS':34s} want PASS     got {got}")
+
+    # Regression fixture for the representation bug: nested DSL in PARSED form (plain inner
+    # quotes). Without the parsed branch this row reads UNGROUNDED and fails, which is how
+    # 87 gold rows failed. The second arm keeps it honest -- an inner literal absent from the
+    # prompt must still fail, or the branch would be granting blanket amnesty to any op-ish
+    # value rather than actually checking the inner literals.
+    nested_prompt = ('At 2027-02-01T09:00:00Z, dispatch a call that schedules a reminder for '
+                     '2027-03-16T09:00:00Z with content "Check pagination regression tests."')
+    for label, content, want in [
+        ("nested DSL, parsed form", "Check pagination regression tests.", "PASS"),
+        ("nested DSL, invented inner literal", "Delete the production database.", "FAIL"),
+    ]:
+        action = f'schedule.remind(content="{content}",at="2027-03-16T09:00:00Z")'
+        row = {"ok": True, "ops": [{"tool": "schedule.schedule", "args": {
+            "action": {"kind": "value", "value": action},
+            "at": {"kind": "value", "value": "2027-02-01T09:00:00Z"}}}]}
+        got = score_row(row, schemas, nested_prompt)["verdict"]
+        ok = got == want
+        bad += not ok
+        print(f"  {'ok  ' if ok else 'FAIL'}  {label:34s} want {want:8s} got {got}")
+
+    reached = {score_row(r, schemas)["verdict"] for _, r, _ in cases}
+    print(f"\nverdicts reached: {sorted(reached)}")
+    if reached != {"PASS", "FAIL", "REFUSED"}:
+        print("SELF-TEST FAILED: not all three verdicts are reachable", file=sys.stderr)
+        return EXIT_FAIL
+    if bad:
+        print(f"SELF-TEST FAILED: {bad} case(s)", file=sys.stderr)
+        return EXIT_FAIL
+    print(f"self-test OK  capture={schemas.fingerprint}  verbs={len(schemas.verbs)}")
+    if schemas.drift:
+        print(f"WARNING capture drift: {schemas.drift}", file=sys.stderr)
+        return EXIT_REFUSED
+    return EXIT_PASS
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--validated", type=Path, help="JSONL emitted by dsl_validator")
+    ap.add_argument("--schema-dir", type=Path, required=True,
+                    help="directory of captured verb schemas")
+    ap.add_argument("--manifest", type=Path, required=True,
+                    help="capture manifest; its (name, sha256) pairs fingerprint the capture")
+    ap.add_argument("--pairs", type=Path,
+                    help="prompt/completion JSONL; enables the groundedness axis. Joined on the\n"
+                         "validator's 1-indexed `line` field, never on position.")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return _self_test(args.schema_dir, args.manifest)
+    if not args.validated:
+        ap.error("--validated or --self-test is required")
+
+    schemas = Schemas(args.schema_dir, args.manifest)
+    if not schemas.verbs:
+        print("REFUSED: no schemas loaded; scoring nothing", file=sys.stderr)
+        return EXIT_REFUSED
+    if schemas.drift:
+        print(f"REFUSED: capture drift, scores would not be attributable: {schemas.drift}", file=sys.stderr)
+        return EXIT_REFUSED
+
+    prompts: dict[int, str] = {}
+    if args.pairs:
+        for i, raw in enumerate(args.pairs.read_text().splitlines(), start=1):
+            if raw.strip():
+                prompts[i] = json.loads(raw)["prompt"]
+        if not prompts:
+            print("REFUSED: --pairs supplied but empty; an empty join is not a clean score",
+                  file=sys.stderr)
+            return EXIT_REFUSED
+
+    counts = {"PASS": 0, "FAIL": 0, "REFUSED": 0}
+    ground_tally: dict[str, int] = {}
+    unjoined = 0
+    for raw in args.validated.read_text().splitlines():
+        if not raw.strip():
+            continue
+        row = json.loads(raw)
+        prompt = None
+        if prompts:
+            lineno = row.get("line")
+            prompt = prompts.get(lineno)
+            if prompt is None:
+                # A validated row whose line number is not in the pairs file means the two
+                # inputs do not describe the same run. Scoring it with the axis silently off
+                # would report a PASS that no groundedness check produced.
+                unjoined += 1
+        scored = score_row(row, schemas, prompt)
+        counts[scored["verdict"]] += 1
+        for op in scored.get("ops", []):
+            g = op.get("groundedness") or {}
+            for k, n in (g.get("recovery") or {}).items():
+                ground_tally[k] = ground_tally.get(k, 0) + n
+
+    if unjoined:
+        print(f"REFUSED: {unjoined} validated row(s) had no matching line in --pairs; "
+              "the two inputs are not the same run", file=sys.stderr)
+        return EXIT_REFUSED
+
+    total = sum(counts.values())
+    if total == 0:
+        print("REFUSED: input contained no rows; an empty input is not a clean score", file=sys.stderr)
+        return EXIT_REFUSED
+
+    print(f"capture={schemas.fingerprint}  verbs={len(schemas.verbs)}  n={total}")
+    for verdict in ("PASS", "FAIL", "REFUSED"):
+        print(f"  {verdict:8s} {counts[verdict]:6d}  {counts[verdict]/total:6.1%}")
+    if prompts:
+        gtot = sum(ground_tally.values())
+        print(f"\ngroundedness: evaluated, {gtot} string literal(s)")
+        for k in sorted(ground_tally, key=lambda k: -ground_tally[k]):
+            print(f"  {k:12s} {ground_tally[k]:6d}  {ground_tally[k]/gtot:6.1%}" if gtot else k)
+    else:
+        print("\ngroundedness: NOT EVALUATED (no --pairs) — literals were not checked "
+              "against any prompt")
+    print("\nexecuted: false — no generated command was run")
+    if counts["FAIL"]:
+        return EXIT_FAIL
+    return EXIT_REFUSED if counts["REFUSED"] else EXIT_PASS
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Two scoring layers over artifacts that already exist. Neither executes a generated command, and
both report that fact in their output.

### `score_dsl_args.py` — argument validity, types, and groundedness

The DSL validator runs the real parser: syntax, AST round-trip, canonical reparse. That is correct
and it is not sufficient. **Parser acceptance is a strictly weaker property than callability** —
`memory.recall(q="...")` parses perfectly and fails at runtime, because the parameter is `query`. An
adapter scored against the weaker property learns to emit plausible commands that do not run.

Three axes, against a schema capture pinned by content (a sha256 over the manifest's sorted
`(name, sha256)` pairs) rather than by date, so a score can be attributed to a capture and the
scorer refuses if any file has drifted from the manifest.

1. **Argument names.** Unknown or missing-required names fail.
2. **Types.** The capture's type vocabulary is not normalised — `bool`/`boolean`,
   `array of string`/`array<string>`, `number`/`float` each name one thing twice — so it is
   normalised before comparison. One union type is deliberately left unmapped and reported as
   `unchecked` rather than guessed at.
3. **Groundedness.** A literal can be well-named and well-typed and still be invented:
   `session.export(id="00000000-0000-0000-0000-000000000000")` names nothing, and the first two
   axes cannot express that, because both read the schema and neither reads the request.

**Absence is not permission.** A verb with no captured schema is REFUSED, never passed. That is
enforceable because the capture distinguishes "takes nothing" (an explicit empty parameter list, a
positive fact in the data) from "not captured" (a missing file). Likewise, with no prompts supplied
the groundedness axis reports `not_evaluated` and contributes no PASS — a check that did not run is
not a check that passed, and the output says which it was.

The groundedness decision boundary is measured, not chosen. Across the 917-row reference split, all
1837 string literals in reference completions ground in their own prompt: verbatim, as base64 of
prompt text, or as nested DSL whose inner literals ground. Zero residual. A zero
reference-violation rate is what makes "ungrounded" decidable instead of a threshold someone picks.
The dataset is synthetic, so that rate is partly a property of its generator rather than a law of
the task; the code says so at the point where the number is used, and scopes what it licenses.

### `gate_log_receipt.py` — a receipt in which absence is a value

A receipt that omits what it could not determine is read as one that determined it. Every field is
`{"value": x}` or `{"unknown": "<why>"}` and never missing, and `require()` lets a consumer name
fields it refuses to proceed without.

A cargo log does not contain the invocation or the source hash, and cargo does not echo its own exit
code, so those are `unknown` unless supplied. `ignored` and `filtered_out` are not summed into one
`skipped`: one is a property of the test, the other of the invocation's filter, and a single number
hides which moved. The count of `test result:` lines is carried because a binary that ran with no
matching tests and one that never built contribute zero to every total and are separable only by
that count — which is the difference between "the gate ran and found nothing" and "the gate did not
run".

## Tests

Both ship `--self-test` with fixtures that are discriminating rather than illustrative.

For groundedness the fixtures are a triple: the same op with a grounded id passes, with a
hallucinated id fails, and **the same hallucinated row with the axis off passes** — the third is
what proves the failure came from that axis and not from another one reacting to a changed literal.
The nested-DSL branch is likewise paired: a nested op in parsed form passes, and one whose inner
literal is absent from the prompt still fails, so the branch checks its inner literals rather than
granting amnesty to anything op-shaped.

Two defects were found by running against real data after the suites were green, and both are now
fixtures:

- the nested-DSL rule matched the JSON-escaped quote form present in raw text, while the scorer runs
  on parsed args where the parser has already unescaped them — so it silently matched nothing and
  failed 87 of 917 **reference** rows, data correct by definition;
- the receipt's `format` field was a bare string while every other field was two-shaped, so the
  first real receipt raised a `TypeError` in a reader. The invariant the module documents is now
  asserted over every field of both a populated and an empty receipt.

## Scope

`scripts/` only. No crate source, manifest, feature, profile, or bench definition is touched.
