### PR TITLE
feat(inference): in-process AdapterRouter::reload closing the route→refit→route loop (ADR-079 G2)

### DIFF
--- a/crates/inference/src/mixture.rs
+++ b/crates/inference/src/mixture.rs
@@ -25,9 +25,24 @@ pub type AdapterId = String;
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum RouterError {
-    /// The fann network forward pass failed.
+    /// The fann network parsing or forward pass failed.
     #[error("gate network error: {0}")]
     Gate(#[from] FannError),
+
+    /// The replacement gate dimensions differ from the live gate.
+    #[error(
+        "replacement gate dimensions {got_inputs} -> {got_outputs} do not match live gate {expected_inputs} -> {expected_outputs}"
+    )]
+    GateDimensionMismatch {
+        /// Live gate input width.
+        expected_inputs: usize,
+        /// Live gate output width.
+        expected_outputs: usize,
+        /// Replacement gate input width.
+        got_inputs: usize,
+        /// Replacement gate output width.
+        got_outputs: usize,
+    },
 
     /// The requested `k` exceeds the number of available adapters.
     #[error("k={k} exceeds available adapter count {available}")]
@@ -105,6 +120,29 @@ impl AdapterRouter {
     /// expected pool size.
     pub fn new(gate: Network) -> Self {
         Self { gate }
+    }
+
+    /// Replace the gate from a complete [`Network::to_bytes`] blob.
+    ///
+    /// Parsing and both dimensions must validate before any mutation: a failed
+    /// reload leaves the live gate intact so a bad refit fails once, rather than
+    /// disrupting subsequent requests.
+    pub fn reload(&mut self, gate_bytes: &[u8]) -> Result<(), RouterError> {
+        let gate = Network::from_bytes(gate_bytes)?;
+        let expected_inputs = self.gate.num_inputs();
+        let expected_outputs = self.gate.num_outputs();
+        let got_inputs = gate.num_inputs();
+        let got_outputs = gate.num_outputs();
+        if got_inputs != expected_inputs || got_outputs != expected_outputs {
+            return Err(RouterError::GateDimensionMismatch {
+                expected_inputs,
+                expected_outputs,
+                got_inputs,
+                got_outputs,
+            });
+        }
+        self.gate = gate;
+        Ok(())
     }
 
     /// Select the top-`k` adapters for the given context and assign each
@@ -219,6 +257,63 @@ mod tests {
             .build()
             .unwrap();
         AdapterRouter::new(net)
+    }
+
+    fn fixed_gate(inputs: usize, outputs: usize, preferred: usize) -> Network {
+        let mut layer = lattice_fann::Layer::zeros(inputs, outputs, Activation::Linear).unwrap();
+        layer.biases_mut()[preferred] = 1.0;
+        Network::new(vec![layer]).unwrap()
+    }
+
+    #[test]
+    fn reload_changes_selection() {
+        let mut router = AdapterRouter::new(fixed_gate(2, 2, 0));
+        let pool = vec!["first".into(), "second".into()];
+        let context = [1.0, 0.5];
+        let before = router.route(&context, &pool, 1).unwrap();
+        assert_eq!(before, vec![(pool[0].clone(), 1.0)]);
+        router.reload(&fixed_gate(2, 2, 1).to_bytes()).unwrap();
+        let after = router.route(&context, &pool, 1).unwrap();
+        assert_ne!(before, after, "reload must replace the live gate");
+        assert_eq!(after, vec![(pool[1].clone(), 1.0)]);
+    }
+
+    #[test]
+    fn reload_wrong_dimensions_preserves_selection() {
+        for (inputs, outputs) in [(3, 2), (2, 3), (3, 3)] {
+            let mut router = AdapterRouter::new(fixed_gate(2, 2, 0));
+            let pool = vec!["first".into(), "second".into()];
+            let context = [1.0, 0.5];
+            let before = router.route(&context, &pool, 1).unwrap();
+            let error = router
+                .reload(&fixed_gate(inputs, outputs, 1).to_bytes())
+                .unwrap_err();
+            assert!(matches!(
+                error,
+                RouterError::GateDimensionMismatch {
+                    expected_inputs: 2,
+                    expected_outputs: 2,
+                    got_inputs,
+                    got_outputs,
+                } if got_inputs == inputs && got_outputs == outputs
+            ));
+            assert_eq!(router.route(&context, &pool, 1).ok(), Some(before));
+            assert_eq!(router.input_size(), 2);
+            assert_eq!(router.output_size(), 2);
+        }
+    }
+
+    #[test]
+    fn reload_malformed_bytes_preserves_selection() {
+        let mut router = AdapterRouter::new(fixed_gate(2, 2, 0));
+        let pool = vec!["first".into(), "second".into()];
+        let context = [1.0, 0.5];
+        let before = router.route(&context, &pool, 1).unwrap();
+        assert!(matches!(
+            router.reload(b"invalid"),
+            Err(RouterError::Gate(_))
+        ));
+        assert_eq!(router.route(&context, &pool, 1).unwrap(), before);
     }
 
     #[test]

--- a/crates/tune/Cargo.toml
+++ b/crates/tune/Cargo.toml
@@ -91,6 +91,11 @@ name = "gdn_lora_wiring"
 path = "tests/gdn_lora_wiring.rs"
 required-features = ["train-backward"]
 
+[[test]]
+name = "router_loop_closure"
+path = "tests/router_loop_closure.rs"
+required-features = ["mixture", "inference-hook", "serde"]
+
 [dev-dependencies]
 tempfile.workspace = true
 proptest.workspace = true

--- a/crates/tune/tests/router_loop_closure.rs
+++ b/crates/tune/tests/router_loop_closure.rs
@@ -1,0 +1,82 @@
+use lattice_fann::{Activation, Network, NetworkBuilder};
+use lattice_inference::mixture::{AdapterRouter, RouterError};
+use lattice_tune::lora::router_update::{
+    DiagonalFisher, FeedbackEvent, PreferenceSignal, ReplayBuffer, RouterUpdateConfig,
+    update_router,
+};
+
+fn gate(inputs: usize, outputs: usize) -> Network {
+    NetworkBuilder::new()
+        .input(inputs)
+        .hidden(16, Activation::Tanh)
+        .output(outputs, Activation::Linear)
+        .build_with_seed(42)
+        .unwrap()
+}
+
+#[test]
+fn feedback_refit_reload_changes_selection() {
+    let network = gate(2, 2);
+    let bytes = network.to_bytes();
+    let mut router = AdapterRouter::new(network);
+    let context = vec![1.0, 0.5];
+    let pool = vec!["first".to_string(), "second".to_string()];
+    let before = router.route(&context, &pool, 1).unwrap();
+    let preferred = 1 - usize::from(before[0].0 == pool[1]);
+    let events = vec![
+        FeedbackEvent {
+            context_vector: context.clone(),
+            preferred_adapter_idx: preferred,
+            adapter_id: pool[preferred].clone(),
+            signal: PreferenceSignal::Positive,
+        };
+        16
+    ];
+    let config = RouterUpdateConfig {
+        learning_rate: 0.1,
+        epochs: 40,
+        aux_loss_coeff: 0.0,
+        z_loss_coeff: 0.0,
+        replay_mix_fraction: 0.0,
+        ..RouterUpdateConfig::default()
+    };
+    let delta = update_router(
+        &bytes,
+        &events,
+        &mut ReplayBuffer::new(32),
+        &mut DiagonalFisher::new(0, 0.99).unwrap(),
+        &config,
+    )
+    .unwrap();
+    assert_eq!(delta.events_consumed, events.len());
+    assert_eq!(router.route(&context, &pool, 1).unwrap(), before);
+    router.reload(&delta.network_bytes).unwrap();
+    let after = router.route(&context, &pool, 1).unwrap();
+    assert_ne!(before, after, "feedback reload must change selection");
+    assert_eq!(after, vec![(pool[preferred].clone(), 1.0)]);
+}
+
+#[test]
+fn rejected_reload_preserves_original_route() {
+    for (inputs, outputs) in [(3, 2), (2, 3), (3, 3)] {
+        let mut router = AdapterRouter::new(gate(2, 2));
+        let context = [1.0, 0.5];
+        let pool = vec!["first".into(), "second".into()];
+        let before = router.route(&context, &pool, 1).unwrap();
+        let error = router
+            .reload(&gate(inputs, outputs).to_bytes())
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            RouterError::GateDimensionMismatch {
+                expected_inputs: 2,
+                expected_outputs: 2,
+                got_inputs,
+                got_outputs,
+            } if got_inputs == inputs && got_outputs == outputs
+        ));
+        assert_eq!(router.route(&context, &pool, 1).ok(), Some(before));
+        assert_eq!(router.input_size(), 2);
+        assert_eq!(router.output_size(), 2);
+    }
+}

