### PR TITLE
build(parity): pin the reference side of e2e_parity_check.py in its own environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,14 @@ uv.lock
 
 # Internal workspace artifacts (audits, notes, local tooling) — local-only
 .khive/
+
+# Reference-side environment for scripts/e2e_parity_check.py, created by
+# `uv venv .venv-parity`. uv also writes a self-ignoring .gitignore inside the
+# directory, which would cover it on its own, but this entry is the rule that
+# actually fires (`git check-ignore -v .venv-parity/bin/python` names this line):
+# git stops at the excluded directory and never descends far enough to read uv's
+# file. The duplication is deliberate rather than redundant. What is being avoided
+# is a multi-GB virtualenv offered up for commit in a public repository if that
+# inner file is ever lost, and the price of not depending on another tool's
+# behaviour for that is one line.
+.venv-parity/

--- a/scripts/requirements-parity.txt
+++ b/scripts/requirements-parity.txt
@@ -1,0 +1,29 @@
+# Reference-side dependencies for scripts/e2e_parity_check.py.
+#
+# These four packages, and only these four, are what the checker compares against:
+# REFERENCE_PACKAGES in e2e_parity_check.py names exactly ("torch", "transformers",
+# "tokenizers", "huggingface_hub"), and the frozen reference fixture at
+# crates/inference/tests/fixtures/e2e_parity_reference_v1/reference.json records a
+# version for each. The frozen path refuses to run when an installed version differs
+# from the recorded one, so a floor ("torch>=2.12") is not a pin the checker can use.
+# The versions below are those recorded versions, read from that fixture.
+#
+# Install into an environment dedicated to this check, not into a shared one:
+#
+#     uv venv .venv-parity
+#     uv pip install --python .venv-parity/bin/python -r scripts/requirements-parity.txt
+#
+# The dedicated environment is the point. A shared environment is re-derived from its
+# own project metadata whenever anything runs `uv sync` or `uv run` against it, and
+# these packages are not in that metadata, so they are dropped without a message. That
+# is not hypothetical: the reference side of this check was silently reduced to
+# "No module named 'torch'" that way, and the failure surfaced only in a scheduled
+# run's captured stderr.
+#
+# When the fixture is refreshed, the recorded versions change and this file changes
+# with it. Re-read them from reference.json rather than editing one line here.
+
+torch==2.12.1
+transformers==5.12.1
+tokenizers==0.22.2
+huggingface_hub==1.20.1

--- a/tests/test_bench_measurement_supervision.py
+++ b/tests/test_bench_measurement_supervision.py
@@ -105,6 +105,7 @@ EXPLICIT_SCRIPT_EXCLUSIONS = frozenset(
         "scripts/lib/quiet-probe.py",
         "scripts/perf-policy.toml",
         "scripts/perf_governor.README.md",
+        "scripts/requirements-parity.txt",
         "scripts/rust-fmt-coverage.allow",
     }
     | INTERNAL_OR_TEST


### PR DESCRIPTION
## What this fixes

`scripts/e2e_parity_check.py` compares lattice's greedy generation against HF transformers.
Its reference side therefore needs `torch`, `transformers`, `tokenizers` and
`huggingface_hub` — and nothing in this repository declared them. They lived in whatever
shared Python environment happened to invoke the script.

A shared environment is re-derived from its own project metadata. These four packages are not
in that metadata, so they can be removed with no message and no error, and nothing notices
until the next comparison tries to import them. That is not a hypothetical:

```
error: reference setup failed: No module named 'torch'
```

That is the entire captured output of a scheduled parity run on 2026-09-11, which reported a
non-zero result for a reason that had nothing to do with lattice.

## What it adds

- `scripts/requirements-parity.txt` — the four reference packages, pinned.
- a `.gitignore` entry for `.venv-parity`, the environment they are installed into.

```
uv venv .venv-parity
uv pip install --python .venv-parity/bin/python -r scripts/requirements-parity.txt
```

## Why exact pins rather than floors

