### PR TITLE
fix(inference): resolve BERT encoder tensor namespaces

### DIFF
--- a/crates/inference/src/weights/f32_weights.rs
+++ b/crates/inference/src/weights/f32_weights.rs
@@ -6,7 +6,8 @@ use crate::weights::safetensors_layout::{
 };
 use memmap2::Mmap;
 use serde_json::Value;
-use std::collections::{HashMap, HashSet};
+use std::borrow::Cow;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -560,60 +561,74 @@ impl SafetensorsFile {
     /// **Unstable**: load BERT weights; tensor name conventions and signature may change.
     ///
     /// Load all BERT weights from the safetensors file.
+    ///
+    /// Encoder tensors may be flat or share one dot-delimited namespace.
+    /// Mixed encoder namespaces are rejected, including misplaced pooler tensors.
     pub fn load_bert_weights(
         &self,
         num_layers: usize,
         hidden_size: usize,
     ) -> Result<BertWeights<'_>, InferenceError> {
-        let word_shape = self.require_shape("embeddings.word_embeddings.weight")?;
-        let position_shape = self.require_shape("embeddings.position_embeddings.weight")?;
-        let token_type_shape = self.require_shape("embeddings.token_type_embeddings.weight")?;
+        let encoder = BertTensorReader::new(self)?;
+        let word_shape = encoder.require_shape("embeddings.word_embeddings.weight")?;
+        let position_shape = encoder.require_shape("embeddings.position_embeddings.weight")?;
+        let token_type_shape = encoder.require_shape("embeddings.token_type_embeddings.weight")?;
 
         if word_shape.len() != 2 || word_shape[1] != hidden_size {
             return Err(InferenceError::ShapeMismatch {
-                name: "embeddings.word_embeddings.weight".into(),
+                name: encoder
+                    .name("embeddings.word_embeddings.weight")
+                    .into_owned(),
                 expected: vec![word_shape[0], hidden_size],
                 actual: word_shape.to_vec(),
             });
         }
         if position_shape.len() != 2 || position_shape[1] != hidden_size {
             return Err(InferenceError::ShapeMismatch {
-                name: "embeddings.position_embeddings.weight".into(),
+                name: encoder
+                    .name("embeddings.position_embeddings.weight")
+                    .into_owned(),
                 expected: vec![position_shape[0], hidden_size],
                 actual: position_shape.to_vec(),
             });
         }
         if token_type_shape.len() != 2 || token_type_shape[1] != hidden_size {
             return Err(InferenceError::ShapeMismatch {
-                name: "embeddings.token_type_embeddings.weight".into(),
+                name: encoder
+                    .name("embeddings.token_type_embeddings.weight")
+                    .into_owned(),
                 expected: vec![token_type_shape[0], hidden_size],
                 actual: token_type_shape.to_vec(),
             });
         }
 
-        let word_embeddings = self.tensor2d(
+        let word_embeddings = encoder.tensor2d(
             "embeddings.word_embeddings.weight",
             word_shape[0],
             word_shape[1],
         )?;
-        let position_embeddings = self.tensor2d(
+        let position_embeddings = encoder.tensor2d(
             "embeddings.position_embeddings.weight",
             position_shape[0],
             position_shape[1],
         )?;
-        let token_type_embeddings = self.tensor2d(
+        let token_type_embeddings = encoder.tensor2d(
             "embeddings.token_type_embeddings.weight",
             token_type_shape[0],
             token_type_shape[1],
         )?;
         let embedding_layer_norm_weight =
-            self.tensor1d("embeddings.LayerNorm.weight", hidden_size)?;
-        let embedding_layer_norm_bias = self.tensor1d("embeddings.LayerNorm.bias", hidden_size)?;
+            encoder.tensor1d("embeddings.LayerNorm.weight", hidden_size)?;
+        let embedding_layer_norm_bias =
+            encoder.tensor1d("embeddings.LayerNorm.bias", hidden_size)?;
 
-        let intermediate_shape = self.require_shape("encoder.layer.0.intermediate.dense.weight")?;
+        let intermediate_shape =
+            encoder.require_shape("encoder.layer.0.intermediate.dense.weight")?;
         if intermediate_shape.len() != 2 || intermediate_shape[1] != hidden_size {
             return Err(InferenceError::ShapeMismatch {
-                name: "encoder.layer.0.intermediate.dense.weight".into(),
+                name: encoder
+                    .name("encoder.layer.0.intermediate.dense.weight")
+                    .into_owned(),
                 expected: vec![intermediate_shape[0], hidden_size],
                 actual: intermediate_shape.to_vec(),
             });
@@ -624,70 +639,70 @@ impl SafetensorsFile {
         for i in 0..num_layers {
             let prefix = format!("encoder.layer.{i}");
             layers.push(TransformerLayerWeights {
-                query_weight: self.tensor2d(
+                query_weight: encoder.tensor2d(
                     &format!("{prefix}.attention.self.query.weight"),
                     hidden_size,
                     hidden_size,
                 )?,
-                query_bias: self
+                query_bias: encoder
                     .tensor1d(&format!("{prefix}.attention.self.query.bias"), hidden_size)?,
-                key_weight: self.tensor2d(
+                key_weight: encoder.tensor2d(
                     &format!("{prefix}.attention.self.key.weight"),
                     hidden_size,
                     hidden_size,
                 )?,
-                key_bias: self
+                key_bias: encoder
                     .tensor1d(&format!("{prefix}.attention.self.key.bias"), hidden_size)?,
-                value_weight: self.tensor2d(
+                value_weight: encoder.tensor2d(
                     &format!("{prefix}.attention.self.value.weight"),
                     hidden_size,
                     hidden_size,
                 )?,
-                value_bias: self
+                value_bias: encoder
                     .tensor1d(&format!("{prefix}.attention.self.value.bias"), hidden_size)?,
-                attn_output_weight: self.tensor2d(
+                attn_output_weight: encoder.tensor2d(
                     &format!("{prefix}.attention.output.dense.weight"),
                     hidden_size,
                     hidden_size,
                 )?,
-                attn_output_bias: self.tensor1d(
+                attn_output_bias: encoder.tensor1d(
                     &format!("{prefix}.attention.output.dense.bias"),
                     hidden_size,
                 )?,
-                attn_layer_norm_weight: self.tensor1d(
+                attn_layer_norm_weight: encoder.tensor1d(
                     &format!("{prefix}.attention.output.LayerNorm.weight"),
                     hidden_size,
                 )?,
-                attn_layer_norm_bias: self.tensor1d(
+                attn_layer_norm_bias: encoder.tensor1d(
                     &format!("{prefix}.attention.output.LayerNorm.bias"),
                     hidden_size,
                 )?,
-                ffn_intermediate_weight: self.tensor2d(
+                ffn_intermediate_weight: encoder.tensor2d(
                     &format!("{prefix}.intermediate.dense.weight"),
                     intermediate_size,
                     hidden_size,
                 )?,
-                ffn_intermediate_bias: self.tensor1d(
+                ffn_intermediate_bias: encoder.tensor1d(
                     &format!("{prefix}.intermediate.dense.bias"),
                     intermediate_size,
                 )?,
-                ffn_output_weight: self.tensor2d(
+                ffn_output_weight: encoder.tensor2d(
                     &format!("{prefix}.output.dense.weight"),
                     hidden_size,
                     intermediate_size,
                 )?,
-                ffn_output_bias: self
+                ffn_output_bias: encoder
                     .tensor1d(&format!("{prefix}.output.dense.bias"), hidden_size)?,
-                ffn_layer_norm_weight: self
+                ffn_layer_norm_weight: encoder
                     .tensor1d(&format!("{prefix}.output.LayerNorm.weight"), hidden_size)?,
-                ffn_layer_norm_bias: self
+                ffn_layer_norm_bias: encoder
                     .tensor1d(&format!("{prefix}.output.LayerNorm.bias"), hidden_size)?,
             });
         }
 
         let pooler_weight =
-            self.tensor2d_optional("pooler.dense.weight", hidden_size, hidden_size)?;
-        let pooler_bias = self.tensor1d_optional("pooler.dense.bias", hidden_size)?;
+            encoder.tensor2d_optional("pooler.dense.weight", hidden_size, hidden_size)?;
+        let pooler_bias = encoder.tensor1d_optional("pooler.dense.bias", hidden_size)?;
 
         Ok(BertWeights {
             word_embeddings,
@@ -704,7 +719,8 @@ impl SafetensorsFile {
     /// Load classifier head weights from a `BertForSequenceClassification` safetensors file.
     ///
     /// Accepts `classifier.weight` shaped `[1, hidden_size]` or `[hidden_size]` and
-    /// `classifier.bias` shaped `[1]`.
+    /// `classifier.bias` shaped `[1]`. Classifier tensors must remain at the top
+    /// level, independently of the BERT encoder namespace.
     pub fn load_cross_encoder_weights(
         &self,
         hidden_size: usize,
@@ -797,6 +813,80 @@ impl SafetensorsFile {
         }
     }
 }
+
+struct BertTensorReader<'a> {
+    file: &'a SafetensorsFile,
+    prefix: &'a str,
+}
+
+impl<'a> BertTensorReader<'a> {
+    fn new(file: &'a SafetensorsFile) -> Result<Self, InferenceError> {
+        let mut prefixes = BTreeSet::new();
+        for name in file.tensors.keys() {
+            // Head shadows cannot establish an encoder namespace.
+            if name.ends_with(".classifier.weight") || name.ends_with(".classifier.bias") {
+                continue;
+            }
+            let offset = ["embeddings.", "encoder.layer.", "pooler."]
+                .into_iter()
+                .flat_map(|family| name.match_indices(family))
+                .map(|(offset, _)| offset)
+                .filter(|&offset| offset == 0 || name.as_bytes()[offset - 1] == b'.')
+                .max();
+            if let Some(offset) = offset {
+                prefixes.insert(&name[..offset]);
+            }
+        }
+        if prefixes.len() > 1 {
+            return Err(InferenceError::InvalidSafetensors(format!(
+                "mixed BERT encoder namespaces: {prefixes:?} (empty prefix is unprefixed)"
+            )));
+        }
+        let prefix = prefixes.into_iter().next().unwrap_or("");
+        Ok(Self { file, prefix })
+    }
+
+    fn name<'n>(&self, name: &'n str) -> Cow<'n, str> {
+        if self.prefix.is_empty() {
+            Cow::Borrowed(name)
+        } else {
+            Cow::Owned(format!("{}{name}", self.prefix))
+        }
+    }
+
+    fn require_shape(&self, name: &str) -> Result<&'a [usize], InferenceError> {
+        self.file.require_shape(&self.name(name))
+    }
+
+    fn tensor1d(&self, name: &str, len: usize) -> Result<Tensor1D<'a>, InferenceError> {
+        self.file.tensor1d(&self.name(name), len)
+    }
+
+    fn tensor2d(
+        &self,
+        name: &str,
+        rows: usize,
+        cols: usize,
+    ) -> Result<Tensor2D<'a>, InferenceError> {
+        self.file.tensor2d(&self.name(name), rows, cols)
+    }
+
+    fn tensor1d_optional(&self, name: &str, len: usize) -> Result<Tensor1D<'a>, InferenceError> {
+        self.file.tensor1d_optional(&self.name(name), len)
+    }
+
+    fn tensor2d_optional(
+        &self,
+        name: &str,
+        rows: usize,
+        cols: usize,
+    ) -> Result<Tensor2D<'a>, InferenceError> {
+        self.file.tensor2d_optional(&self.name(name), rows, cols)
+    }
+}
+
+#[cfg(test)]
+mod bert_namespace_tests;
 
 /// **Unstable**: per-layer Qwen3 decoder weights; field set may change with model variants.
 ///

--- a/crates/inference/src/weights/f32_weights/bert_namespace_tests.rs
+++ b/crates/inference/src/weights/f32_weights/bert_namespace_tests.rs
@@ -1,0 +1,417 @@
+use super::SafetensorsFile;
+use crate::attention::AttentionBuffers;
+use crate::error::InferenceError;
+use crate::forward::cpu::matmul_bt;
+use crate::model::CrossEncoderModel;
+
+const HIDDEN: usize = 4;
+const INTERMEDIATE: usize = 6;
+const LAYERS: usize = 2;
+const VOCAB: &str =
+    "[PAD]\n[UNK]\n[CLS]\n[SEP]\n[MASK]\nred\nblue\ngreen\ncat\ndog\nruns\nsleeps\n";
+const PAIRS: [(&str, &str); 3] = [
+    ("red cat", "blue dog"),
+    ("green dog runs", "red cat sleeps"),
+    ("blue dog", "red cat"),
+];
+
+#[derive(Clone)]
+struct Tensor {
+    name: String,
+    shape: Vec<usize>,
+    values: Vec<f32>,
+}
+
+impl Tensor {
+    fn new(name: &str, shape: &[usize], values: Vec<f32>) -> Self {
+        assert_eq!(shape.iter().product::<usize>(), values.len(), "{name}");
+        Self {
+            name: name.to_owned(),
+            shape: shape.to_vec(),
+            values,
+        }
+    }
+}
+
+fn fill(count: usize, seed: usize) -> Vec<f32> {
+    (0..count)
+        .map(|i| (((i * 17 + seed * 13) % 37) as f32 - 18.0) * 0.013)
+        .collect()
+}
+
+fn checkpoint(prefix: &str, pooler: bool) -> Vec<Tensor> {
+    let mut tensors = vec![
+        Tensor::new(
+            "embeddings.word_embeddings.weight",
+            &[12, HIDDEN],
+            fill(12 * HIDDEN, 1),
+        ),
+        Tensor::new(
+            "embeddings.position_embeddings.weight",
+            &[32, HIDDEN],
+            fill(32 * HIDDEN, 2),
+        ),
+        Tensor::new(
+            "embeddings.token_type_embeddings.weight",
+            &[2, HIDDEN],
+            fill(2 * HIDDEN, 3),
+        ),
+        Tensor::new(
+            "embeddings.LayerNorm.weight",
+            &[HIDDEN],
+            vec![0.91, 1.13, 0.87, 1.07],
+        ),
+        Tensor::new("embeddings.LayerNorm.bias", &[HIDDEN], fill(HIDDEN, 4)),
+    ];
+    for layer in 0..LAYERS {
+        for (index, (suffix, shape)) in [
+            ("attention.self.query.weight", vec![HIDDEN, HIDDEN]),
+            ("attention.self.query.bias", vec![HIDDEN]),
+            ("attention.self.key.weight", vec![HIDDEN, HIDDEN]),
+            ("attention.self.key.bias", vec![HIDDEN]),
+            ("attention.self.value.weight", vec![HIDDEN, HIDDEN]),
+            ("attention.self.value.bias", vec![HIDDEN]),
+            ("attention.output.dense.weight", vec![HIDDEN, HIDDEN]),
+            ("attention.output.dense.bias", vec![HIDDEN]),
+            ("attention.output.LayerNorm.weight", vec![HIDDEN]),
+            ("attention.output.LayerNorm.bias", vec![HIDDEN]),
+            ("intermediate.dense.weight", vec![INTERMEDIATE, HIDDEN]),
+            ("intermediate.dense.bias", vec![INTERMEDIATE]),
+            ("output.dense.weight", vec![HIDDEN, INTERMEDIATE]),
+            ("output.dense.bias", vec![HIDDEN]),
+            ("output.LayerNorm.weight", vec![HIDDEN]),
+            ("output.LayerNorm.bias", vec![HIDDEN]),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let mut values = fill(shape.iter().product(), 5 + index + 19 * layer);
+            if suffix.ends_with("LayerNorm.weight") {
+                for value in &mut values {
+                    *value += 1.0;
+                }
+            }
+            tensors.push(Tensor::new(
+                &format!("encoder.layer.{layer}.{suffix}"),
+                &shape,
+                values,
+            ));
+        }
+    }
+    if pooler {
+        tensors.extend([
+            Tensor::new(
+                "pooler.dense.weight",
+                &[HIDDEN, HIDDEN],
+                vec![
+                    0.31, -0.22, 0.07, 0.19, -0.11, 0.41, 0.23, -0.09, 0.17, 0.03, -0.37, 0.29,
+                    0.13, -0.27, 0.11, 0.43,
+                ],
+            ),
+            Tensor::new(
+                "pooler.dense.bias",
+                &[HIDDEN],
+                vec![0.07, -0.13, 0.05, 0.11],
+            ),
+        ]);
+    }
+    for tensor in &mut tensors {
+        tensor.name = format!("{prefix}{}", tensor.name);
+    }
+    tensors.extend([
+        Tensor::new(
+            "classifier.weight",
+            &[1, HIDDEN],
+            vec![0.43, -0.71, 0.29, 0.58],
+        ),
+        Tensor::new("classifier.bias", &[1], vec![-0.17]),
+    ]);
+    tensors
+}
+
+fn safetensors_bytes(tensors: &[Tensor]) -> Vec<u8> {
+    let mut header = serde_json::Map::new();
+    let mut payload = Vec::new();
+    for tensor in tensors {
+        let start = payload.len();
+        for value in &tensor.values {
+            payload.extend_from_slice(&value.to_le_bytes());
+        }
+        assert!(
+            header
+                .insert(
+                    tensor.name.clone(),
+                    serde_json::json!({
+                        "dtype": "F32",
+                        "shape": tensor.shape,
+                        "data_offsets": [start, payload.len()],
+                    }),
+                )
+                .is_none(),
+            "duplicate fixture tensor {}",
+            tensor.name,
+        );
+    }
+    let mut header_bytes = serde_json::to_vec(&header).unwrap();
+    header_bytes.resize(header_bytes.len().next_multiple_of(8), b' ');
+    let mut bytes = (header_bytes.len() as u64).to_le_bytes().to_vec();
+    bytes.extend(header_bytes);
+    bytes.extend(payload);
+    bytes
+}
+
+fn model_directory(tensors: &[Tensor]) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("vocab.txt"), VOCAB).unwrap();
+    let config = serde_json::json!({
+        "vocab_size": 12,
+        "hidden_size": HIDDEN,
+        "num_hidden_layers": LAYERS,
+        "num_attention_heads": 2,
+        "intermediate_size": INTERMEDIATE,
+        "max_position_embeddings": 32,
+        "type_vocab_size": 2,
+        "layer_norm_eps": 1e-5,
+    });
+    std::fs::write(dir.path().join("config.json"), config.to_string()).unwrap();
+    std::fs::write(
+        dir.path().join("model.safetensors"),
+        safetensors_bytes(tensors),
+    )
+    .unwrap();
+    dir
+}
+
+fn bits(values: &[f32]) -> Vec<u32> {
+    values.iter().map(|value| value.to_bits()).collect()
+}
+
+fn evaluate(tensors: &[Tensor]) -> Vec<(Vec<u32>, u32, u32)> {
+    let dir = model_directory(tensors);
+    let model = CrossEncoderModel::from_directory(dir.path()).unwrap();
+    let file = SafetensorsFile::open(&dir.path().join("model.safetensors")).unwrap();
+    let classifier = file.load_cross_encoder_weights(HIDDEN).unwrap();
+    PAIRS
+        .iter()
+        .map(|&(query, document)| {
+            let bert = model.bert();
+            let input = bert.tokenizer().tokenize_pair(query, document);
+            assert!(input.real_length > 3);
+            assert!(input.token_type_ids[..input.real_length].contains(&1));
+            let mut buffers = AttentionBuffers::new(input.real_length, HIDDEN, 2, INTERMEDIATE);
+            let hidden = bert.forward_tokenized(&input, &mut buffers);
+            let cls = &hidden[..HIDDEN];
+            let (weight, bias) = bert.pooler_parameters();
+            let mut pooled = vec![0.0; HIDDEN];
+            let logit = if weight.is_empty() {
+                classifier.logit(cls)
+            } else {
+                matmul_bt(cls, weight, &mut pooled, 1, HIDDEN, HIDDEN);
+                for (value, bias) in pooled.iter_mut().zip(bias) {
+                    *value = (*value + bias).tanh();
+                }
+                classifier.logit(&pooled)
+            };
+            assert!(logit.is_finite());
+            let sigmoid = if logit >= 0.0 {
+                1.0 / (1.0 + (-logit).exp())
+            } else {
+                let exp = logit.exp();
+                exp / (1.0 + exp)
+            };
+            let score = model.score(query, document);
+            assert!(score > 0.0 && score < 1.0);
+            assert_eq!(score.to_bits(), sigmoid.to_bits());
+            (bits(&hidden), logit.to_bits(), score.to_bits())
+        })
+        .collect()
+}
+
+fn rename(tensors: &mut [Tensor], old: &str, new: &str) {
+    tensors
+        .iter_mut()
+        .find(|tensor| tensor.name == old)
+        .unwrap()
+        .name = new.to_owned();
+}
+
+fn assert_mixed(tensors: &[Tensor]) {
+    let file = SafetensorsFile::from_bytes(safetensors_bytes(tensors)).unwrap();
+    let error = file.load_bert_weights(LAYERS, HIDDEN).unwrap_err();
+    assert!(
+        matches!(&error, InferenceError::InvalidSafetensors(message)
+            if message.contains("mixed BERT encoder namespaces")),
+        "expected mixed namespace error, got {error:?}",
+    );
+}
+
+#[test]
+fn bert_namespace_flat_and_prefixed_logits_and_scores_are_bit_identical() {
+    let flat = evaluate(&checkpoint("", true));
+    assert!(flat.windows(2).any(|pair| pair[0].1 != pair[1].1));
+    for prefix in [
+        "bert.",
+        "custom_encoder.",
+        "model.backbone.",
+        "wrapper.embeddings.",
+        "wrapper.encoder.layer.",
+        "wrapper.pooler.",
+    ] {
+        assert_eq!(flat, evaluate(&checkpoint(prefix, true)), "{prefix}");
+    }
+}
+
+#[test]
+fn bert_namespace_absent_pooler_preserves_direct_cls_scores() {
+    let flat = evaluate(&checkpoint("", false));
+    for prefix in ["bert.", "custom.encoder."] {
+        let tensors = checkpoint(prefix, false);
+        let file = SafetensorsFile::from_bytes(safetensors_bytes(&tensors)).unwrap();
+        let weights = file.load_bert_weights(LAYERS, HIDDEN).unwrap();
+        assert!(weights.pooler_weight.data.is_empty());
+        assert!(weights.pooler_bias.data.is_empty());
+        assert_eq!(flat, evaluate(&tensors), "{prefix}");
+    }
+    let with_pooler = evaluate(&checkpoint("", true));
+    assert!(flat.iter().zip(with_pooler).any(|(a, b)| a.1 != b.1));
+}
+
+#[test]
+fn bert_namespace_classifier_stays_top_level_even_with_a_namespaced_shadow() {
+    let expected = evaluate(&checkpoint("", true));
+    for prefix in [
+        "bert.",
+        "wrapper.embeddings.",
+        "wrapper.encoder.layer.",
+        "wrapper.pooler.",
+    ] {
+        let mut tensors = checkpoint(prefix, true);
+        tensors.extend([
+            Tensor::new(
+                &format!("{prefix}classifier.weight"),
+                &[1, HIDDEN],
+                vec![9.0; HIDDEN],
+            ),
+            Tensor::new(&format!("{prefix}classifier.bias"), &[1], vec![12.0]),
+        ]);
+        let file = SafetensorsFile::from_bytes(safetensors_bytes(&tensors)).unwrap();
+        let classifier = file.load_cross_encoder_weights(HIDDEN).unwrap();
+        assert_eq!(
+            bits(&classifier.classifier_weight),
+            bits(&[0.43, -0.71, 0.29, 0.58])
+        );
+        assert_eq!(classifier.classifier_bias.to_bits(), (-0.17_f32).to_bits());
+        assert_eq!(expected, evaluate(&tensors), "{prefix}");
+    }
+}
+
+#[test]
+fn bert_namespace_namespaced_only_classifier_is_rejected() {
+    let mut tensors = checkpoint("bert.", true);
+    rename(&mut tensors, "classifier.weight", "bert.classifier.weight");
+    rename(&mut tensors, "classifier.bias", "bert.classifier.bias");
+    let dir = model_directory(&tensors);
+    let error = CrossEncoderModel::from_directory(dir.path()).err().unwrap();
+    assert!(
+        matches!(&error, InferenceError::MissingTensor(name) if name == "classifier.weight"),
+        "{error:?}",
+    );
+}
+
+#[test]
+fn bert_namespace_rejects_complete_encoder_with_alternate_stray_tensor() {
+    for (prefix, stray_prefix) in [("", "bert."), ("bert.", ""), ("bert.", "other.")] {
+        let mut tensors = checkpoint(prefix, true);
+        let mut stray = tensors
+            .iter()
+            .find(|tensor| tensor.name == format!("{prefix}embeddings.position_embeddings.weight"))
+            .unwrap()
+            .clone();
+        stray.name = format!("{stray_prefix}embeddings.position_embeddings.weight");
+        tensors.push(stray);
+        assert_mixed(&tensors);
+    }
+}
+
+#[test]
+fn bert_namespace_rejects_two_complete_encoder_namespaces() {
+    for (prefix, second) in [("", "bert."), ("bert.", "other.encoder.")] {
+        let mut tensors = checkpoint(prefix, true);
+        tensors.extend(
+            checkpoint(second, true)
+                .into_iter()
+                .filter(|tensor| !tensor.name.starts_with("classifier.")),
+        );
+        assert_mixed(&tensors);
+    }
+}
+
+#[test]
+fn bert_namespace_rejects_split_embedding_and_layer_namespaces() {
+    for suffix in [
+        "embeddings.LayerNorm.bias",
+        "encoder.layer.0.attention.self.query.weight",
+        "encoder.layer.1.output.LayerNorm.bias",
+    ] {
+        let mut tensors = checkpoint("bert.", true);
+        rename(&mut tensors, &format!("bert.{suffix}"), suffix);
+        assert_mixed(&tensors);
+    }
+}
+
+#[test]
+fn bert_namespace_rejects_misplaced_and_split_pooler() {
+    for misplaced in [
+        &["pooler.dense.weight"][..],
+        &["pooler.dense.bias"][..],
+        &["pooler.dense.weight", "pooler.dense.bias"][..],
+    ] {
+        let mut tensors = checkpoint("bert.", true);
+        for suffix in misplaced {
+            rename(&mut tensors, &format!("bert.{suffix}"), suffix);
+        }
+        assert_mixed(&tensors);
+    }
+}
+
+#[test]
+fn bert_namespace_partial_checkpoint_reports_qualified_missing_tensor() {
+    for prefix in ["", "bert.", "model.encoder."] {
+        for suffix in [
+            "embeddings.word_embeddings.weight",
+            "embeddings.position_embeddings.weight",
+            "embeddings.token_type_embeddings.weight",
+            "embeddings.LayerNorm.bias",
+            "encoder.layer.0.intermediate.dense.weight",
+            "encoder.layer.1.attention.self.query.weight",
+            "encoder.layer.1.output.LayerNorm.bias",
+        ] {
+            let mut tensors = checkpoint(prefix, true);
+            let missing = format!("{prefix}{suffix}");
+            tensors.retain(|tensor| tensor.name != missing);
+            let file = SafetensorsFile::from_bytes(safetensors_bytes(&tensors)).unwrap();
+            let error = file.load_bert_weights(LAYERS, HIDDEN).unwrap_err();
+            assert!(
+                matches!(&error, InferenceError::MissingTensor(name) if name == &missing),
+                "missing {missing}: {error:?}",
+            );
+        }
+    }
+}
+
+#[test]
+fn bert_namespace_partial_pooler_keeps_existing_cross_encoder_rejection() {
+    for prefix in ["", "bert."] {
+        for suffix in ["pooler.dense.weight", "pooler.dense.bias"] {
+            let mut tensors = checkpoint(prefix, true);
+            tensors.retain(|tensor| tensor.name != format!("{prefix}{suffix}"));
+            let dir = model_directory(&tensors);
+            let error = CrossEncoderModel::from_directory(dir.path()).err().unwrap();
+            assert!(
+                matches!(&error, InferenceError::UnsupportedModel(message)
+                    if message.contains("pooler requires both")),
+                "{error:?}",
+            );
+        }
+    }
+}


### PR DESCRIPTION
`CrossEncoderModel` could not load a standard bert-prefixed classification checkpoint. The
loader asked for `embeddings.word_embeddings.weight` and friends by literal name, so a
checkpoint that stores the encoder under a shared `bert.` namespace — which is what the stock
HF cross-encoder export produces — failed on the first tensor lookup. Closes #1528.

## The change

Encoder tensor lookups now go through a small resolver that determines the encoder namespace
once, from the tensor names actually present, and prefixes every subsequent lookup. A flat
checkpoint resolves to the empty prefix and takes exactly the path it took before.

Namespace detection looks for the three encoder families (`embeddings.`, `encoder.layer.`,
`pooler.`) at a dot boundary. The boundary test is load-bearing rather than decorative:
`position_embeddings.` and `token_type_embeddings.` both contain `embeddings.` as a substring,
preceded by `_`, and treating those as namespace evidence would compute a prefix from the
middle of a tensor name.

Two cases are refused rather than guessed at. More than one distinct encoder namespace is an
error, including a pooler that sits outside the namespace holding the rest of the encoder,
because silently picking one is how a checkpoint loads with half its weights uninitialised.
Classification-head tensors are excluded from namespace detection, since a head is not encoder
evidence, and the head continues to be read at the top level.

Error messages report the qualified name that was actually looked up, not the unqualified one,
so a missing tensor in a prefixed checkpoint names the tensor a user can search for.

## Verification

Ten tests, covering both halves: flat-versus-prefixed equivalence, and the refusals. The
equivalence test compares logits and scores **bit for bit** rather than within a tolerance, so
it cannot pass on an approximately-correct load.

`cargo clippy --workspace --all-targets -- -D warnings` is clean. The full
`lattice-inference` library suite passes: 2868 passed, 0 failed, 17 ignored.

The tests are mutation-sensitive, and this was measured with two independent source mutations
rather than asserted:

| mutation | tests failed |
|---|---|
| namespace prefix ignored when qualifying a name | 6 |
| mixed-namespace rejection disabled | 4 |

The two failure sets are **disjoint**, and their union is all ten tests, so every test guards
exactly one half of the change and neither half is covered only incidentally by the other.
After restoring, the file hashes back to its pre-mutation object id and all ten pass again.

## bench-compare disposition

**Structural waiver. No declared bench target executes the changed code.**

`crates/inference` declares 25 bench targets at this revision. Searching all of them, plus the
`embed` and `fann` bench sources, for any symbol this diff touches returns exactly one file:
`benches/inference_bench.rs` names the `BertWeights` type. It does not reach the changed code —
it builds that struct in memory through its own `synthetic_bert_weights` fixture and never
constructs a `SafetensorsFile` or calls `load_bert_weights`, which is the only entry point into
the resolver. Compilation is not the predicate here; the type is compiled in and the loading
path is never executed by any group.

The build inputs are identical between base and head, which is the other half of the
disposition and is checked separately from reachability: the diff is two files, both Rust
sources under `src/`, one of them `#[cfg(test)]` and therefore absent from a bench build. No
manifest, lockfile, feature set, profile, build script, generated source, bench-target
definition or harness changes.

Stating the residual plainly, because that is the point of the section: an unreachable change
is not a safe change, it is an unmeasured one. This diff adds a prefix computation performed
once per model load and one `Cow` per tensor lookup during loading. It is on the load path, not
in any per-token or per-batch inner loop, and no declared benchmark measures model loading.

## End-to-end evidence on the checkpoint the issue names

The tests above build synthetic safetensors, which proves the resolver but not that a real
export has the shape the resolver assumes. So the same loader was run against the actual stock
checkpoint, pinned by content rather than by name:

```
cross-encoder/ms-marco-MiniLM-L6-v2 @ 233902d25c440f23af6f7d6e94d2946bac0bee0a
model.safetensors sha256 821d1aa69520101d6e0737f78a042ae25b19e5cb9160701909d10434f4aeb0ae
```

Every file was checksum-verified before use, so "which checkpoint" is not an open question.

| loader | result |
|---|---|
| this branch | `CROSS_ENCODER_LOADED`, exit 0 |
| namespace resolution neutralised in place | `CROSS_ENCODER_LOAD_ERROR: Missing tensor: embeddings.word_embeddings.weight`, exit 1 |
| restored | `CROSS_ENCODER_LOADED`, exit 0 |

The negative arm reproduces the reported failure verbatim, on the real file, through the same
binary. The source hashes back to its pre-mutation object id after restoring.

The loading probe used here is not part of this diff; it is kept separate so this change stays
two source files.
