### PR TITLE
test(tune): measure adapter routing on prompt embeddings

### DIFF
--- a/crates/embed/examples/prompt_router_vectors.rs
+++ b/crates/embed/examples/prompt_router_vectors.rs
@@ -1,0 +1,53 @@
+//! Export BGE-small prompt vectors for a separate adapter-routing experiment.
+//! Arguments: labelled JSONL input and output JSON path. Input rows contain
+//! `prompt`, `label` (0 or 1), and `split` (`train` or `test`).
+
+#[cfg(feature = "native")]
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use lattice_embed::{EmbeddingModel, EmbeddingService, NativeEmbeddingService};
+    use std::{collections::HashSet, time::Instant};
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        return Err("expected input JSONL and output JSON paths".into());
+    }
+    let model = EmbeddingModel::BgeSmallEnV15;
+    let service = NativeEmbeddingService::with_model(model);
+    let mut seen = HashSet::new();
+    let mut rows = Vec::new();
+    for line in std::fs::read_to_string(&args[1])?.lines() {
+        let mut row: serde_json::Value = serde_json::from_str(line)?;
+        let prompt = row["prompt"].as_str().ok_or("missing prompt")?.to_string();
+        if prompt.trim().is_empty() || !seen.insert(prompt.to_lowercase()) {
+            return Err("empty or duplicate prompt".into());
+        }
+        if !matches!(row["label"].as_u64(), Some(0 | 1))
+            || !matches!(row["split"].as_str(), Some("train" | "test"))
+        {
+            return Err("invalid label or split".into());
+        }
+        let start = Instant::now();
+        let vectors = service.embed_query(&[prompt], model).await?;
+        let elapsed = start.elapsed().as_secs_f64();
+        let vector = vectors.first().ok_or("empty embedding result")?;
+        if vector.len() != 384 || vector.iter().any(|v| !v.is_finite()) {
+            return Err("invalid embedding".into());
+        }
+        row["vector"] = serde_json::json!(vector);
+        row["embedding_seconds"] = serde_json::json!(elapsed);
+        rows.push(row);
+    }
+    let result = serde_json::json!({"model": "bge-small-en-v1.5", "dimension": 384,
+        "mrl": false, "role": "query", "rows": rows});
+    std::fs::write(&args[2], serde_json::to_vec(&result)?)?;
+    println!(
+        "exported {} vectors; model=bge-small-en-v1.5 dimension=384 mrl=false",
+        rows.len()
+    );
+    Ok(())
+}
+
+#[cfg(not(feature = "native"))]
+fn main() {
+    panic!("enable native");
+}

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -27,7 +27,7 @@ train-backward = ["dep:lattice-inference", "lattice-inference/train-backward", "
 sqlite = ["dep:rusqlite", "serde"]
 # Online adapter-selector refit from preference feedback (experimental, bench-gated).
 # Pulls in the lattice-fann training primitives (RLOO / EWC++) for gate updates.
-mixture = ["lattice-fann/online-router"]
+mixture = ["lattice-fann/online-router", "lattice-inference?/mixture"]
 # Fixed labels for tests and examples. Never enables the default labeling path.
 simulated-teacher = []
 
@@ -97,3 +97,7 @@ proptest.workspace = true
 
 [lints]
 workspace = true
+
+[[example]]
+name = "prompt_router"
+required-features = ["mixture", "inference-hook", "serde"]

--- a/crates/tune/examples/prompt_router.md
+++ b/crates/tune/examples/prompt_router.md
@@ -1,0 +1,51 @@
+# Prompt embedding routing experiment
+
+This two-stage experiment measures whether prompt embeddings separate two adapter
+domains. It does not measure response quality or prove either adapter is useful.
+No dependency on `lattice-embed` is added to the training or inference crates.
+
+Prepare JSONL records containing `prompt` (string), `label` (0 or 1), and `split`
+(`train` or `test`). Use independently held-out prompts, at least 30 records per
+class per split, and equal class counts in the test split. Assign splits before
+embedding; keep related sources in the same split and audit near duplicates.
+The examples reject case-insensitive exact duplicates across the entire dataset.
+Do not include completions or provenance in the embedded prompt.
+
+```sh
+cargo run --release -p lattice-embed --example prompt_router_vectors -- prompts.jsonl vectors.json
+cargo run --release -p lattice-tune --features mixture,inference-hook,serde --example prompt_router -- vectors.json
+```
+
+The first stage uses `NativeEmbeddingService::embed_query`, BGE-small-en-v1.5,
+384 dimensions, no MRL truncation. It exports embeddings and per-call wall times.
+Its first call includes lazy model initialization; subsequent calls use the
+loaded model. There is no embedding cache wrapper. Model files must already be
+available when offline mode is enabled.
+
+The second stage uses a 384 → 16 tanh → 2 softmax FANN classifier, initialized
+with seed 42, trained for 100 epochs with seed 42, learning rate 0.03, batch 16,
+and the remaining `TrainingConfig` defaults. The shuffled arm permutes labels
+independently within each split with fixed seeds, preserving class counts and
+using identical embeddings and training settings. Real accuracy must exceed the
+held-out majority-class rate. Shuffled accuracy must lie within three binomial
+standard errors of 0.5; this interval requires a balanced held-out split. A small
+corpus or one split/seed is limited evidence, even when these checks pass.
+
+The independent feedback arm requires linear output logits for RLOO, retaining
+the same hidden shape and initialization seed. It routes a held-out vector,
+records 16 positive events for the initially unselected adapter, calls
+`update_router`, and routes the identical vector and pool again. It requires a
+changed selection, 16 consumed events, replay accuracy 1.0, and an unchanged
+no-update counterfactual. This is a controlled preference reversal, not a replay
+of measured adapter response quality.
+
+An optional final argument selects `real`, `shuffled`, `balance`, `loop`, or `cost`
+for isolated checks. Cost output is one warm embedding call and one warm gate
+forward, plus the cold embedding call. These are observational timings, without
+prefill comparison or statistical performance guarantees. Follow the repository's
+machine-lock policy when running measurements.
+
+Report real and shuffled accuracy together with class balance, source provenance,
+seed policy, model/dimension, and a lexical baseline when domain phrasing might
+explain separation. Preserve failures: a failed real arm is a valid negative
+result, while a successful shuffled classifier invalidates the interpretation.

--- a/crates/tune/examples/prompt_router.rs
+++ b/crates/tune/examples/prompt_router.rs
@@ -1,0 +1,240 @@
+//! Measure held-out adapter-domain separation and feedback on exported embeddings.
+//! Run with mixture,inference-hook,serde. Arguments: vector JSON and optional arm
+//! (`real`, `shuffled`, `balance`, `loop`, `cost`; default runs all).
+
+use lattice_fann::{Activation, BackpropTrainer, Network, NetworkBuilder, Trainer, TrainingConfig};
+use lattice_inference::mixture::AdapterRouter;
+use lattice_tune::lora::router_update::{
+    DiagonalFisher, FeedbackEvent, PreferenceSignal, ReplayBuffer, RouterUpdateConfig,
+    update_router,
+};
+use serde::Deserialize;
+use std::{collections::HashSet, error::Error, time::Instant};
+
+type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
+#[derive(Deserialize)]
+struct Data {
+    model: String,
+    dimension: usize,
+    mrl: bool,
+    rows: Vec<Row>,
+}
+
+#[derive(Deserialize)]
+struct Row {
+    prompt: String,
+    label: usize,
+    split: String,
+    vector: Vec<f32>,
+    embedding_seconds: f64,
+}
+
+fn gate(dim: usize, output: Activation) -> Result<Network> {
+    Ok(NetworkBuilder::new()
+        .input(dim)
+        .hidden(16, Activation::Tanh)
+        .output(2, output)
+        .build_with_seed(42)?)
+}
+
+fn shuffle<T>(values: &mut [T], mut state: u64) {
+    for i in (1..values.len()).rev() {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        values.swap(i, (state % (i as u64 + 1)) as usize);
+    }
+}
+
+fn majority(labels: &[usize]) -> f64 {
+    let zero = labels.iter().filter(|&&label| label == 0).count();
+    zero.max(labels.len() - zero) as f64 / labels.len() as f64
+}
+
+fn fit(data: &Data, shuffled: bool) -> Result<f64> {
+    let train: Vec<&Row> = data.rows.iter().filter(|r| r.split == "train").collect();
+    let test: Vec<&Row> = data.rows.iter().filter(|r| r.split == "test").collect();
+    let mut train_labels: Vec<usize> = train.iter().map(|r| r.label).collect();
+    let mut test_labels: Vec<usize> = test.iter().map(|r| r.label).collect();
+    if shuffled {
+        shuffle(&mut train_labels, 7183);
+        shuffle(&mut test_labels, 9919);
+    }
+    let inputs: Vec<Vec<f32>> = train.iter().map(|r| r.vector.clone()).collect();
+    let targets: Vec<Vec<f32>> = train_labels
+        .iter()
+        .map(|&label| {
+            let mut target = vec![0.0; 2];
+            target[label] = 1.0;
+            target
+        })
+        .collect();
+    let mut network = gate(data.dimension, Activation::Softmax)?;
+    let config = TrainingConfig {
+        learning_rate: 0.03,
+        max_epochs: 100,
+        target_error: 0.0,
+        batch_size: 16,
+        seed: Some(42),
+        ..TrainingConfig::default()
+    };
+    let trained = BackpropTrainer::new().train(&mut network, &inputs, &targets, &config)?;
+    let mut correct = 0;
+    for (row, label) in test.iter().zip(test_labels.iter()) {
+        let scores = network.forward(&row.vector)?;
+        correct += usize::from(usize::from(scores[1] > scores[0]) == *label);
+    }
+    let accuracy = correct as f64 / test.len() as f64;
+    println!(
+        "shuffled={shuffled} correct={correct}/{} accuracy={accuracy:.6} epochs={}",
+        test.len(),
+        trained.epochs_trained
+    );
+    Ok(accuracy)
+}
+
+fn feedback(data: &Data) -> Result<()> {
+    let context = &data
+        .rows
+        .iter()
+        .find(|r| r.split == "test")
+        .ok_or("no test row")?
+        .vector;
+    let network = gate(data.dimension, Activation::Linear)?;
+    let bytes = network.to_bytes();
+    let pool = vec!["domain-0".to_string(), "domain-1".to_string()];
+    let before = AdapterRouter::new(network).route(context, &pool, 1)?;
+    let selected = usize::from(before[0].0 == pool[1]);
+    let desired = 1 - selected;
+    let events = vec![
+        FeedbackEvent {
+            context_vector: context.clone(),
+            preferred_adapter_idx: desired,
+            adapter_id: pool[desired].clone(),
+            signal: PreferenceSignal::Positive,
+        };
+        16
+    ];
+    let config = RouterUpdateConfig {
+        learning_rate: 0.1,
+        epochs: 40,
+        aux_loss_coeff: 0.0,
+        z_loss_coeff: 0.0,
+        replay_mix_fraction: 0.0,
+        ..RouterUpdateConfig::default()
+    };
+    let delta = update_router(
+        &bytes,
+        &events,
+        &mut ReplayBuffer::new(32),
+        &mut DiagonalFisher::new(0, 0.99)?,
+        &config,
+    )?;
+    let after =
+        AdapterRouter::new(Network::from_bytes(&delta.network_bytes)?).route(context, &pool, 1)?;
+    let unchanged = AdapterRouter::new(Network::from_bytes(&bytes)?).route(context, &pool, 1)?;
+    println!(
+        "loop before={before:?} after={after:?} events_consumed={} replay_accuracy={:?}",
+        delta.events_consumed, delta.replay_accuracy
+    );
+    assert_eq!(before, unchanged, "no-update counterfactual changed");
+    assert_ne!(before, after, "feedback did not change selection");
+    assert_eq!(after[0].0, pool[desired]);
+    assert_eq!(delta.events_consumed, events.len());
+    assert_eq!(delta.replay_accuracy, Some(1.0));
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    let path = args.get(1).ok_or("expected vector JSON path")?;
+    let arm = args.get(2).map(String::as_str).unwrap_or("all");
+    if !["all", "real", "shuffled", "balance", "loop", "cost"].contains(&arm) {
+        return Err("unknown arm".into());
+    }
+    let data: Data = serde_json::from_slice(&std::fs::read(path)?)?;
+    let mut seen = HashSet::new();
+    for row in &data.rows {
+        if row.label > 1
+            || !["train", "test"].contains(&row.split.as_str())
+            || row.vector.len() != data.dimension
+            || row.vector.iter().any(|v| !v.is_finite())
+            || !seen.insert(row.prompt.to_lowercase())
+        {
+            return Err("invalid or duplicate row".into());
+        }
+    }
+    let labels: Vec<usize> = data
+        .rows
+        .iter()
+        .filter(|r| r.split == "test")
+        .map(|r| r.label)
+        .collect();
+    for split in ["train", "test"] {
+        for label in 0..2 {
+            if data
+                .rows
+                .iter()
+                .filter(|r| r.split == split && r.label == label)
+                .count()
+                < 30
+            {
+                return Err("need at least 30 rows per domain per split".into());
+            }
+        }
+    }
+    let floor = majority(&labels);
+    println!(
+        "model={} dimension={} mrl={} heldout_counts=[{},{}] majority={floor:.6}",
+        data.model,
+        data.dimension,
+        data.mrl,
+        labels.iter().filter(|&&l| l == 0).count(),
+        labels.iter().filter(|&&l| l == 1).count()
+    );
+    if arm == "all" || arm == "balance" {
+        assert_eq!(majority(&[0, 0, 0, 0, 0, 0, 0, 1, 1, 1]), 0.7);
+        assert_eq!(majority(&[0, 1, 1, 1]), 0.75);
+        assert!(floor >= 0.5);
+        println!("balance checks passed");
+    }
+    if arm == "all" || arm == "real" {
+        assert!(
+            fit(&data, false)? > floor,
+            "real labels do not beat majority floor"
+        );
+    }
+    if arm == "all" || arm == "shuffled" {
+        let accuracy = fit(&data, true)?;
+        let tolerance = 3.0 * (0.25 / labels.len() as f64).sqrt();
+        println!(
+            "shuffled acceptance: |accuracy-0.5| <= {tolerance:.6} (balanced corpus required)"
+        );
+        assert_eq!(
+            floor, 0.5,
+            "control interval requires balanced heldout labels"
+        );
+        assert!(
+            (accuracy - 0.5).abs() <= tolerance,
+            "shuffled control outside chance interval"
+        );
+    }
+    if arm == "all" || arm == "loop" {
+        feedback(&data)?;
+    }
+    if arm == "all" || arm == "cost" {
+        let row = data.rows.get(1).ok_or("missing warm embedding sample")?;
+        let mut network = gate(data.dimension, Activation::Softmax)?;
+        network.forward(&row.vector)?;
+        let start = Instant::now();
+        std::hint::black_box(network.forward(std::hint::black_box(&row.vector))?);
+        let seconds = start.elapsed().as_secs_f64();
+        assert!(seconds > 0.0 && row.embedding_seconds > 0.0);
+        println!(
+            "warm_embedding_seconds={} single_gate_forward_seconds={seconds} cold_embedding_seconds={}",
+            row.embedding_seconds, data.rows[0].embedding_seconds
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
Two examples and a short guide for measuring whether prompt embeddings can route between two
adapter domains, plus a feature-forwarding entry so the tune example can enable the inference
mixture path when `inference-hook` is on. No library code changes; no data is committed.

**Method.** `lattice-embed --example prompt_router_vectors` exports BGE-small-en-v1.5 query
embeddings (384-d, no MRL truncation) for labelled prompts and records per-call wall time.
`lattice-tune --example prompt_router` trains a 384 → 16 tanh → 2 softmax FANN gate (init seed 42,
train seed 42, 100 epochs, batch 16, lr 0.03) and reports held-out accuracy for the real labels
and for labels permuted independently within each split (same vectors, same settings), the
majority-class floor, a controlled preference-reversal check through `update_router` (16 positive
events toward the initially unselected adapter; must change the selection, consume 16 events,
replay accuracy 1.0, and leave the no-update counterfactual unchanged), and single-call timings.
Acceptance thresholds were fixed before each run: real accuracy above the majority floor, shuffled
accuracy within three binomial standard errors of 0.5 on a balanced 100-row test split, and a
train-only bag-of-words logistic model on the same split as the lexical baseline the embedding arm
must beat.

**Findings on two corpora (local, not committed).**

- Corpus A, commit-message prompts vs request-DSL prompts (160/160 train, 50/50 test): gate 100/100
  real, 48/100 shuffled, and bag-of-words also 100/100. A one-line rule on the instruction prefix
  scores 420/420 across both splits; one label has a single distinct opening phrase across all
  210 rows. The two domains are two instruction templates, so this split is a ceiling effect and
  says nothing about embedding routing. Reported as the reason a lexical baseline is mandatory.
- Corpus B, `memory.*` requests vs `gtd.*` requests drawn from a split that assigns whole verbs to
  train or test (test verbs `memory.remember`, `gtd.complete` never seen in training; the four
  most common instruction openings are shared by both labels, 152/210 and 154/210 rows), with
  every `memory.<verb>`/`gtd.<verb>` token and every bare `memory`/`gtd` word removed from the
  prompt text before any arm (the correction-style prompts embed the DSL call, so 45 of 420 rows
  carried the label as a token; zero after stripping, no duplicates created, 160/160 train and
  50/50 test retained): gate 88/100 real, 52/100 shuffled; bag-of-words 50/100, predicting a
  single class for every test row because the held-out verbs bring held-out phrasing and the
  train-indicative words do not transfer; an independent logistic regression on the same stripped
  vectors scores 94/100 (shuffled-train control 36/100). Unstripped, the same corpus read 93/100 and
  is reported only as confounded. This is evidence that a pretrained embedding carries intent across
  phrasing a train-only lexical model cannot, on this pair. Its limits: the test split is
  effectively two prompt templates, so the template-level sample is tiny and the accuracy carries
  template variance rather than 100-row variance; the corpus phrasing is generated; one split and
  one seed; nothing here measures adapter response quality.
- Cost, observational single calls on a desktop CPU (release build): warm embedding ≈5–6 ms per
  prompt, cold first call ≈0.3 s (lazy load), one gate forward ≈0.4 µs. No prefill comparison was
  measured, so no claim about embedding cost relative to decode.

## bench-compare disposition

Run on the bench box, `--quick`, ABBA, `scripts/bench-compare.sh
5c45f04c 44abe0ca`, targets `lattice-inference:elementwise_cpu_bench` (filter `gelu`) and
`lattice-embed:simd` (filter `simd_dot_product`), default features, both locks uncontended, idle
98.6% / 97.8% / 98.4% at the three checkpoints (floor 70%), AC power, thermal nominal, all
machine-state gates passed.

| Bench | Δ point | bound-lower | bound-upper | order bias ≤ |
|---|---:|---:|---:|---:|
| `add_bias_gelu/4096` | +0.01% | -0.55% | +0.57% | +0.32% |
| `add_bias_gelu/896` | +0.10% | -0.34% | +0.55% | +0.26% |
| `gelu/4096` | +0.32% | -0.26% | +0.90% | +0.46% |
| `gelu/896` | -0.06% | -1.96% | +1.87% | +1.07% |
| `simd_dot_product/*` (8 rows, informational) | -0.22%…+0.64% | | | |

All gated groups within the ±3.0% band; bench-compare showed no change. The A/B was run because
`crates/tune/Cargo.toml` changed, not waived. Beside it, the structural fact: `cargo tree -e
normal,build,dev` at the head lists `lattice-tune` under neither `lattice-inference` nor
`lattice-embed`, the embed example is an autodiscovered example target never linked into a bench,
and `Cargo.lock` is unchanged, so base and head bench binaries are built from identical inputs.
The new examples are unmeasured code; the table cannot say otherwise.