--- a/docs/adr/ADR-079-adaptive-micro-lora-brain.md
+++ b/docs/adr/ADR-079-adaptive-micro-lora-brain.md
@@ -152,8 +152,7 @@ synthesizing record; it references the seven above rather than re-opening any of
   a rotation-aware trainer (ADR-054) would slot into the TRAIN stage without changing GOVERN/COMPOSE/
   ROUTE/CONSUME, since composition and routing operate on adapter blobs regardless of the basis they
   were trained in.
-- G2's caller-owned loop-closure boundary is documented, not hidden: a host runtime wiring the
-  adaptive loop knows it owns gate persistence/reload until G2 lands.
+- Gate persistence stays caller-owned; `AdapterRouter::reload` closes the adaptive loop in-process.
 
 ## S-row rider
 
@@ -161,6 +160,8 @@ When any Gn lands (most likely G1, surface-B GDN grads), record it as a status u
 this ADR so the traceability chain shows idea → composed-record → gap-closure, not a silent flip.
 
 ## Amendment 1 (2026-09-10) — G2's re-entry trigger has fired; the closure contract, fixed before it is built
+
+**2026-09-12 — G2 landed:** atomic `AdapterRouter::reload` and route → feedback → refit → reload → route regression tests close the in-process loop.
 
 **G2 has not landed. Its trigger has.** G2 was written to fire "if in-process closure becomes a
 requirement", and it now has: the adaptive-loop work item wires feedback through `update_router`


