### PR TITLE
feat(tune): measure response quality under adapter routing

### DIFF
--- a/crates/tune/examples/prompt_router.md
+++ b/crates/tune/examples/prompt_router.md
@@ -174,7 +174,7 @@ S1 is supplementary and outside the decision rule, registered before the origina
 
 **Run 1 (pre-fix).** First-line callable results were routed 28/80 (35.0%), single-M 8/80 (10.0%), single-G 20/80 (25.0%), base 0/80 (0.0%). The old loader merged the prompt/completion boundary on 52/80 held-out rows; all 31 leading-newline memory-adapter outputs across the 80 prompts belonged to merged rows. It also omitted EOS, and memory-adapter outputs on their own family contained glued repeats on 16/40 prompts (issue #1545, fixed by #1546).
 
-Timings were recorded on an Apple-silicon desktop and are informational, never a benchmark verdict: the relay holds the bench window shared. Every timing below carries its producing phase's start/end conditions. The trainer's `done` duration covers the step loop and scoring; the conditions receipt records full phase time. The driver uses `uv run --no-project python3`.
+Timings were recorded on an Apple-silicon desktop and are informational, never a benchmark verdict: the machine's bench window was held shared, so other work could overlap these phases. Every timing below carries its producing phase's start/end conditions. The trainer's `done` duration covers the step loop and scoring; the conditions receipt records full phase time. The driver uses `uv run --no-project python3`.
 
 train-M:
 

--- a/crates/tune/examples/prompt_router.md
+++ b/crates/tune/examples/prompt_router.md
@@ -99,6 +99,10 @@ comparison. No response quality was measured, and these results support no routi
 
 ### Response quality under routing
 
+Run 2 uses the corrected loader from #1546: prompt and completion tokenize
+separately, and the model EOS token is appended. The split, training flags,
+and scoring rule remain fixed.
+
 The fixed construction uses only the training split of a captured request corpus
 (SHA-256 prefix `6ff089c0e380213e`, 2,806 single-line completions). Its separate
 validation/test splits hold out entire verbs and answer a different generalization
@@ -131,75 +135,55 @@ the prompt's family. Exact match compares canonical requests. All 100 schema JSO
 files, including underscore files, contribute to capture `625b8392f752d63d`
 (98 verbs). The parser source SHA-256 is
 `62992e89258640e2c76752961eda1af42bb0cc097fb713341182b3e9d2d8a915`.
-The control command is `uv run --no-project python3 scripts/microlora/w6_score.py
---self-test`, after preparing the input directory and validator. All controls were
-completed before generation. Family acceptance requires a nonempty set of qualified
-calls outside double-quoted literals, all belonging to the prompt's family.
 
-| Control                            | Expected                                                            | Observed                                                        |
-| ---------------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------- |
-| C0 scorer self-test                | PASS, FAIL, REFUSED reachable; capture `625b8392f752d63d`, 98 verbs | Matched                                                         |
-| C1 gold callable-on-family         | 80/80                                                               | 80/80                                                           |
-| C2 wrong first parameter NOT PASS  | 80/80                                                               | 80/80; all parse successfully and fail argument-name validation |
-| C3 wrong family rejected           | 80/80                                                               | 80/80                                                           |
-| C4 prefixed prose parser rejection | 80/80                                                               | 80/80                                                           |
+The control command is `uv run --no-project python3 scripts/microlora/w6_score.py --self-test --input INPUT_DIR --out SCORE_DIR --validator VALIDATOR --generations OUTPUT_DIR`. Controls completed before generation. First-line extraction is `output.split("\n", 1)[0].strip()` and records whether any newline was emitted. Family acceptance requires a nonempty set of qualified calls outside double-quoted literals, all in the prompt's family. C2's 80 mutated completions all parse and are rejected by argument validation.
 
-Base has no adapter. Single-M applies the memory adapter to every prompt;
-single-G applies the task adapter to every prompt. Routed follows the gate,
-oracle follows the true family, and random uses Python `Random(20260912).choice`
-over M/G in held-out input order.
+Base has no adapter. Single-M applies the memory adapter to all prompts; single-G applies the task adapter to all prompts. Routed follows the gate, oracle follows the true family, and random uses Python `Random(20260912).choice` over M/G in held-out order. Selection arms reuse deterministic M/G outputs.
 
-| Arm      | Callable overall | Callable memory | Callable gtd  | Exact overall | Exact memory | Exact gtd     |
-| -------- | ---------------- | --------------- | ------------- | ------------- | ------------ | ------------- |
-| base     | 0/80 (0.0%)      | 0/40 (0.0%)     | 0/40 (0.0%)   | 0/80 (0.0%)   | 0/40 (0.0%)  | 0/40 (0.0%)   |
-| single-M | 8/80 (10.0%)     | 8/40 (20.0%)    | 0/40 (0.0%)   | 8/80 (10.0%)  | 8/40 (20.0%) | 0/40 (0.0%)   |
-| single-G | 20/80 (25.0%)    | 0/40 (0.0%)     | 20/40 (50.0%) | 17/80 (21.2%) | 0/40 (0.0%)  | 17/40 (42.5%) |
-| routed   | 28/80 (35.0%)    | 8/40 (20.0%)    | 20/40 (50.0%) | 25/80 (31.2%) | 8/40 (20.0%) | 17/40 (42.5%) |
-| oracle   | 28/80 (35.0%)    | 8/40 (20.0%)    | 20/40 (50.0%) | 25/80 (31.2%) | 8/40 (20.0%) | 17/40 (42.5%) |
-| random   | 12/80 (15.0%)    | 5/40 (12.5%)    | 7/40 (17.5%)  | 11/80 (13.8%) | 5/40 (12.5%) | 6/40 (15.0%)  |
+| Control                            | Expected                                                            | Observed                                            |
+| ---------------------------------- | ------------------------------------------------------------------- | --------------------------------------------------- |
+| C0 scorer self-test                | PASS, FAIL, REFUSED reachable; capture `625b8392f752d63d`, 98 verbs | Matched                                             |
+| C1 gold callable-on-family         | 80/80                                                               | 80/80                                               |
+| C2 wrong first parameter NOT PASS  | 80/80                                                               | 80/80; all parse, all fail argument-name validation |
+| C3 wrong family rejected           | 80/80                                                               | 80/80                                               |
+| C4 prefixed prose parser rejection | 80/80                                                               | 80/80                                               |
 
-Routing accuracy is 80/80; shuffled-label accuracy is 47/80, within its
-predefined chance interval. All 12 duplicate outputs match byte-for-byte.
-Newline presence is retained per output in the scoring artifacts.
-Under the fixed rule, routing is **USEFUL**: it meets the overall best-single
-minus-five-points bound and strictly exceeds base on each family.
+| arm      | callable overall | memory        | gtd            | exact overall | memory        | gtd           |
+| -------- | ---------------- | ------------- | -------------- | ------------- | ------------- | ------------- |
+| base     | 0/80 (0.0%)      | 0/40 (0.0%)   | 0/40 (0.0%)    | 0/80 (0.0%)   | 0/40 (0.0%)   | 0/40 (0.0%)   |
+| single-M | 39/80 (48.8%)    | 39/40 (97.5%) | 0/40 (0.0%)    | 39/80 (48.8%) | 39/40 (97.5%) | 0/40 (0.0%)   |
+| single-G | 40/80 (50.0%)    | 0/40 (0.0%)   | 40/40 (100.0%) | 38/80 (47.5%) | 0/40 (0.0%)   | 38/40 (95.0%) |
+| routed   | 79/80 (98.8%)    | 39/40 (97.5%) | 40/40 (100.0%) | 77/80 (96.2%) | 39/40 (97.5%) | 38/40 (95.0%) |
+| oracle   | 79/80 (98.8%)    | 39/40 (97.5%) | 40/40 (100.0%) | 77/80 (96.2%) | 39/40 (97.5%) | 38/40 (95.0%) |
+| random   | 42/80 (52.5%)    | 26/40 (65.0%) | 16/40 (40.0%)  | 41/80 (51.2%) | 26/40 (65.0%) | 15/40 (37.5%) |
 
-Memory train NLL: 1.7006 → 0.0077; held-out NLL: 1.2385 → 0.0025.
-Task train NLL: 1.4251 → 0.0036; held-out NLL: 1.7972 → 0.0057.
-Both clear the fixed 50% held-out NLL-reduction threshold.
+Routing accuracy is 80/80; shuffled-label accuracy is 47/80, within its predefined chance interval. All 12 primary-arm duplicate outputs match byte-for-byte.
 
-Timings were recorded on an Apple-silicon desktop. The shared bench window makes
-these timings informational, never a benchmark verdict. Recorded phases used a
-direct Python interpreter entry; the packaged shell wrapper now invokes the same
-standard-library driver through `uv run --no-project python3`. The trainer's `done`
-duration covers the step loop and its scoring, not the full phase; each conditions
-receipt records the full phase elapsed time. Cache and scoring passes are shown
-separately. Each timing below belongs to its named phase's start/end conditions.
+memory: train NLL 2.2866 → 0.0076; held-out NLL 1.8271 → 0.0034 (99.814% reduction).
+gtd: train NLL 1.7828 → 0.0032; held-out NLL 2.2718 → 0.0028 (99.877% reduction).
 
-train-M, with its conditions below:
+Under the fixed rule, routing is **USEFUL**: routed meets the best-single-adapter minus-five-points bound overall and strictly exceeds base on each family.
+
+S1 is supplementary and outside the decision rule, registered before the original adapter outputs existed. It uses the base model with `<think>\n\n</think>\n\n` appended to each verbatim prompt, with the same decode flags. Four separate-process duplicates also match.
+
+| Supplementary arm | First-line parser accepted | First-line callable | First-non-blank-line parser accepted | First-non-blank-line callable | Reopened `<think>` |
+| ----------------- | -------------------------- | ------------------- | ------------------------------------ | ----------------------------- | ------------------ |
+| S1                | 0/80                       | 0/80                | 0/80                                 | 0/80                          | 0/80               |
+
+**Why base reads 0.** In run 1, the raw model opened `<think>` on 70/80 prompts and a code fence on 9/80; its first line was blank on 80/80. With the think block closed (S1), its outputs include prose, SQL, HTTP, and unrelated code, and still parse on 0/80 under both line rules. These controls support attributing the floor to the model not knowing the request DSL, beyond the leading blank line and open thinking block.
+
+**Run 1 (pre-fix).** First-line callable results were routed 28/80 (35.0%), single-M 8/80 (10.0%), single-G 20/80 (25.0%), base 0/80 (0.0%). The old loader merged the prompt/completion boundary on 52/80 held-out rows; all 31 leading-newline memory-adapter outputs across the 80 prompts belonged to merged rows. It also omitted EOS, and memory-adapter outputs on their own family contained glued repeats on 16/40 prompts (issue #1545, fixed by #1546).
+
+Timings were recorded on an Apple-silicon desktop and are informational, never a benchmark verdict: the relay holds the bench window shared. Every timing below carries its producing phase's start/end conditions. The trainer's `done` duration covers the step loop and scoring; the conditions receipt records full phase time. The driver uses `uv run --no-project python3`.
+
+train-M:
 
 ```text
-1182 completion positions across 48 samples in 83.3s (10 threads)
-held-out: 255 completion positions across 8 valid samples in 17.5s (10 threads)
-baseline scoring: train pass 105.6s, held-out pass 22.3s
-step loop: 96 steps in 318.0s (3.31s/step), in-loop scoring 127.6s over 1 point(s), epilogue re-scoring 0.0s
-=== done: train 1.7006→0.0077 (-1.6929)  |  held-out 1.2385→0.0025 (-1.2360)  in 445.6s ===
-```
-
-train-G, with its conditions below:
-
-```text
-1688 completion positions across 48 samples in 110.9s (10 threads)
-held-out: 232 completion positions across 8 valid samples in 16.9s (10 threads)
-baseline scoring: train pass 146.9s, held-out pass 20.3s
-step loop: 96 steps in 437.0s (4.55s/step), in-loop scoring 164.0s over 1 point(s), epilogue re-scoring 0.0s
-=== done: train 1.4251→0.0036 (-1.4215)  |  held-out 1.7972→0.0057 (-1.7914)  in 601.1s ===
-```
-
-Route cost, with the route conditions below:
-
-```text
-warm_embedding_seconds=0.00464475 single_gate_forward_seconds=0.000000458 cold_embedding_seconds=0.302235958
+1259 completion positions across 48 samples in 84.4s (10 threads)
+held-out: 269 completion positions across 8 valid samples in 17.8s (10 threads)
+baseline scoring: train pass 109.4s, held-out pass 22.7s
+step loop: 96 steps in 328.9s (3.43s/step), in-loop scoring 132.1s over 1 point(s), epilogue re-scoring 0.0s
+=== done: train 2.2866→0.0076 (-2.2790)  |  held-out 1.8271→0.0034 (-1.8237)  in 461.0s ===
 ```
 
 ```json
@@ -207,22 +191,32 @@ warm_embedding_seconds=0.00464475 single_gate_forward_seconds=0.000000458 cold_e
   "phase": "train-M",
   "start": {
     "kern.memorystatus_vm_pressure_level": "1",
-    "vm.loadavg": "{ 1.68 1.78 1.85 }",
+    "vm.loadavg": "{ 1.10 1.17 1.31 }",
     "hw.model": "Mac16,10",
     "hw.memsize": "17179869184",
     "machdep.cpu.brand_string": "Apple M4"
   },
   "window": "shared; informational timing only",
   "ok": true,
-  "elapsed_seconds": 680.5020301659999,
+  "elapsed_seconds": 699.4037639590097,
   "end": {
     "kern.memorystatus_vm_pressure_level": "1",
-    "vm.loadavg": "{ 1.91 2.57 2.85 }",
+    "vm.loadavg": "{ 1.66 2.00 2.04 }",
     "hw.model": "Mac16,10",
     "hw.memsize": "17179869184",
     "machdep.cpu.brand_string": "Apple M4"
   }
 }
+```
+
+train-G:
+
+```text
+1762 completion positions across 48 samples in 113.1s (10 threads)
+held-out: 246 completion positions across 8 valid samples in 18.6s (10 threads)
+baseline scoring: train pass 152.4s, held-out pass 20.9s
+step loop: 96 steps in 446.0s (4.65s/step), in-loop scoring 169.1s over 1 point(s), epilogue re-scoring 0.0s
+=== done: train 1.7828→0.0032 (-1.7796)  |  held-out 2.2718→0.0028 (-2.2690)  in 615.1s ===
 ```
 
 ```json
@@ -230,63 +224,67 @@ warm_embedding_seconds=0.00464475 single_gate_forward_seconds=0.000000458 cold_e
   "phase": "train-G",
   "start": {
     "kern.memorystatus_vm_pressure_level": "1",
-    "vm.loadavg": "{ 1.55 2.34 2.75 }",
+    "vm.loadavg": "{ 3.74 2.56 2.24 }",
     "hw.model": "Mac16,10",
     "hw.memsize": "17179869184",
     "machdep.cpu.brand_string": "Apple M4"
   },
   "window": "shared; informational timing only",
   "ok": true,
-  "elapsed_seconds": 906.7692175840001,
+  "elapsed_seconds": 930.964566583978,
   "end": {
     "kern.memorystatus_vm_pressure_level": "1",
-    "vm.loadavg": "{ 1.62 1.99 2.64 }",
+    "vm.loadavg": "{ 1.78 2.01 2.35 }",
     "hw.model": "Mac16,10",
     "hw.memsize": "17179869184",
     "machdep.cpu.brand_string": "Apple M4"
   }
 }
 ```
+
+gen-base:
 
 ```json
 {
   "phase": "gen-base",
   "start": {
     "kern.memorystatus_vm_pressure_level": "1",
-    "vm.loadavg": "{ 2.74 2.52 2.74 }",
+    "vm.loadavg": "{ 2.09 2.15 2.38 }",
     "hw.model": "Mac16,10",
     "hw.memsize": "17179869184",
     "machdep.cpu.brand_string": "Apple M4"
   },
   "window": "shared; informational timing only",
   "ok": true,
-  "elapsed_seconds": 333.334467208,
+  "elapsed_seconds": 338.5525895419996,
   "end": {
     "kern.memorystatus_vm_pressure_level": "1",
-    "vm.loadavg": "{ 1.45 1.83 2.33 }",
+    "vm.loadavg": "{ 1.90 1.92 2.18 }",
     "hw.model": "Mac16,10",
     "hw.memsize": "17179869184",
     "machdep.cpu.brand_string": "Apple M4"
   }
 }
 ```
+
+gen-M:
 
 ```json
 {
   "phase": "gen-M",
   "start": {
     "kern.memorystatus_vm_pressure_level": "1",
-    "vm.loadavg": "{ 1.21 1.73 2.28 }",
+    "vm.loadavg": "{ 1.62 1.85 2.15 }",
     "hw.model": "Mac16,10",
     "hw.memsize": "17179869184",
     "machdep.cpu.brand_string": "Apple M4"
   },
   "window": "shared; informational timing only",
   "ok": true,
-  "elapsed_seconds": 306.585580333,
+  "elapsed_seconds": 210.76446954201674,
   "end": {
     "kern.memorystatus_vm_pressure_level": "1",
-    "vm.loadavg": "{ 1.74 1.70 2.08 }",
+    "vm.loadavg": "{ 1.75 1.79 2.06 }",
     "hw.model": "Mac16,10",
     "hw.memsize": "17179869184",
     "machdep.cpu.brand_string": "Apple M4"
@@ -294,27 +292,35 @@ warm_embedding_seconds=0.00464475 single_gate_forward_seconds=0.000000458 cold_e
 }
 ```
 
+gen-G:
+
 ```json
 {
   "phase": "gen-G",
   "start": {
     "kern.memorystatus_vm_pressure_level": "1",
-    "vm.loadavg": "{ 1.46 1.62 2.04 }",
+    "vm.loadavg": "{ 1.66 1.77 2.04 }",
     "hw.model": "Mac16,10",
     "hw.memsize": "17179869184",
     "machdep.cpu.brand_string": "Apple M4"
   },
   "window": "shared; informational timing only",
   "ok": true,
-  "elapsed_seconds": 321.186848292,
+  "elapsed_seconds": 203.1446277089999,
   "end": {
     "kern.memorystatus_vm_pressure_level": "1",
-    "vm.loadavg": "{ 1.87 1.70 1.93 }",
+    "vm.loadavg": "{ 1.86 1.74 1.96 }",
     "hw.model": "Mac16,10",
     "hw.memsize": "17179869184",
     "machdep.cpu.brand_string": "Apple M4"
   }
 }
+```
+
+route:
+
+```text
+warm_embedding_seconds=0.004635875 single_gate_forward_seconds=0.000000416 cold_embedding_seconds=0.303303792
 ```
 
 ```json
@@ -322,17 +328,42 @@ warm_embedding_seconds=0.00464475 single_gate_forward_seconds=0.000000458 cold_e
   "phase": "route",
   "start": {
     "kern.memorystatus_vm_pressure_level": "1",
-    "vm.loadavg": "{ 1.25 1.54 1.84 }",
+    "vm.loadavg": "{ 1.76 1.72 1.95 }",
     "hw.model": "Mac16,10",
     "hw.memsize": "17179869184",
     "machdep.cpu.brand_string": "Apple M4"
   },
   "window": "shared; informational timing only",
   "ok": true,
-  "elapsed_seconds": 1.751243125,
+  "elapsed_seconds": 1.7448832500376739,
   "end": {
     "kern.memorystatus_vm_pressure_level": "1",
-    "vm.loadavg": "{ 1.25 1.54 1.84 }",
+    "vm.loadavg": "{ 1.76 1.72 1.95 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  }
+}
+```
+
+gen-S1:
+
+```json
+{
+  "phase": "gen-S1",
+  "start": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 1.56 1.68 1.92 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  },
+  "window": "shared; informational timing only",
+  "ok": true,
+  "elapsed_seconds": 332.17996287497226,
+  "end": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 1.74 1.66 1.82 }",
     "hw.model": "Mac16,10",
     "hw.memsize": "17179869184",
     "machdep.cpu.brand_string": "Apple M4"

--- a/crates/tune/examples/prompt_router.md
+++ b/crates/tune/examples/prompt_router.md
@@ -1,7 +1,7 @@
 # Prompt embedding routing experiment
 
-This two-stage experiment measures whether prompt embeddings separate two adapter
-domains. It does not measure response quality or prove either adapter is useful.
+The separation arms measure whether prompt embeddings separate two adapter
+domains. Separation alone does not establish response quality or adapter usefulness.
 No dependency on `lattice-embed` is added to the training or inference crates.
 
 Prepare JSONL records containing `prompt` (string), `label` (0 or 1), and `split`
@@ -39,8 +39,11 @@ changed selection, 16 consumed events, replay accuracy 1.0, and an unchanged
 no-update counterfactual. This is a controlled preference reversal, not a replay
 of measured adapter response quality.
 
-An optional final argument selects `real`, `shuffled`, `balance`, `loop`, or `cost`
-for isolated checks. Cost output is one warm embedding call and one warm gate
+An optional final argument selects `real`, `shuffled`, `balance`, `loop`, `cost`,
+or `decisions` for isolated checks. The `decisions` arm uses the same real-label
+fit and seed 42, then emits `decision idx=<i> label=<l> predicted=<p>` for every
+test row in input order, followed by the accuracy line. It is explicitly selected
+and is excluded from the default `all` arm. Cost output is one warm embedding call and one warm gate
 forward, plus the cold embedding call. These are observational timings, without
 prefill comparison or statistical performance guarantees. Follow the repository's
 machine-lock policy when running measurements.
@@ -93,3 +96,246 @@ Test rows are template-generated, so row count overstates the evidence, includin
 A and B; effective test size is the template count, not the row count. Opening counts
 are not template counts. Single-call timings are observational, without a prefill
 comparison. No response quality was measured, and these results support no routing decision.
+
+### Response quality under routing
+
+The fixed construction uses only the training split of a captured request corpus
+(SHA-256 prefix `6ff089c0e380213e`, 2,806 single-line completions). Its separate
+validation/test splits hold out entire verbs and answer a different generalization
+question. Single-family extraction ignores calls inside double-quoted literals:
+257 memory rows and 204 task rows, with zero case-insensitive prompt duplicates
+dropped. With seed 20260912, proportional largest-remainder allocation reserves
+40 prompts per family, at least one per verb. Verb groups are shuffled in lexical
+order, followed by each family's remaining and held-out rows. The held-out verb
+counts are memory recall/feedback/prune 24/14/2 and tasks/transition/next 16/16/8.
+
+Each adapter uses the first 48 shuffled training rows. The first eight held-out
+rows supply the trainer's NLL read-out without weight updates and remain among
+the 40 generation-scored prompts. Exact prompt overlap is zero; completion overlap
+under different prompts is 4/40 memory and 5/40 tasks, limiting independence.
+The Qwen3.5-0.8B trainer flags are `--seq-len 256 --steps 96 --max-train 48
+--max-valid 8 --first-layer 19 --rank 8 --alpha 16 --lr 1e-3 --log-every 96
+--seed 4277009102`. The generator uses each verbatim prompt with
+`--max-tokens 64 --temperature 0 --seed 1`.
+
+The router uses all 96 adapter-training prompts and the same 80 held-out prompts,
+unstripped, with memory label 0 and task label 1. Both splits have at least 30
+rows per label, and held-out labels balance 40/40. The `real`, `shuffled`, `cost`,
+and `decisions` arms use BGE-small-en-v1.5 vectors. Routed, oracle, and seed-20260912
+coin selections reuse the two adapter outputs only after the four duplicate
+prompts per generation arm match byte-for-byte in separate processes.
+
+Callable-on-family requires the first generated line to pass the real request
+parser and the captured argument scorer, with every qualified verb belonging to
+the prompt's family. Exact match compares canonical requests. All 100 schema JSON
+files, including underscore files, contribute to capture `625b8392f752d63d`
+(98 verbs). The parser source SHA-256 is
+`62992e89258640e2c76752961eda1af42bb0cc097fb713341182b3e9d2d8a915`.
+The control command is `uv run --no-project python3 scripts/microlora/w6_score.py
+--self-test`, after preparing the input directory and validator. All controls were
+completed before generation. Family acceptance requires a nonempty set of qualified
+calls outside double-quoted literals, all belonging to the prompt's family.
+
+| Control                            | Expected                                                            | Observed                                                        |
+| ---------------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------- |
+| C0 scorer self-test                | PASS, FAIL, REFUSED reachable; capture `625b8392f752d63d`, 98 verbs | Matched                                                         |
+| C1 gold callable-on-family         | 80/80                                                               | 80/80                                                           |
+| C2 wrong first parameter NOT PASS  | 80/80                                                               | 80/80; all parse successfully and fail argument-name validation |
+| C3 wrong family rejected           | 80/80                                                               | 80/80                                                           |
+| C4 prefixed prose parser rejection | 80/80                                                               | 80/80                                                           |
+
+Base has no adapter. Single-M applies the memory adapter to every prompt;
+single-G applies the task adapter to every prompt. Routed follows the gate,
+oracle follows the true family, and random uses Python `Random(20260912).choice`
+over M/G in held-out input order.
+
+| Arm      | Callable overall | Callable memory | Callable gtd  | Exact overall | Exact memory | Exact gtd     |
+| -------- | ---------------- | --------------- | ------------- | ------------- | ------------ | ------------- |
+| base     | 0/80 (0.0%)      | 0/40 (0.0%)     | 0/40 (0.0%)   | 0/80 (0.0%)   | 0/40 (0.0%)  | 0/40 (0.0%)   |
+| single-M | 8/80 (10.0%)     | 8/40 (20.0%)    | 0/40 (0.0%)   | 8/80 (10.0%)  | 8/40 (20.0%) | 0/40 (0.0%)   |
+| single-G | 20/80 (25.0%)    | 0/40 (0.0%)     | 20/40 (50.0%) | 17/80 (21.2%) | 0/40 (0.0%)  | 17/40 (42.5%) |
+| routed   | 28/80 (35.0%)    | 8/40 (20.0%)    | 20/40 (50.0%) | 25/80 (31.2%) | 8/40 (20.0%) | 17/40 (42.5%) |
+| oracle   | 28/80 (35.0%)    | 8/40 (20.0%)    | 20/40 (50.0%) | 25/80 (31.2%) | 8/40 (20.0%) | 17/40 (42.5%) |
+| random   | 12/80 (15.0%)    | 5/40 (12.5%)    | 7/40 (17.5%)  | 11/80 (13.8%) | 5/40 (12.5%) | 6/40 (15.0%)  |
+
+Routing accuracy is 80/80; shuffled-label accuracy is 47/80, within its
+predefined chance interval. All 12 duplicate outputs match byte-for-byte.
+Newline presence is retained per output in the scoring artifacts.
+Under the fixed rule, routing is **USEFUL**: it meets the overall best-single
+minus-five-points bound and strictly exceeds base on each family.
+
+Memory train NLL: 1.7006 → 0.0077; held-out NLL: 1.2385 → 0.0025.
+Task train NLL: 1.4251 → 0.0036; held-out NLL: 1.7972 → 0.0057.
+Both clear the fixed 50% held-out NLL-reduction threshold.
+
+Timings were recorded on an Apple-silicon desktop. The shared bench window makes
+these timings informational, never a benchmark verdict. Recorded phases used a
+direct Python interpreter entry; the packaged shell wrapper now invokes the same
+standard-library driver through `uv run --no-project python3`. The trainer's `done`
+duration covers the step loop and its scoring, not the full phase; each conditions
+receipt records the full phase elapsed time. Cache and scoring passes are shown
+separately. Each timing below belongs to its named phase's start/end conditions.
+
+train-M, with its conditions below:
+
+```text
+1182 completion positions across 48 samples in 83.3s (10 threads)
+held-out: 255 completion positions across 8 valid samples in 17.5s (10 threads)
+baseline scoring: train pass 105.6s, held-out pass 22.3s
+step loop: 96 steps in 318.0s (3.31s/step), in-loop scoring 127.6s over 1 point(s), epilogue re-scoring 0.0s
+=== done: train 1.7006→0.0077 (-1.6929)  |  held-out 1.2385→0.0025 (-1.2360)  in 445.6s ===
+```
+
+train-G, with its conditions below:
+
+```text
+1688 completion positions across 48 samples in 110.9s (10 threads)
+held-out: 232 completion positions across 8 valid samples in 16.9s (10 threads)
+baseline scoring: train pass 146.9s, held-out pass 20.3s
+step loop: 96 steps in 437.0s (4.55s/step), in-loop scoring 164.0s over 1 point(s), epilogue re-scoring 0.0s
+=== done: train 1.4251→0.0036 (-1.4215)  |  held-out 1.7972→0.0057 (-1.7914)  in 601.1s ===
+```
+
+Route cost, with the route conditions below:
+
+```text
+warm_embedding_seconds=0.00464475 single_gate_forward_seconds=0.000000458 cold_embedding_seconds=0.302235958
+```
+
+```json
+{
+  "phase": "train-M",
+  "start": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 1.68 1.78 1.85 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  },
+  "window": "shared; informational timing only",
+  "ok": true,
+  "elapsed_seconds": 680.5020301659999,
+  "end": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 1.91 2.57 2.85 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  }
+}
+```
+
+```json
+{
+  "phase": "train-G",
+  "start": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 1.55 2.34 2.75 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  },
+  "window": "shared; informational timing only",
+  "ok": true,
+  "elapsed_seconds": 906.7692175840001,
+  "end": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 1.62 1.99 2.64 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  }
+}
+```
+
+```json
+{
+  "phase": "gen-base",
+  "start": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 2.74 2.52 2.74 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  },
+  "window": "shared; informational timing only",
+  "ok": true,
+  "elapsed_seconds": 333.334467208,
+  "end": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 1.45 1.83 2.33 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  }
+}
+```
+
+```json
+{
+  "phase": "gen-M",
+  "start": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 1.21 1.73 2.28 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  },
+  "window": "shared; informational timing only",
+  "ok": true,
+  "elapsed_seconds": 306.585580333,
+  "end": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 1.74 1.70 2.08 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  }
+}
+```
+
+```json
+{
+  "phase": "gen-G",
+  "start": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 1.46 1.62 2.04 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  },
+  "window": "shared; informational timing only",
+  "ok": true,
+  "elapsed_seconds": 321.186848292,
+  "end": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 1.87 1.70 1.93 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  }
+}
+```
+
+```json
+{
+  "phase": "route",
+  "start": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 1.25 1.54 1.84 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  },
+  "window": "shared; informational timing only",
+  "ok": true,
+  "elapsed_seconds": 1.751243125,
+  "end": {
+    "kern.memorystatus_vm_pressure_level": "1",
+    "vm.loadavg": "{ 1.25 1.54 1.84 }",
+    "hw.model": "Mac16,10",
+    "hw.memsize": "17179869184",
+    "machdep.cpu.brand_string": "Apple M4"
+  }
+}
+```

--- a/crates/tune/examples/prompt_router.rs
+++ b/crates/tune/examples/prompt_router.rs
@@ -1,6 +1,7 @@
 //! Measure held-out adapter-domain separation and feedback on exported embeddings.
 //! Run with mixture,inference-hook,serde. Arguments: vector JSON and optional arm
-//! (`real`, `shuffled`, `balance`, `loop`, `cost`; default runs all).
+//! (`real`, `shuffled`, `balance`, `loop`, `cost`, `decisions`; default runs all except decisions).
+//! `decisions` fits real labels and prints each held-out prediction in input order.
 
 use lattice_fann::{Activation, BackpropTrainer, Network, NetworkBuilder, Trainer, TrainingConfig};
 use lattice_inference::mixture::AdapterRouter;
@@ -52,7 +53,7 @@ fn majority(labels: &[usize]) -> f64 {
     zero.max(labels.len() - zero) as f64 / labels.len() as f64
 }
 
-fn fit(data: &Data, shuffled: bool) -> Result<f64> {
+fn fit(data: &Data, shuffled: bool, decisions: bool) -> Result<f64> {
     let train: Vec<&Row> = data.rows.iter().filter(|r| r.split == "train").collect();
     let test: Vec<&Row> = data.rows.iter().filter(|r| r.split == "test").collect();
     let mut train_labels: Vec<usize> = train.iter().map(|r| r.label).collect();
@@ -81,9 +82,13 @@ fn fit(data: &Data, shuffled: bool) -> Result<f64> {
     };
     let trained = BackpropTrainer::new().train(&mut network, &inputs, &targets, &config)?;
     let mut correct = 0;
-    for (row, label) in test.iter().zip(test_labels.iter()) {
+    for (idx, (row, label)) in test.iter().zip(test_labels.iter()).enumerate() {
         let scores = network.forward(&row.vector)?;
-        correct += usize::from(usize::from(scores[1] > scores[0]) == *label);
+        let predicted = usize::from(scores[1] > scores[0]);
+        correct += usize::from(predicted == *label);
+        if decisions {
+            println!("decision idx={idx} label={label} predicted={predicted}");
+        }
     }
     let accuracy = correct as f64 / test.len() as f64;
     println!(
@@ -150,7 +155,17 @@ fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
     let path = args.get(1).ok_or("expected vector JSON path")?;
     let arm = args.get(2).map(String::as_str).unwrap_or("all");
-    if !["all", "real", "shuffled", "balance", "loop", "cost"].contains(&arm) {
+    if ![
+        "all",
+        "real",
+        "shuffled",
+        "balance",
+        "loop",
+        "cost",
+        "decisions",
+    ]
+    .contains(&arm)
+    {
         return Err("unknown arm".into());
     }
     let data: Data = serde_json::from_slice(&std::fs::read(path)?)?;
@@ -201,12 +216,15 @@ fn main() -> Result<()> {
     }
     if arm == "all" || arm == "real" {
         assert!(
-            fit(&data, false)? > floor,
+            fit(&data, false, false)? > floor,
             "real labels do not beat majority floor"
         );
     }
+    if arm == "decisions" {
+        fit(&data, false, true)?;
+    }
     if arm == "all" || arm == "shuffled" {
-        let accuracy = fit(&data, true)?;
+        let accuracy = fit(&data, true, false)?;
         let tolerance = 3.0 * (0.25 / labels.len() as f64).sqrt();
         println!(
             "shuffled acceptance: |accuracy-0.5| <= {tolerance:.6} (balanced corpus required)"

--- a/scripts/bench-measurements.toml
+++ b/scripts/bench-measurements.toml
@@ -330,6 +330,17 @@ path = "scripts/fake_quant_pilot.py"
 role = "measurement"
 supervision = "both-locks+quiet"
 
+# Phase driver for the routing-quality experiment (crates/tune/examples/prompt_router.md,
+# "Response quality under routing"). It trains, generates, and routes, and writes a
+# per-phase receipt with start/end machine conditions and wall-clock elapsed time as
+# provenance; the doc declares every such time informational and never a benchmark
+# verdict. The elapsed field is what the discovery regex matched. Not a measurement
+# entry point: no benchmark is run and no timing is compared or gated.
+[[entry]]
+path = "scripts/microlora/w6_phase.sh"
+role = "consumer"
+supervision = "none"
+
 # Only `--run` is a measurement entry point and self-supervises. `--checkpoint`
 # is a bench-compare-internal gate that inherits bench-compare's held locks.
 [[entry]]

--- a/scripts/microlora/README.md
+++ b/scripts/microlora/README.md
@@ -161,16 +161,20 @@ the final prompt-plus-completion tokens with the target model before training.
 
 `w6_build_sets.py --source TRAIN --schema-dir SCHEMAS` verifies the pinned capture,
 then constructs seeded, within-verb memory and task splits in `w6-input/`.
-`w6_score.py --self-test --validator VALIDATOR` runs gold, wrong-parameter,
+`w6_score.py --self-test --validator VALIDATOR --out SCORES --generations OUTPUT_DIR` runs gold, wrong-parameter,
 wrong-family, and prose controls before scoring any generated output. Both run
 with `uv run --no-project python3`. Inputs, adapters, generations, and logs are
 local artifacts and must not be committed.
 
 Under the repository's machine-lock policy, run `w6_phase.sh` once per phase:
-`train-M`, `train-G`, `gen-base`, `gen-M`, `gen-G`, `route`. It requires
+`train-M`, `train-G`, `gen-base`, `gen-M`, `gen-G`, `route`. Supplementary `gen-S1`
+uses the base model with `<think>\n\n</think>\n\n` appended to each prompt. It requires
 `CARGO_TARGET_DIR` and the four release trainer/generator/router binaries, writes
 full output and start/end conditions into `w6-out/`, and checks duplicate-process
 outputs before accepting selection-based arms. Preserve `w6-out/` across any
 synchronization that deletes destination files. Run `w6_score.py` with
-`--generations OUTPUT_DIR` after all phases. See the prompt-router example's
+`--validator VALIDATOR --out SCORES --generations OUTPUT_DIR` after all phases.
+Add `--supplementary-s1` to score S1 under both first-line and first-non-blank-line
+rules separately from the routing decision. All three paths are explicit, including
+for `--self-test`. See the prompt-router example's
 measurement document for the fixed decision rule and interpretation.

--- a/scripts/microlora/README.md
+++ b/scripts/microlora/README.md
@@ -156,3 +156,21 @@ uv run --no-project scripts/microlora/test_synth_khive_dsl.py \
 
 The DSL generator also uses character budgets rather than tokenization. Check
 the final prompt-plus-completion tokens with the target model before training.
+
+### Response quality under routing
+
+`w6_build_sets.py --source TRAIN --schema-dir SCHEMAS` verifies the pinned capture,
+then constructs seeded, within-verb memory and task splits in `w6-input/`.
+`w6_score.py --self-test --validator VALIDATOR` runs gold, wrong-parameter,
+wrong-family, and prose controls before scoring any generated output. Both run
+with `uv run --no-project python3`. Inputs, adapters, generations, and logs are
+local artifacts and must not be committed.
+
+Under the repository's machine-lock policy, run `w6_phase.sh` once per phase:
+`train-M`, `train-G`, `gen-base`, `gen-M`, `gen-G`, `route`. It requires
+`CARGO_TARGET_DIR` and the four release trainer/generator/router binaries, writes
+full output and start/end conditions into `w6-out/`, and checks duplicate-process
+outputs before accepting selection-based arms. Preserve `w6-out/` across any
+synchronization that deletes destination files. Run `w6_score.py` with
+`--generations OUTPUT_DIR` after all phases. See the prompt-router example's
+measurement document for the fixed decision rule and interpretation.

--- a/scripts/microlora/w6_build_sets.py
+++ b/scripts/microlora/w6_build_sets.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Construct seeded, within-verb memory/task adapter splits from a pinned capture."""
+
+import argparse
+import collections
+import hashlib
+import json
+import random
+import re
+import shutil
+from pathlib import Path
+
+SEED = 20260912
+
+
+def calls(text):
+    """Extract qualified calls outside double-quoted literals."""
+    blank = re.sub(r'"(?:\\.|[^"\\])*"', '""', text)
+    return re.findall(r"\b([a-z_]+\.[a-z_]+)\s*\(", blank)
+
+
+def load(path):
+    return [
+        json.loads(line) for line in Path(path).read_text().splitlines() if line.strip()
+    ]
+
+
+def write(path, rows):
+    Path(path).write_text("".join(json.dumps(row) + "\n" for row in rows))
+
+
+def build(source, schema, out):
+    raw = source.read_bytes()
+    if not hashlib.sha256(raw).hexdigest().startswith("6ff089c0e380213e"):
+        raise ValueError("source hash differs")
+    rows = load(source)
+    if len(rows) != 2806 or any("\n" in r["completion"] for r in rows):
+        raise ValueError("expected 2806 single-line completions")
+    files = sorted(schema.glob("*.json"))
+    if len(files) != 100:
+        raise ValueError("expected 100 schema JSON files")
+    manifest = {
+        "files": [
+            {"name": p.name, "sha256": hashlib.sha256(p.read_bytes()).hexdigest()}
+            for p in files
+        ]
+    }
+    digest = hashlib.sha256()
+    for item in manifest["files"]:
+        digest.update(f"{item['name']}:{item['sha256']}\n".encode())
+    if digest.hexdigest()[:16] != "625b8392f752d63d":
+        raise ValueError("schema fingerprint differs")
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "schemas").mkdir(exist_ok=True)
+    for path in files:
+        shutil.copyfile(path, out / "schemas" / path.name)
+    shutil.copyfile(source, out / "train.jsonl")
+    (out / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    rng = random.Random(SEED)
+    seen, held, router, counts = set(), [], [], {}
+    for label, (family, expected) in enumerate((("memory", 257), ("gtd", 204))):
+        family_rows = [
+            r
+            for r in rows
+            if {v.split(".")[0] for v in calls(r["completion"])} == {family}
+        ]
+        if len(family_rows) != expected:
+            raise ValueError(f"{family}: expected {expected}, found {len(family_rows)}")
+        unique = []
+        for row in family_rows:
+            key = row["prompt"].lower()
+            if key not in seen:
+                unique.append(row)
+                seen.add(key)
+        groups = collections.defaultdict(list)
+        for row in unique:
+            verbs = set(calls(row["completion"]))
+            if len(verbs) != 1:
+                raise ValueError("stratification requires one distinct verb per row")
+            groups[next(iter(verbs))].append(row)
+        expected_verbs = (
+            {"memory.recall", "memory.feedback", "memory.prune"}
+            if label == 0
+            else {"gtd.tasks", "gtd.transition", "gtd.next"}
+        )
+        if set(groups) != expected_verbs:
+            raise ValueError("family verb set differs")
+        allocation = {v: max(1, 40 * len(g) // len(unique)) for v, g in groups.items()}
+        while sum(allocation.values()) < 40:
+            v = max(
+                sorted(groups),
+                key=lambda v: 40 * len(groups[v]) / len(unique) - allocation[v],
+            )
+            allocation[v] += 1
+        while sum(allocation.values()) > 40:
+            v = max(
+                (v for v in sorted(groups) if allocation[v] > 1),
+                key=lambda v: allocation[v] - 40 * len(groups[v]) / len(unique),
+            )
+            allocation[v] -= 1
+        train, test = [], []
+        for verb in sorted(groups):
+            group = groups[verb]
+            rng.shuffle(group)
+            test.extend(group[: allocation[verb]])
+            train.extend(group[allocation[verb] :])
+        rng.shuffle(train)
+        rng.shuffle(test)
+        if len(test) != 40 or len(train) < 48:
+            raise ValueError("insufficient rows")
+        directory = out / f"adapter-{family}"
+        directory.mkdir(exist_ok=True)
+        write(directory / "train.jsonl", train[:48])
+        write(directory / "valid.jsonl", test[:8])
+        write(directory / "heldout.jsonl", test)
+        write(out / f"adapter-train-{family}.jsonl", train)
+        write(out / f"heldout-{family}.jsonl", test)
+        offset = len(held)
+        held.extend(
+            dict(row, idx=offset + i, family=family) for i, row in enumerate(test)
+        )
+        for split, selected in (("train", train[:48]), ("test", test)):
+            if len(selected) < 30:
+                raise ValueError("router requires 30 rows per domain and split")
+            router.extend(
+                {"prompt": r["prompt"], "label": label, "split": split}
+                for r in selected
+            )
+        counts[family] = {
+            "raw": expected,
+            "deduped": len(unique),
+            "dropped": expected - len(unique),
+            "heldout_by_verb": allocation,
+            "remaining": len(train),
+        }
+    if collections.Counter(r["family"] for r in held) != {"memory": 40, "gtd": 40}:
+        raise ValueError("held-out labels must balance 40/40")
+    write(out / "heldout.jsonl", held)
+    write(out / "router.jsonl", router)
+    (out / "construction.json").write_text(json.dumps(counts, indent=2) + "\n")
+    print(json.dumps(counts, indent=2))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", required=True, type=Path)
+    parser.add_argument("--schema-dir", required=True, type=Path)
+    parser.add_argument("--out", type=Path, default=Path("w6-input"))
+    args = parser.parse_args()
+    build(args.source, args.schema_dir, args.out)

--- a/scripts/microlora/w6_phase.sh
+++ b/scripts/microlora/w6_phase.sh
@@ -2,7 +2,7 @@
 # Run one phase under the caller's machine locks and admission checks.
 set -euo pipefail
 phase=${1:?expected phase}
-: "${CARGO_TARGET_DIR:?expected relay target directory}"
+: "${CARGO_TARGET_DIR:?set CARGO_TARGET_DIR before running a phase}"
 mkdir -p w6-out
 UV_CACHE_DIR=w6-out/uv-cache uv run --no-project python3 - "$phase" <<'PY'
 import json, os, pathlib, subprocess, sys, time

--- a/scripts/microlora/w6_phase.sh
+++ b/scripts/microlora/w6_phase.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Run one phase under the caller's machine locks and admission checks.
+set -euo pipefail
+phase=${1:?expected phase}
+: "${CARGO_TARGET_DIR:?expected relay target directory}"
+mkdir -p w6-out
+UV_CACHE_DIR=w6-out/uv-cache uv run --no-project python3 - "$phase" <<'PY'
+import json, os, pathlib, subprocess, sys, time
+phase = sys.argv[1]
+out = pathlib.Path('w6-out')
+bin_dir = pathlib.Path(os.environ['CARGO_TARGET_DIR']) / 'release'
+model = pathlib.Path.home() / '.lattice/models/qwen3.5-0.8b'
+def conditions():
+    names = ['kern.memorystatus_vm_pressure_level', 'vm.loadavg', 'hw.model', 'hw.memsize', 'machdep.cpu.brand_string']
+    return {name: subprocess.check_output(['sysctl', '-n', name], text=True).strip() for name in names}
+receipt = {'phase': phase, 'start': conditions(), 'window': 'shared; informational timing only'}
+start = time.monotonic()
+def run(cmd, path):
+    with open(path, 'wb') as log:
+        result = subprocess.run([str(x) for x in cmd], stdout=log, stderr=subprocess.STDOUT)
+    if result.returncode:
+        raise RuntimeError(f'{cmd[0]} exited {result.returncode}; see {path}')
+try:
+    if phase in ('train-M', 'train-G'):
+        family = 'memory' if phase == 'train-M' else 'gtd'
+        run([bin_dir / 'train_grad_full', '--model-dir', model, '--data-dir', f'w6-input/adapter-{family}', '--seq-len', '256', '--steps', '96', '--max-train', '48', '--max-valid', '8', '--first-layer', '19', '--rank', '8', '--alpha', '16', '--lr', '1e-3', '--log-every', '96', '--seed', '4277009102', '--save', out / f'adapter-{family}.safetensors'], out / f'{phase}.log')
+    elif phase in ('gen-base', 'gen-M', 'gen-G'):
+        arm = phase[4:]
+        rows = [json.loads(line) for line in pathlib.Path('w6-input/heldout.jsonl').read_text().splitlines()]
+        if len(rows) != 80:
+            raise ValueError('expected 80 prompts')
+        with open(out / f'gen-{arm}.jsonl', 'w') as dest, open(out / f'duplicates-{arm}.jsonl', 'w') as duplicates:
+            for row in rows:
+                cmd = [bin_dir / 'generate_lora', '--model-dir', model, '--prompt', row['prompt'], '--max-tokens', '64', '--temperature', '0', '--seed', '1']
+                if arm != 'base':
+                    family = 'memory' if arm == 'M' else 'gtd'
+                    cmd += ['--lora', out / f'adapter-{family}.safetensors']
+                for repeat in range(2 if row['idx'] in (0, 1, 40, 41) else 1):
+                    log = out / f'raw-{arm}-{row["idx"]}-{repeat}.log'
+                    run(cmd, log)
+                    text = log.read_bytes().decode('utf-8')
+                    if text.count('--- Output ---\n') != 1 or text.count('\n--- Stats ---') != 1:
+                        raise ValueError(f'missing/ambiguous output markers: {log}')
+                    output, stats = text.split('--- Output ---\n', 1)[1].split('\n--- Stats ---', 1)
+                    if (arm != 'base') != ('LoRA: ACTIVE' in stats.splitlines()):
+                        raise ValueError(f'adapter activation marker differs from arm: {log}')
+                    result = {k: row[k] for k in ('idx', 'family', 'prompt')}
+                    result.update(output=output, stats=stats)
+                    if repeat:
+                        if output != original:
+                            raise ValueError(f'K5: nondeterministic output {arm} idx={row["idx"]}')
+                        duplicates.write(json.dumps(result) + '\n')
+                        duplicates.flush()
+                    else:
+                        original = output
+                        dest.write(json.dumps(result) + '\n')
+                        dest.flush()
+    elif phase == 'route':
+        run([bin_dir / 'examples/prompt_router_vectors', 'w6-input/router.jsonl', out / 'vectors.json'], out / 'vectors.log')
+        for arm in ('real', 'shuffled', 'cost', 'decisions'):
+            run([bin_dir / 'examples/prompt_router', out / 'vectors.json', arm], out / f'route-{arm}.log')
+    else:
+        raise ValueError(f'unknown phase {phase}')
+    receipt['ok'] = True
+except BaseException as error:
+    receipt['ok'] = False
+    receipt['error'] = str(error)
+    raise
+finally:
+    receipt['elapsed_seconds'] = time.monotonic() - start
+    receipt['end'] = conditions()
+    (out / f'conditions-{phase}.json').write_text(json.dumps(receipt, indent=2) + '\n')
+PY

--- a/scripts/microlora/w6_phase.sh
+++ b/scripts/microlora/w6_phase.sh
@@ -24,15 +24,16 @@ try:
     if phase in ('train-M', 'train-G'):
         family = 'memory' if phase == 'train-M' else 'gtd'
         run([bin_dir / 'train_grad_full', '--model-dir', model, '--data-dir', f'w6-input/adapter-{family}', '--seq-len', '256', '--steps', '96', '--max-train', '48', '--max-valid', '8', '--first-layer', '19', '--rank', '8', '--alpha', '16', '--lr', '1e-3', '--log-every', '96', '--seed', '4277009102', '--save', out / f'adapter-{family}.safetensors'], out / f'{phase}.log')
-    elif phase in ('gen-base', 'gen-M', 'gen-G'):
+    elif phase in ('gen-base', 'gen-M', 'gen-G', 'gen-S1'):
         arm = phase[4:]
         rows = [json.loads(line) for line in pathlib.Path('w6-input/heldout.jsonl').read_text().splitlines()]
         if len(rows) != 80:
             raise ValueError('expected 80 prompts')
         with open(out / f'gen-{arm}.jsonl', 'w') as dest, open(out / f'duplicates-{arm}.jsonl', 'w') as duplicates:
             for row in rows:
-                cmd = [bin_dir / 'generate_lora', '--model-dir', model, '--prompt', row['prompt'], '--max-tokens', '64', '--temperature', '0', '--seed', '1']
-                if arm != 'base':
+                prompt = row['prompt'] + ('<think>\n\n</think>\n\n' if arm == 'S1' else '')
+                cmd = [bin_dir / 'generate_lora', '--model-dir', model, '--prompt', prompt, '--max-tokens', '64', '--temperature', '0', '--seed', '1']
+                if arm in ('M', 'G'):
                     family = 'memory' if arm == 'M' else 'gtd'
                     cmd += ['--lora', out / f'adapter-{family}.safetensors']
                 for repeat in range(2 if row['idx'] in (0, 1, 40, 41) else 1):
@@ -42,13 +43,15 @@ try:
                     if text.count('--- Output ---\n') != 1 or text.count('\n--- Stats ---') != 1:
                         raise ValueError(f'missing/ambiguous output markers: {log}')
                     output, stats = text.split('--- Output ---\n', 1)[1].split('\n--- Stats ---', 1)
-                    if (arm != 'base') != ('LoRA: ACTIVE' in stats.splitlines()):
+                    if (arm in ('M', 'G')) != ('LoRA: ACTIVE' in stats.splitlines()):
                         raise ValueError(f'adapter activation marker differs from arm: {log}')
                     result = {k: row[k] for k in ('idx', 'family', 'prompt')}
                     result.update(output=output, stats=stats)
+                    if arm == 'S1':
+                        result['generation_prompt'] = prompt
                     if repeat:
                         if output != original:
-                            raise ValueError(f'K5: nondeterministic output {arm} idx={row["idx"]}')
+                            raise ValueError(f'nondeterministic output across two processes: {arm} idx={row["idx"]}')
                         duplicates.write(json.dumps(result) + '\n')
                         duplicates.flush()
                     else:

--- a/scripts/microlora/w6_score.py
+++ b/scripts/microlora/w6_score.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Validate controls before scoring deterministic adapter-output selections."""
+
+import argparse
+import collections
+import json
+import random
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from score_dsl_args import EXIT_FAIL, EXIT_PASS, EXIT_REFUSED, Schemas, score_row
+from w6_build_sets import calls, load, write
+
+
+def validate(rows, args, name):
+    pairs = args.out / f"{name}-pairs.jsonl"
+    validated = args.out / f"{name}-validated.jsonl"
+    write(pairs, rows)
+    result = subprocess.run(
+        [str(args.validator.resolve())],
+        input="".join(json.dumps({"completion": r["completion"]}) + "\n" for r in rows),
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    validated.write_text(result.stdout)
+    (args.out / f"{name}-validator-stderr.log").write_text(result.stderr)
+    parsed = load(validated)
+    if len(parsed) != len(rows) or [r["line"] for r in parsed] != list(
+        range(1, len(rows) + 1)
+    ):
+        raise ValueError("validator row identity mismatch")
+    if any(r.get("parser_source_sha256") != args.parser_sha for r in parsed):
+        raise ValueError("parser source changed")
+    cmd = [
+        sys.executable,
+        str(Path(__file__).with_name("score_dsl_args.py")),
+        "--validated",
+        str(validated),
+        "--pairs",
+        str(pairs),
+        "--schema-dir",
+        str(args.schema_dir),
+        "--manifest",
+        str(args.manifest),
+    ]
+    scored = subprocess.run(cmd, text=True, capture_output=True, check=False)
+    (args.out / f"{name}-scorer.log").write_text(
+        json.dumps(cmd)
+        + "\n"
+        + scored.stdout
+        + scored.stderr
+        + f"\nexit_code={scored.returncode}\n"
+    )
+    scores = []
+    for row, parsed_row in zip(rows, parsed):
+        if parsed_row["ok"] and not isinstance(
+            parsed_row.get("canonical_request"), str
+        ):
+            raise ValueError("accepted row missing canonical request")
+        score = score_row(parsed_row, args.schemas, row["prompt"])
+        verbs = calls(row["completion"])
+        family_ok = bool(verbs) and all(v.split(".")[0] == row["family"] for v in verbs)
+        scores.append(
+            dict(
+                idx=row["idx"],
+                parser_ok=parsed_row["ok"],
+                canonical=parsed_row.get("canonical_request"),
+                family_ok=family_ok,
+                callable_on_family=bool(
+                    parsed_row["ok"] and score["verdict"] == "PASS" and family_ok
+                ),
+                **score,
+            )
+        )
+    counts = collections.Counter(row["verdict"] for row in scores)
+    expected_exit = (
+        EXIT_FAIL
+        if counts["FAIL"]
+        else EXIT_REFUSED
+        if counts["REFUSED"]
+        else EXIT_PASS
+    )
+    cli_counts = {
+        name: int(count)
+        for name, count in re.findall(
+            r"^\s*(PASS|FAIL|REFUSED)\s+(\d+)\s", scored.stdout, re.MULTILINE
+        )
+    }
+    if scored.returncode != expected_exit or cli_counts != {
+        name: counts[name] for name in ("PASS", "FAIL", "REFUSED")
+    }:
+        raise ValueError("scorer CLI result differs from per-row scoring")
+    write(args.out / f"{name}-scores.jsonl", scores)
+    return scores
+
+
+def controls(gold, args):
+    cmd = [
+        sys.executable,
+        str(Path(__file__).with_name("score_dsl_args.py")),
+        "--self-test",
+        "--schema-dir",
+        str(args.schema_dir),
+        "--manifest",
+        str(args.manifest),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    (args.out / "scorer-self-test.log").write_text(result.stdout + result.stderr)
+    c0 = (
+        result.returncode == 0
+        and re.search(r"capture=625b8392f752d63d\s+verbs=98", result.stdout) is not None
+        and "['FAIL', 'PASS', 'REFUSED']" in result.stdout
+    )
+    table = [
+        {
+            "control": "C0",
+            "ok": c0,
+            "expected": "three verdicts; capture=625b8392f752d63d verbs=98",
+            "actual": result.stdout.splitlines()[-1:],
+        }
+    ]
+    if not c0:
+        (args.out / "controls.json").write_text(json.dumps(table, indent=2) + "\n")
+        raise ValueError("K4: C0 failed")
+    canonical_gold = None
+    for name in ("C1", "C2", "C3", "C4"):
+        rows = [dict(r) for r in gold]
+        for row in rows:
+            if name == "C2":
+                blank = re.sub(
+                    r'"(?:\\.|[^"\\])*"', lambda m: " " * len(m[0]), row["completion"]
+                )
+                match = re.search(r"\(\s*([a-z_]+)\s*=", blank)
+                if not match:
+                    raise ValueError("K4: gold has no first parameter to mutate")
+                key = match[1]
+                new = {
+                    "query": "q",
+                    "limit": "max",
+                    "id": "ident",
+                    "status": "state",
+                }.get(key, key + "_x")
+                row["completion"] = (
+                    row["completion"][: match.start(1)]
+                    + new
+                    + row["completion"][match.end(1) :]
+                )
+            elif name == "C3":
+                row["family"] = "gtd" if row["family"] == "memory" else "memory"
+            elif name == "C4":
+                row["completion"] = "Here is the request: " + row["completion"]
+        scores = validate(rows, args, name)
+        if name == "C1":
+            canonical_gold = [r["canonical"] for r in scores]
+            count = sum(r["callable_on_family"] for r in scores)
+        elif name == "C2":
+            count = sum(r["verdict"] != "PASS" for r in scores)
+        elif name == "C3":
+            count = sum(not r["family_ok"] for r in scores)
+        else:
+            count = sum(not r["parser_ok"] for r in scores)
+        table.append(
+            {"control": name, "expected": 80, "actual": count, "ok": count == 80}
+        )
+    (args.out / "controls.json").write_text(json.dumps(table, indent=2) + "\n")
+    print(json.dumps(table, indent=2))
+    if not all(r["ok"] for r in table):
+        raise ValueError("K4: SCORER DEFECT")
+    return canonical_gold
+
+
+def score_generations(gold, canonical_gold, args):
+    outputs = {}
+    for arm in ("base", "M", "G"):
+        rows = load(args.generations / f"gen-{arm}.jsonl")
+        if len(rows) != 80:
+            raise ValueError(f"expected 80 generations: {arm}")
+        for row, target in zip(rows, gold):
+            if any(row[k] != target[k] for k in ("idx", "family", "prompt")):
+                raise ValueError("generation identity mismatch")
+        duplicates = load(args.generations / f"duplicates-{arm}.jsonl")
+        if [r["idx"] for r in duplicates] != [0, 1, 40, 41]:
+            raise ValueError("K5: missing duplicate processes")
+        for row in duplicates:
+            if any(
+                row[k] != rows[row["idx"]][k] for k in ("family", "prompt", "output")
+            ):
+                raise ValueError("K5: duplicate outputs differ")
+        outputs[arm] = rows
+    decisions = re.findall(
+        r"^decision idx=(\d+) label=(\d+) predicted=(\d+)$",
+        (args.generations / "route-decisions.log").read_text(),
+        re.MULTILINE,
+    )
+    if len(decisions) != 80:
+        raise ValueError("missing router decisions")
+    predicted = []
+    for i, (idx, label, pred) in enumerate(decisions):
+        if (
+            int(idx) != i
+            or int(label) != (gold[i]["family"] == "gtd")
+            or pred not in ("0", "1")
+        ):
+            raise ValueError("router identity mismatch")
+        predicted.append(int(pred))
+    rng = random.Random(20260912)
+    selections = {
+        "base": ["base"] * 80,
+        "single-M": ["M"] * 80,
+        "single-G": ["G"] * 80,
+        "routed": ["M" if p == 0 else "G" for p in predicted],
+        "oracle": ["M" if r["family"] == "memory" else "G" for r in gold],
+        "random": [rng.choice(("M", "G")) for _ in gold],
+    }
+    summary = {}
+    for arm, selection in selections.items():
+        rows = []
+        for i, source in enumerate(selection):
+            row = dict(outputs[source][i])
+            row.update(
+                completion=row["output"].split("\n", 1)[0].strip(),
+                newline_emitted="\n" in row["output"],
+                selected=source,
+            )
+            rows.append(row)
+        scores = validate(rows, args, arm)
+        result = {}
+        for family in ("overall", "memory", "gtd"):
+            indices = [
+                i
+                for i, row in enumerate(gold)
+                if family == "overall" or row["family"] == family
+            ]
+            result[family] = {
+                "n": len(indices),
+                "callable": sum(scores[i]["callable_on_family"] for i in indices),
+                "exact": sum(
+                    scores[i]["parser_ok"]
+                    and scores[i]["canonical"] == canonical_gold[i]
+                    for i in indices
+                ),
+                "newline": sum(rows[i]["newline_emitted"] for i in indices),
+            }
+        summary[arm] = result
+    summary["routing_correct"] = sum(
+        p == (r["family"] == "gtd") for p, r in zip(predicted, gold)
+    )
+    base = summary["base"]["overall"]["callable"]
+    single = max(
+        summary[arm]["overall"]["callable"] for arm in ("single-M", "single-G")
+    )
+    decision = {"routing_failure": summary["routing_correct"] < 72, "nll": {}}
+    for family, suffix in (("memory", "M"), ("gtd", "G")):
+        log = args.generations / f"train-{suffix}.log"
+        if log.exists():
+            points = re.findall(
+                r"step\s+(0|96)\s+train NLL: ([0-9.]+)\s+held-out NLL: ([0-9.]+)",
+                log.read_text(),
+            )
+            if len(points) != 2 or [p[0] for p in points] != ["0", "96"]:
+                raise ValueError("missing step-0/final NLL read-out")
+            before, after = float(points[0][2]), float(points[1][2])
+            if before <= 0:
+                raise ValueError("invalid initial NLL")
+            decision["nll"][family] = {
+                "initial_train": float(points[0][1]),
+                "final_train": float(points[1][1]),
+                "initial_valid": before,
+                "final_valid": after,
+                "drop_fraction": 1 - after / before,
+            }
+    if base >= 72:
+        decision["verdict"] = "KILLED(K1): CEILING"
+    elif single <= base:
+        decision["verdict"] = "KILLED(K2): ADAPTERS NOT USEFUL"
+    elif len(decision["nll"]) != 2:
+        raise ValueError("both trainer NLL read-outs required")
+    elif any(v["drop_fraction"] < 0.5 for v in decision["nll"].values()):
+        decision["verdict"] = "KILLED(K3): UNDER-TRAINED; decision rule not applied"
+    elif decision["routing_failure"]:
+        decision["verdict"] = "KILLED(K6): ROUTING failure; oracle retained"
+    else:
+        failures = []
+        if summary["routed"]["overall"]["callable"] < single - 4:
+            failures.append("routed below best single adapter minus five points")
+        for family in ("memory", "gtd"):
+            if (
+                summary["routed"][family]["callable"]
+                <= summary["base"][family]["callable"]
+            ):
+                failures.append(f"routed does not beat base on {family}")
+        decision["verdict"] = (
+            "NOT USEFUL: " + "; ".join(failures) if failures else "USEFUL"
+        )
+    (args.out / "decision.json").write_text(json.dumps(decision, indent=2) + "\n")
+    (args.out / "response-scores.json").write_text(json.dumps(summary, indent=2) + "\n")
+    lines = [
+        "| arm | callable overall | memory | gtd | exact overall | memory | gtd |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for arm in selections:
+        cells = []
+        for metric in ("callable", "exact"):
+            for family in ("overall", "memory", "gtd"):
+                cell = summary[arm][family]
+                cells.append(
+                    f"{cell[metric]}/{cell['n']} ({100 * cell[metric] / cell['n']:.1f}%)"
+                )
+        lines.append("| " + arm + " | " + " | ".join(cells) + " |")
+    (args.out / "response-table.md").write_text("\n".join(lines) + "\n")
+    print("\n".join(lines))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=Path("w6-input"))
+    parser.add_argument("--out", type=Path, default=Path(".khive/leg"))
+    parser.add_argument(
+        "--validator", type=Path, default=Path(".khive/leg/khive-dsl-validator")
+    )
+    parser.add_argument("--generations", type=Path, default=Path(".khive/leg/w6-out"))
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    args.out.mkdir(parents=True, exist_ok=True)
+    args.schema_dir, args.manifest = (
+        args.input / "schemas",
+        args.input / "manifest.json",
+    )
+    args.schemas = Schemas(args.schema_dir, args.manifest)
+    if args.schemas.drift:
+        raise ValueError("schema capture drift")
+    result = subprocess.run(
+        [str(args.validator.resolve()), "--self-test"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    (args.out / "validator-self-test.json").write_text(result.stdout)
+    receipt = json.loads(result.stdout)
+    if receipt.get("ok") is not True or not receipt.get("parser_source_sha256"):
+        raise ValueError("validator self-test failed")
+    args.parser_sha = receipt["parser_source_sha256"]
+    gold = load(args.input / "heldout.jsonl")
+    if (
+        len(gold) != 80
+        or [r["idx"] for r in gold] != list(range(80))
+        or collections.Counter(r["family"] for r in gold) != {"memory": 40, "gtd": 40}
+    ):
+        raise ValueError("expected 80 uniquely indexed, balanced gold rows")
+    canonical_gold = controls(gold, args)
+    if not args.self_test:
+        score_generations(gold, canonical_gold, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/microlora/w6_score.py
+++ b/scripts/microlora/w6_score.py
@@ -314,15 +314,60 @@ def score_generations(gold, canonical_gold, args):
     print("\n".join(lines))
 
 
+def score_supplementary(gold, args):
+    """Score the closed-thinking base control outside the routing decision."""
+    rows = load(args.generations / "gen-S1.jsonl")
+    if len(rows) != len(gold):
+        raise ValueError("expected 80 supplementary generations")
+    for row, target in zip(rows, gold):
+        if any(row[k] != target[k] for k in ("idx", "family", "prompt")):
+            raise ValueError("supplementary generation identity mismatch")
+        if row.get("generation_prompt") != target["prompt"] + "<think>\n\n</think>\n\n":
+            raise ValueError("supplementary prompt suffix differs")
+    duplicates = load(args.generations / "duplicates-S1.jsonl")
+    if [row["idx"] for row in duplicates] != [0, 1, 40, 41] or any(
+        any(
+            row[k] != rows[row["idx"]][k]
+            for k in ("prompt", "family", "output", "generation_prompt")
+        )
+        for row in duplicates
+    ):
+        raise ValueError("supplementary duplicate outputs differ")
+    summary = {
+        "n": len(rows),
+        "reopened_think": sum("<think>" in row["output"] for row in rows),
+    }
+    for rule in ("first-line", "first-non-blank-line"):
+        pairs = []
+        for row in rows:
+            lines = row["output"].split("\n")
+            completion = (
+                lines[0].strip()
+                if rule == "first-line"
+                else next((line.strip() for line in lines if line.strip()), "")
+            )
+            pairs.append(
+                dict(row, completion=completion, newline_emitted="\n" in row["output"])
+            )
+        scores = validate(pairs, args, "S1-" + rule)
+        summary[rule] = {
+            "parser_ok": sum(row["parser_ok"] for row in scores),
+            "callable": sum(row["callable_on_family"] for row in scores),
+        }
+    (args.out / "supplementary-S1.json").write_text(
+        json.dumps(summary, indent=2) + "\n"
+    )
+    print(json.dumps(summary, indent=2))
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input", type=Path, default=Path("w6-input"))
-    parser.add_argument("--out", type=Path, default=Path(".khive/leg"))
-    parser.add_argument(
-        "--validator", type=Path, default=Path(".khive/leg/khive-dsl-validator")
-    )
-    parser.add_argument("--generations", type=Path, default=Path(".khive/leg/w6-out"))
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--validator", type=Path, required=True)
+    parser.add_argument("--generations", type=Path, required=True)
     parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--supplementary-s1", action="store_true")
     args = parser.parse_args()
     args.out.mkdir(parents=True, exist_ok=True)
     args.schema_dir, args.manifest = (
@@ -351,7 +396,9 @@ def main():
     ):
         raise ValueError("expected 80 uniquely indexed, balanced gold rows")
     canonical_gold = controls(gold, args)
-    if not args.self_test:
+    if args.supplementary_s1 and not args.self_test:
+        score_supplementary(gold, args)
+    elif not args.self_test:
         score_generations(gold, canonical_gold, args)
 
 


### PR DESCRIPTION
Measures whether a prompt router in front of two micro-LoRA adapters improves the responses the model actually produces, with the no-routing baselines beside it. Adds the `decisions` arm to `crates/tune/examples/prompt_router.rs` (prints each held-out prediction so the routed arm can be reconstructed from artifacts), the `scripts/microlora/w6_*` build/phase/score scripts, and the recorded section `### Response quality under routing` in `crates/tune/examples/prompt_router.md`.

