### PR TITLE
fix(microlora): gate held-out splits on whole-verb partition; state the schema-check limit

### DIFF
--- a/scripts/microlora/README.md
+++ b/scripts/microlora/README.md
@@ -110,6 +110,10 @@ It never dispatches operations. The generator checks registered verbs, required
 parameters, parameter types, intended AST equality, and every file after readback.
 These checks establish syntax and the stated schema contracts; they do not prove
 record existence, authorization, or successful execution against a database.
+Parameter validation covers captured name, required, and type fields; it does not
+check bounds, enumerations, or patterns carried only as description prose, or the
+result types behind previous-result references, which are admitted by the reviewed
+allow-list.
 
 Output includes the three JSONL splits, matching `.provenance.jsonl` sidecars, and
 `CURATION.md`. It must be local storage outside tracked paths; repository locations
@@ -122,8 +126,15 @@ listed exclusion stops generation before any row is written, and the refusal nam
 every such verb. The report lists actual small-pack proportions, excluded verbs
 with their reasons, template counts, and validation limits. `check_split_integrity.py`
 checks exact prompt and completion overlap and prompt-length balance between two
-split files; it does not re-derive the verb partition, so a same-verb row in two
-splits passes it.
+split files. Opt in with `--verb-partition` to also reject completion verbs shared
+by both splits (exit 4), with a train-against-itself positive control. Calls inside
+double-quoted literals are ignored; this lexical check does not inspect embedded
+scheduled actions. Without the flag, a same-verb row in two splits still passes.
+
+```sh
+uv run --no-project python3 scripts/microlora/check_split_integrity.py \
+  --dir "$DATA_DIR/khive-dsl" --verb-partition
+```
 
 To include recorded calls, add `--merge-real "$REAL_JSONL"`. Each input row must
 contain string `ops`, boolean `ok`, and optionally `error` and `corrected_ops`.

--- a/scripts/microlora/check_split_integrity.py
+++ b/scripts/microlora/check_split_integrity.py
@@ -2,7 +2,7 @@
 """Check a train/held-out JSONL pair for the leakage that would invalidate a held-out NLL claim.
 
 It reports three distinct things and refuses to collapse them, because they have different
-consequences and only the first is a broken split:
+consequences and only the first is a broken split by default:
 
   PROMPT OVERLAP      a held-out prompt that also appears in train. This is real leakage: the model
                       was trained on the exact input it is being scored on, and any held-out number
@@ -19,13 +19,19 @@ consequences and only the first is a broken split:
                       longer than train is not exchangeable with it, so the held-out number answers
                       a slightly different question than "how well does this generalise".
 
+With --verb-partition, also report distinct completion calls and their crossing set.
+Double-quoted string literals are blanked before extracting pack.verb calls and bare kg verbs.
+Any crossing breaks the whole-verb partition; train against itself must cross on every verb.
+This lexical check does not inspect operations embedded inside string literals.
+
 Every count is printed with its denominator, and a positive control (train against itself) runs in
 the same invocation so an empty overlap cannot be a broken comparison silently reading as clean.
 
-Exit: 0 clean, 2 unreadable input, 3 PROMPT overlap found (the only fail-the-run condition).
+Exit: 0 clean, 2 unreadable input/control failure, 3 PROMPT overlap,
+4 VERB crossing with --verb-partition (takes precedence over prompt overlap).
 
 Usage:
-    uv run python scripts/microlora/check_split_integrity.py --dir DIR [--train train.jsonl] [--valid valid.jsonl]
+    uv run python scripts/microlora/check_split_integrity.py --dir DIR [--train train.jsonl] [--valid valid.jsonl] [--verb-partition]
 """
 
 from __future__ import annotations
@@ -34,6 +40,7 @@ import argparse
 import collections
 import hashlib
 import json
+import re
 import statistics
 import sys
 from pathlib import Path
@@ -47,11 +54,21 @@ def h(s: str) -> str:
     return hashlib.sha256(s.encode("utf-8")).hexdigest()[:16]
 
 
+def completion_verbs(rows: list[dict]) -> set[str]:
+    verbs = set()
+    for row in rows:
+        blanked = re.sub(r'"(?:\\.|[^"\\])*"', '""', row["completion"])
+        verbs.update(re.findall(r"\b([a-z_]+\.[a-z_]+)\s*\(", blanked))
+        verbs.update(re.findall(r"(?<![\w.])([a-z_]+)\s*\(", blanked))
+    return verbs
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--dir", required=True, type=Path)
     ap.add_argument("--train", default="train.jsonl")
     ap.add_argument("--valid", default="valid.jsonl")