### PR DESCRIPTION
Closes ADR-079 G2 as fixed by its Amendment 1. `AdapterRouter::reload(&mut self, gate_bytes)` (in `lattice-inference` under `mixture`) accepts the complete FANN blob that `update_router` returns in `RouterDelta.network_bytes`, parses it, compares both endpoint widths against the live gate, and swaps only when both match; a mismatch returns a new `RouterError::GateDimensionMismatch` carrying all four widths and leaves the router untouched, and malformed bytes return through the existing `Gate` path. Gate persistence stays caller-owned; what the caller no longer owns is the out-of-process round trip. The ADR's Consequences line is revised to say so and Amendment 1 records the landing.

Tests. Three unit tests in `mixture.rs` (reload changes the selection for the same context and pool; wrong-width reloads over three shapes return the variant and the pre-reload selection survives; malformed bytes preserve routing). `crates/tune/tests/router_loop_closure.rs` (a `[[test]]` requiring `mixture`, `inference-hook`, `serde`) runs route → 16 positive feedback events → `update_router` → `reload` → route and asserts the selection changed to the preferred adapter, plus a mismatch case asserting the error and the unchanged route. Mutation checks: a `reload` that validates but never swaps fails the loop-closure test; a `reload` that swaps before validating fails the mismatch arm. `cargo test -p lattice-inference --features mixture --lib`: 2879 passed; loop-closure target: 2 passed; `cargo clippy --workspace --all-targets` with the three features: clean; fmt clean.

## bench-compare disposition

Structural: `crates/inference/src/mixture.rs` is compiled only under `#[cfg(feature = "mixture")]` (`src/lib.rs:83`), and `mixture` is not in `lattice-inference`'s default set (`default = ["std", "download", "serve"]`). At the head, the manifest declares 25 `[[bench]]` tables; none lists `mixture` in `required-features`, and no file under `crates/inference/benches/` names `mixture` or `AdapterRouter` (22 of them name `criterion`, as the search control). `crates/inference/Cargo.toml` and `Cargo.lock` are unchanged by this change; the only manifest edit is the `[[test]]` table in `crates/tune/Cargo.toml`, and `lattice-tune` is not in the dependency closure of the inference or embed bench builds. Base and head bench binaries are therefore built from identical effective source. The new code is unmeasured, not shown safe: no bench target reaches it.