**Construction (fixed before any output was scored).** Two rank-8 adapters (layers 19..23, alpha 16, 48 training rows each, 96 steps, lr 1e-3, seq-len 256, seed 4277009102) on Qwen3.5-0.8B: one for the memory family of request verbs, one for the task family. 40 held-out prompts per family from the same training split (the corpus's validation/test splits hold out entire verbs and answer a different question). Generation is greedy, `--max-tokens 64 --temperature 0 --seed 1`, on each verbatim prompt. The router is the existing BGE-small gate. Routed, oracle, and seeded-random arms are selections over the deterministic single-adapter outputs; four prompts per arm are generated twice in separate processes and must match byte-for-byte before any selection arm is read (16/16 did).

**Scorer with planted-wrong controls.** A response counts as callable-on-family when its first line passes the real request parser and the captured argument scorer, and every verb belongs to the prompt's family. Before generation the scorer ran C1 gold completions (80/80 pass), C2 gold with the first parameter renamed (80/80 NOT PASS: all parse, all fail argument validation), C3 gold with the family swapped (80/80 rejected), and C4 prose-prefixed gold (80/80 parser reject); the schema capture fingerprint is asserted on every scoring call. The decision rule and stop conditions were written down first: routing is called useful only if it reaches the best single adapter minus five points overall and beats base on each family; the run is discarded if base already scores ≥ 90%, if the best single adapter does not beat base, if held-out NLL drops by less than half, if any control is off, if any duplicate generation differs, or if routing accuracy is under 90%.

**The number, with its baseline.**

| arm | callable overall | memory | task |
| --- | --- | --- | --- |
| base (no adapter) | 0/80 | 0/40 | 0/40 |
| single-M on everything | 39/80 | 39/40 | 0/40 |
| single-G on everything | 40/80 | 0/40 | 40/40 |
| **routed** | **79/80** | 39/40 | 40/40 |
| oracle (true family) | 79/80 | 39/40 | 40/40 |
| random (seed 20260912) | 42/80 | 26/40 | 16/40 |

Routing accuracy 80/80; shuffled-label control 47/80, inside its chance interval. Exact match against the held-out completions is 39/40 and 38/40 for the two adapters (the three misses: one wrong signal value, one `gtd.next` where `gtd.tasks` was expected, one order swap inside a two-call batch). Off-family, each adapter emits its own family's verbs, which is why the single-adapter arms read 0 there and why the gate is load-bearing. The base floor is the model not knowing the request language, not a formatting artifact: a supplementary arm that closes the thinking block in the prompt produces SQL, prose, and HTTP and still scores 0/80 under both first-line and first-non-blank-line rules.

**Run 1, kept as the pre-fix record.** The same construction on the previous JSONL loader scored routed 28/80, single-M 8/80, single-G 20/80. Investigating why led to #1545 (the loader merged the prompt/completion boundary token on 52/80 held-out rows and appended no EOS), fixed in #1546; run 2 above is on the fixed loader with everything else held fixed. The doc keeps run 1's numbers and the reason they moved.

**Timing disclosure.** All training, generation, and routing timings in the doc are informational: they were recorded on an Apple-silicon desktop under a shared bench window with other work allowed to overlap, and each phase carries its start/end pressure and load-average conditions. None is offered as a benchmark.

## bench-compare disposition

Not applicable: no `crates/inference`, `crates/embed`, or `crates/fann` source is touched (the diff is `crates/tune/examples/`, `scripts/microlora/`, and docs).

**Measurement inventory.** `scripts/microlora/w6_phase.sh` is classified in `scripts/bench-measurements.toml` (`role = "consumer"`, unsupervised): the inventory's discovery regex matches the `elapsed_seconds` field of its per-phase provenance receipts, and the entry records that no benchmark is run and no timing is compared or gated. The advisory source analysis finds no direct measurement pattern in it.

**Reproduce.** `scripts/microlora/w6_build_sets.py` (split), `scripts/microlora/w6_phase.sh {train-M,train-G,gen-base,gen-M,gen-G,gen-S1,route}`, `scripts/microlora/w6_score.py --self-test …` then `w6_score.py …` with explicit `--input/--out/--validator/--generations`; flags, seeds, and n are pinned in the doc section.