+    ap.add_argument("--verb-partition", action="store_true", help="fail on completion verbs shared by both splits")
     args = ap.parse_args()
 
     tp, vp = args.dir / args.train, args.dir / args.valid
@@ -93,6 +110,22 @@ def main() -> int:
     lv = [len(r["prompt"]) for r in va]
     print(f"  prompt length median: train {statistics.median(lt):.0f}B, valid {statistics.median(lv):.0f}B "
           f"(ratio {statistics.median(lv)/statistics.median(lt):.2f})")
+
+    if args.verb_partition:
+        train_verbs, valid_verbs = completion_verbs(tr), completion_verbs(va)
+        verb_control = train_verbs & completion_verbs(tr)
+        crossing = train_verbs & valid_verbs
+        print(f"  VERB count: train {len(train_verbs)} distinct/{len(tr)} rows, "
+              f"valid {len(valid_verbs)} distinct/{len(va)} rows")
+        print(f"  control (train verbs found in train): {len(verb_control)}/{len(train_verbs)}  [must be all]")
+        print(f"  VERB crossing: {len(crossing)}/{len(train_verbs)} train, "
+              f"{len(crossing)}/{len(valid_verbs)} valid: {', '.join(sorted(crossing)) or 'none'}")
+        if verb_control != train_verbs:
+            print("REFUSED: the verb control failed; the comparison itself is broken", file=sys.stderr)
+            return 2
+        if crossing:
+            print("FAIL: completion verbs appear in both splits: " + ", ".join(sorted(crossing)), file=sys.stderr)
+            return 4
 
     print()
     if p_over:

--- a/scripts/microlora/synth_khive_dsl.py
+++ b/scripts/microlora/synth_khive_dsl.py
@@ -1442,6 +1442,7 @@ def curation_report(
         "",
         "## Validation",
         "",
+        "Parameter validation covers captured name, required, and type fields; it does not check bounds, enumerations, or patterns carried only as description prose, or the result types behind previous-result references, which are admitted by the reviewed allow-list.",
         f"Validator binary SHA-256: `{validator.binary_hash}`.",
         f"Parser marker: `{PARSER}`; source SHA-256: `{validator.source_hash}`.",
         'The validator consumes JSONL `{"completion":"..."}` on stdin and emits one ordered JSONL result per input.',

--- a/scripts/microlora/test_check_split_integrity.py
+++ b/scripts/microlora/test_check_split_integrity.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Stdlib regression tests for split integrity diagnostics."""
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+CHECKER = Path(os.environ.get("SPLIT_CHECKER", Path(__file__).with_name("check_split_integrity.py")))
+LEGACY_STDOUT = b"""train 1 rows (1 distinct completions, 1 appearing once)
+valid 1 rows
+  control (train prompts found in train): 1/1  [must be all]
+  PROMPT overlap:     0/1
+  COMPLETION overlap: 0/1  (0 distinct strings)
+  prompt length median: train 5B, valid 5B (ratio 1.00)
+
+PASS on the condition that voids a run: no held-out prompt appears in train.
+"""
+
+
+class SplitIntegrityTests(unittest.TestCase):
+    def run_checker(self, train, valid, *flags):
+        directory = Path(tempfile.mkdtemp(prefix="split-integrity-"))
+        for name, completion in (("train", train), ("valid", valid)):
+            (directory / f"{name}.jsonl").write_text(
+                json.dumps({"prompt": name, "completion": completion}) + "\n"
+            )
+        return subprocess.run(
+            ["uv", "run", "--no-project", "python3", str(CHECKER), "--dir", str(directory), *flags],
+            capture_output=True,
+        )
+
+    def test_crossing_fails_and_names_verb(self):
+        result = self.run_checker('memory.recall(query="a")', 'memory.recall(query="b")', "--verb-partition")
+        self.assertEqual(result.returncode, 4, result.stderr.decode())
+        self.assertIn(b"VERB crossing: 1/1 train, 1/1 valid: memory.recall", result.stdout)
+        self.assertIn(b"control (train verbs found in train): 1/1  [must be all]", result.stdout)
+
+    def test_bare_kg_verb_crosses(self):
+        result = self.run_checker('search(query="a")', 'search(query="b")', "--verb-partition")
+        self.assertEqual(result.returncode, 4, result.stderr.decode())
+        self.assertIn(b"valid: search", result.stdout)
+
+    def test_disjoint_and_literals_are_ignored(self):
+        literal = json.dumps('escaped " quote, backslash \\, x.y( and search(')
+        result = self.run_checker(f'memory.recall(query={literal}) | get(id="a")', f'comm.thread(id={literal})', "--verb-partition")
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        self.assertIn(b"VERB count: train 2 distinct/1 rows, valid 1 distinct/1 rows", result.stdout)
+        self.assertIn(b"VERB crossing: 0/2 train, 0/1 valid: none", result.stdout)
+        self.assertIn(b"control (train verbs found in train): 2/2  [must be all]", result.stdout)
+
+    def test_flag_off_stdout_is_byte_identical(self):
+        train, valid = 'memory.recall(query="a")', 'comm.thread(id="b")'
+        off = self.run_checker(train, valid)
+        on = self.run_checker(train, valid, "--verb-partition")
+        self.assertEqual(off.returncode, 0)
+        self.assertEqual(on.returncode, 0)
+        self.assertEqual(off.stdout, LEGACY_STDOUT)
+        self.assertEqual(
+            off.stdout,
+            b"".join(line for line in on.stdout.splitlines(keepends=True)
+                     if not line.startswith((b"  VERB", b"  control (train verbs"))),
+        )
+        crossing_off = self.run_checker(train, 'memory.recall(query="b")')
+        self.assertEqual(crossing_off.returncode, 0)
+        self.assertEqual(crossing_off.stdout, LEGACY_STDOUT)
+
+    def test_crossing_takes_priority_over_prompt_overlap(self):
+        result = self.run_checker('search(query="a")', 'search(query="b")', "--verb-partition", "--valid", "train.jsonl")
+        self.assertEqual(result.returncode, 4, result.stderr.decode())
+
+    def test_no_calls(self):
+        result = self.run_checker('"x.y("', '"search("', "--verb-partition")
+        self.assertEqual(result.returncode, 0, result.stderr.decode())
+        self.assertIn(b"VERB crossing: 0/0 train, 0/0 valid: none", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/microlora/test_synth_khive_dsl.py
+++ b/scripts/microlora/test_synth_khive_dsl.py
@@ -83,6 +83,24 @@ def parser_record(completion, ops, mode="single", line=1):
 
 
 class SplitAndSchemaTests(unittest.TestCase):
+    def test_report_states_parameter_validation_limits(self):
+        from types import SimpleNamespace
+
+        schemas = fixture_schemas()
+        report = synth.curation_report(
+            [], schemas, {}, synth.split_verbs(schemas),
+            SimpleNamespace(binary_hash="a" * 64, source_hash="b" * 64),
+            {}, {}, None,
+        )
+        validation = report.split("## Validation\n", 1)[1].split("\n## ", 1)[0]
+        self.assertIn(
+            "Parameter validation covers captured name, required, and type fields; "
+            "it does not check bounds, enumerations, or patterns carried only as "
+            "description prose, or the result types behind previous-result references, "
+            "which are admitted by the reviewed allow-list.",
+            validation,
+        )
+
     def test_stratified_assignment_is_stable_and_schedule_is_entirely_test(self):
         schemas = {f"pack.v{i}": schema(f"pack.v{i}", "pack") for i in range(20)}
         schemas.update(


### PR DESCRIPTION
`check_split_integrity.py` reported prompt overlap, completion overlap and length imbalance between two split files but never looked at which registry verbs a completion calls, so a train row and a held-out row calling the same verb passed it while the generator's stated partition is by whole verb. This adds an opt-in `--verb-partition` mode: string literals are blanked, `pack.verb(` and bare kg-verb calls are extracted per split, the counts and the crossing set are printed with denominators alongside a train-against-itself control, and any crossing fails the run with a new exit code 4 (taking precedence over prompt overlap). Without the flag the output is byte-identical to before, which a test asserts. Six new tests cover crossing, the bare-verb form, literal blanking, the flag-off path, precedence and the no-call case; with the crossing check no-op'd, three of them fail.

Second, the generated curation report and the README now state what parameter validation covers (captured name, required, type) and what it does not: bounds, enumerations and patterns that the capture carries only as description prose, and the result types behind previous-result references, which are admitted by the reviewed allow-list. One test asserts the sentence is present.

Scripts and docs only; no crate code. `test_synth_khive_dsl.py` 31 OK (7 skips without the parser), `test_check_split_integrity.py` 6 OK.
