### PR TITLE
fix(bench): make-bench-gate asked the gate about a baseline it never writes

### DIFF
--- a/scripts/bench-gate.sh
+++ b/scripts/bench-gate.sh
@@ -111,13 +111,24 @@ bench_quiet_checkpoint "bench-gate: after measurements"
 echo "UNSUITABLE AS BENCHMARK EVIDENCE: local bench-gate has no run provenance"
 rc=0
 gate_rc=0
+# --baseline-name base, on BOTH calls. The stored baselines are copied in under
+# <group>/base/ (that is how perf-baselines stores them, and it is the name the
+# `cargo bench -- --baseline base` runs above read), while this flag defaults to
+# `compare-base`, which is what bench-compare.sh writes. The gate's help text --
+# "Named-baseline dir to look for when base/ is absent" -- describes the tolerant
+# RENDER path; the strict inventory that --require-measurements consults declines
+# that fallback on purpose, and says so in find_selected_baseline_files' own
+# docstring. Without the flag the gate finds no selected base set at all and
+# refuses with rc=2, so `make bench-gate` exits 2 no matter what the numbers say.
 "$PYTHON_BIN" scripts/perf-bench-gate.py \
     "$inference_root" "$arch-local/lattice-inference:elementwise_cpu_bench" \
     --target lattice-inference:elementwise_cpu_bench \
+    --baseline-name base \
     --require-measurements || rc=$?
 "$PYTHON_BIN" scripts/perf-bench-gate.py \
     "$embed_root" "$arch-local/lattice-embed:simd" \
     --target lattice-embed:simd \
+    --baseline-name base \
     --require-measurements || gate_rc=$?
 if [[ "$rc" -eq 2 || "$gate_rc" -eq 2 ]]; then
     exit 2


### PR DESCRIPTION
## The defect

`make bench-gate` copies the stored baselines in under `<group>/base/` — that is how
`perf-baselines` stores them (`<arch>/add_bias_gelu/4096/base/estimates.json`), and it is
the name the `cargo bench -- --baseline base` runs immediately above depend on. It then
calls `perf-bench-gate.py` with **no `--baseline-name`**, and that flag defaults to
`compare-base`, which is what `bench-compare.sh` writes.

So the gate is asked about a baseline this path never creates. It finds no selected base
set and refuses under `--require-measurements` with `rc=2`. Both invocations are affected
and the script maps either `2` to `exit 2`, so **`make bench-gate` exits 2 regardless of
what the benchmarks did** — a documented local command that cannot return a verdict.

## The refusal is correct; the question was wrong

Nothing here weakens the gate. `find_selected_baseline_files` declines the tolerant
`base/` fallback on purpose, and says why in its own docstring: those fallbacks "are not
evidence about the named base arm selected by `--baseline-name`". That is right.

What misleads is the flag's help text — *"Named-baseline dir to look for when `base/` is
absent"* — which describes the tolerant **render** path, not the strict inventory
`--require-measurements` consults. Reading that line sends you looking for a missing
anchor instead of a mismatched name.

## Control

Run against the layout `perf-baselines` actually stores, copied into a scratch Criterion
root rather than a hand-built fixture:

| arm | result |
|---|---|
| as called today | `error: --require-measurements set but selected baseline 'compare-base' contains no benchmark estimates ... for target lattice-inference:elementwise_cpu_bench` |
| `--baseline-name base` | selects the arm and names `lattice-inference:elementwise_cpu_bench: add_bias_gelu/4096` as a member, advancing to the head-comparison check |

The second arm is what makes the first one evidence: the gate moves from *"no selected
base set"* to *"the base set is here, now show me the head"*. Without it, arm A only shows
that some error exists.

## Scope

`scripts/bench-gate.sh` only. No `crates/inference/src` or `crates/embed/src` change, so
no bench-compare A/B is owed and `e2e-parity` does not trigger. `make bench-gate` is the
only caller (`Makefile`); no workflow invokes it.

Note for anyone verifying on Apple silicon: `perf-baselines` publishes `aarch64-linux` and
`x86_64-linux` only, and `bench-gate.sh` derives `aarch64-darwin` there, so the command is
separately unreachable on a Mac. The control above is why this is still demonstrated
rather than argued.