`REFERENCE_PACKAGES` in `e2e_parity_check.py` names exactly those four, and the frozen
reference fixture at `crates/inference/tests/fixtures/e2e_parity_reference_v1/reference.json`
records a version for each. The frozen comparison path **refuses to run** when an installed
version differs from the recorded one, so `torch>=2.12` is not a pin that path can use. The
versions in the new file are the fixture's recorded versions, and they were cross-checked
against it by a script rather than transcribed by eye.

When the fixture is refreshed, this file changes with it, and the file says so.

## Why a dedicated environment rather than adding the pins to an existing one

Measured in a throwaway `uv` project with an undeclared package hand-installed:

| command | result |
|---|---|
| `uv run python -c "pass"` | package survived |
| `uv sync` | `Uninstalled 1 package`, gone |
| `uv sync --inexact` | package survived |

Stated narrowly on purpose: this shows that a plain `uv run` did not prune, not that `uv run`
never syncs. The point that matters is the second row. An environment governed by project
metadata loses what that metadata does not name, and the reference packages are exactly that.

## Verification

- the four pins equal the fixture's recorded versions, compared mechanically
- after installing into the dedicated environment, the same four read back through
  `importlib.metadata` — the mechanism the checker itself uses — and match the fixture exactly;
  the previously-used shared interpreter still answers `ModuleNotFoundError` as a control
- **a full live comparison passes**: 4 prompts, 15/15 token agreement each, no first
  difference, `rc=0`, 13m17s on an idle machine

```
## E2E Parity Report

**PASS**: all 4 prompts match within their respective match windows

| Prompt | Window | Agreement | First Diff | Verdict |
|--------|--------|-----------|------------|---------|
| `The capital of France is`                      | 3 | 15/15 | none | PASS |
| `In the year 2024, artificial intelligence`     | 3 | 15/15 | none | PASS |
| `def fibonacci(n): ...`                         | 3 | 15/15 | none | PASS |
| `def merge_sort(arr): ...`                      | 2 | 15/15 | none | PASS |
```

- `git check-ignore -v .venv-parity/bin/python` names the new `.gitignore` line as the rule
  that actually matches, rather than uv's own file inside the directory

## Bench disposition

This PR touches `scripts/` and `.gitignore` only. It adds no Rust, changes no manifest, lock
file, feature set, or profile, and reaches no bench target. The A/B requirement applies to
changes under `crates/inference/`, `crates/embed/` and `crates/fann/`, and this is not one.

## Scope

Deliberately not included: the five other scripts in `scripts/` that import torch or
transformers (`gemma4_stage3_goldens.py`, `gemma4_stage5_e2e_golden.py`,
`vision_goldens_qwen35.py`, `compare_logits.py`, `gen_embed_parity_goldens.py`). They were
found by a sweep and they have the same latent problem, but they also need `mlx` and other
development dependencies, so they belong with the development project rather than with this
narrow reference pin. Saying so here rather than leaving it implied: they are unfixed, not
unaffected.
## Measurement-inventory contract

`tests/test_bench_measurement_supervision` enumerates **every file under `scripts/` recursively**,
not just `scripts/bench*`, and requires each to be classifiable as a script or declared as an
explicit non-script asset. A `.txt` with no shebang is neither, so adding the pins file makes that
contract fail until the file is declared. It is listed in `EXPLICIT_SCRIPT_EXCLUSIONS` beside the
data assets it resembles (`scripts/lib/bench-quick-informational-targets.txt`,
`scripts/perf-policy.toml`).

That line is load-bearing, and it was checked rather than assumed: reverting it fails the contract
with `scripts/requirements-parity.txt: no supported extension or shebang (suffix '.txt')`, and
restoring it passes 65 tests.

Two other members of that CI job failed on a first local run and **neither was this change**: they
were PATH artifacts, with Xcode's Python 3.9.6 ahead of a 3.11+ interpreter. Both pass once the
interpreter order is corrected. Recorded here rather than dropped, because "two more tests were
also red" is exactly the kind of thing that quietly becomes a claim about the diff.

---

Supersedes #1533, which is closed. That branch carried two defects unrelated to its content: the
commit used the wrong author address for this repository, and its message ended with a trailer that
is not permitted here. This branch is one commit, authored `OceanLi <quantocean.li@gmail.com>` to
match the repository's own convention, with no trailer.
