### PR TITLE
fix(inference): reject head_dim != 128 in the Metal fused_attention shape guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,9 +540,11 @@ jobs:
       # grammar steps' convention; the exact-count grep guards against a silently
       # zero-matching filter the same way those steps do. The gating command writes
       # its log directly (no pipe) so its exit status gates on its own.
-      # The count is 5 since #854: the shared RMS-norm reduction tests
+      # The count is 6 since the fused_attention head_dim guard: its test
+      # validate_fused_kernel_shape_rejects_head_dim_other_than_128 and
+      # the two shared RMS-norm reduction tests
       # (flash_attention_rms_norm_uses_shared_reduction_helper,
-      # rms_norm_matches_pre_854_oracle_on_finite_input) live in this same
+      # rms_norm_matches_pre_854_oracle_on_finite_input) all live in this same
       # `forward::metal::` module and match the filter. Adding or removing a
       # test in that module requires updating this count in the same PR.
       - name: inference — metal-gpu fused_attention fail-closed gate (macOS only)
@@ -557,7 +559,7 @@ jobs:
             exit 1
           fi
           cat "$log"
-          grep -Eq '^test result: ok\. 5 passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' "$log"
+          grep -Eq '^test result: ok\. 6 passed; 0 failed; 0 ignored; 0 measured; [0-9]+ filtered out;' "$log"
       # #1263: `compact_metal_candidate_path_applies_min_p` lives in the
       # `#[cfg(all(target_os = "macos", feature = "metal-gpu"))] mod inner`
       # module of metal_qwen35.rs, so the macOS metal-gpu clippy/build legs

--- a/crates/inference/src/forward/metal.rs
+++ b/crates/inference/src/forward/metal.rs
@@ -82,11 +82,13 @@ mod inner {
         layer_limit: Option<usize>,
     }
 
+    const FUSED_ATTENTION_SIMD_WIDTH: usize = 32;
+
     /// Validate model shape for Metal fused kernels and return the GQA group count.
     ///
-    /// Enforces structural requirements only — head_dim must be divisible by 4
-    /// (for float4 operations) and nonzero, kv_heads nonzero, and q_heads
-    /// divisible by kv_heads. The exact values are injected into the MSL source
+    /// Enforces the exact head_dim required by the kernel's one-SIMD-lane-per-float4
+    /// mapping, as well as nonzero and float4 divisibility checks, nonzero kv_heads,
+    /// and q_heads divisible by kv_heads. Values are injected into the MSL source
     /// at compile time via `msl_source_for`.
     fn validate_fused_kernel_shape(config: &QwenConfig) -> Result<usize, String> {
         if config.head_dim == 0 {
@@ -95,6 +97,13 @@ mod inner {
         if !config.head_dim.is_multiple_of(4) {
             return Err(format!(
                 "Metal fused attention requires head_dim divisible by 4 (for float4 ops); got {}",
+                config.head_dim
+            ));
+        }
+        if config.head_dim / 4 != FUSED_ATTENTION_SIMD_WIDTH {
+            let required_head_dim = 4 * FUSED_ATTENTION_SIMD_WIDTH;
+            return Err(format!(
+                "Metal fused attention supports head_dim={required_head_dim} only (one SIMD lane per float4, {FUSED_ATTENTION_SIMD_WIDTH} lanes); got {}",
                 config.head_dim
             ));
         }
@@ -835,6 +844,30 @@ mod inner {
         use crate::measurement::gpu_test_lock;
         use crate::weights::{QwenLayerWeights, Tensor1D, Tensor2D};
 
+        #[test]
+        fn validate_fused_kernel_shape_rejects_head_dim_other_than_128() {
+            let mut config = QwenConfig {
+                vocab_size: 8,
+                hidden_size: 32,
+                num_hidden_layers: 1,
+                num_attention_heads: 4,
+                num_key_value_heads: 2,
+                head_dim: 128,
+                intermediate_size: 48,
+                max_position_embeddings: 32,
+                rms_norm_eps: 1e-6,
+                rope_theta: 1_000_000.0,
+            };
+            assert_eq!(validate_fused_kernel_shape(&config), Ok(2));
+
+            for head_dim in [64, 256] {
+                config.head_dim = head_dim;
+                let err = validate_fused_kernel_shape(&config).unwrap_err();
+                assert!(err.contains("head_dim=128"), "{err}");
+                assert!(err.contains(&head_dim.to_string()), "{err}");
+            }
+        }
+
         /// ADR-066 D3.1 / ADR-080 C1 (PR #794): a capability-gated
         /// Metal test must report a distinct skip or fail closed when
         /// `LATTICE_METAL_TEST_ENFORCE=1` is set, never silently early-return `ok` —
@@ -1163,7 +1196,7 @@ kernel void rms_norm_pre_854_oracle(
                 num_hidden_layers: 1,
                 num_attention_heads: 4,
                 num_key_value_heads: 2,
-                head_dim: 8,
+                head_dim: 128,
                 intermediate_size: 48,
                 max_position_embeddings: 32,
                 rms_norm_eps: 1e-6,

--- a/crates/inference/src/forward/shaders/flash_attention.metal
+++ b/crates/inference/src/forward/shaders/flash_attention.metal
@@ -106,6 +106,7 @@ kernel void fused_attention(
     constexpr uint FA_TILE_Q       = 4u;
     constexpr uint FA_TILE_K       = 16u;
     constexpr uint FA_SIMD_WIDTH   = 32u;
+    static_assert(FA_HEAD_DIM4 == FA_SIMD_WIDTH, "fused_attention maps one SIMD lane to one float4 of the head; head_dim must be 4 * FA_SIMD_WIDTH");
     constexpr uint FA_ROWS_PER_TG  = FA_TILE_Q * FA_GQA_GROUPS;
     constexpr uint FA_THREADS_PER_TG = FA_ROWS_PER_TG * FA_SIMD_WIDTH;
 


### PR DESCRIPTION
Fixes #1549.

## Summary

`fused_attention` in `crates/inference/src/forward/shaders/flash_attention.metal` maps one SIMD lane to one `float4` of the head (`q_frag = Q4[q_base4 + lane]`, `dot(q_frag, K_tile[tk][lane])` reduced with `simd_sum`, `V_tile[tk][lane]`, `O4[out_base4 + lane]`). With `FA_SIMD_WIDTH = 32`, that is exactly `head_dim == 128`. `validate_fused_kernel_shape` (`crates/inference/src/forward/metal.rs`) admitted any nonzero `head_dim` divisible by 4, so a model with `head_dim` 64 or 256 would have compiled and run the kernel with a silently wrong lane mapping (a 64-wide head reads past its own float4s into the next head; a 256-wide head is only half reduced).

No shipped checkpoint hits this today: every Qwen3-Embedding configuration this path serves uses `head_dim = 128`, and the Qwen3.5 decode path pins its own `METAL_FLASH_HEAD_DIM` with an error. The defect is latent; this PR closes it at the shape guard so the next model config with a different head width fails loudly at construction instead of producing wrong embeddings.

## Changes

- `crates/inference/src/forward/metal.rs`
  - `const FUSED_ATTENTION_SIMD_WIDTH: usize = 32;` next to the guard, and a new check after the divisible-by-4 check: `head_dim / 4 != FUSED_ATTENTION_SIMD_WIDTH` returns `Err("Metal fused attention supports head_dim=128 only (one SIMD lane per float4, 32 lanes); got N")`.
  - Doc comment on `validate_fused_kernel_shape` states the lane-mapping contract.
  - New test `validate_fused_kernel_shape_rejects_head_dim_other_than_128`: `head_dim` 128 with two GQA groups is `Ok(2)`; 64 and 256 are `Err` naming `head_dim=128` and the rejected value.
  - The corrupted-Q fixture behind `fused_attention_fails_closed_on_{nan,inf}_q_lane` moved from `head_dim: 8` to `head_dim: 128`. It ran the live kernel at a width the kernel never supported; its corruption mechanism and fail-closed assertions are unchanged.
- `crates/inference/src/forward/shaders/flash_attention.metal`
- `.github/workflows/ci.yml`
  - The `fused_attention fail-closed gate` step pins the exact number of tests matched by `--lib forward::metal::`; it now says 6 (was 5), and its comment names the new test. The other 13 exact-count steps in `ci.yml` and `e2e-parity.yml` filter on names or modules this test does not match (checked each filter against the new test's full path).
  - `static_assert(FA_HEAD_DIM4 == FA_SIMD_WIDTH, ...)` right after `FA_SIMD_WIDTH`, so the shader itself refuses to compile for any injected `FA_HEAD_DIM` other than `4 * FA_SIMD_WIDTH`. This is the second layer: it holds even if the Rust guard is bypassed.

## Verification

Run on an Apple-silicon box with `LATTICE_METAL_TEST_ENFORCE=1` (so the Metal tests cannot silently skip):

- `cargo clippy -p lattice-inference --features metal-gpu --all-targets -- -D warnings` clean.
- `cargo test -p lattice-inference --features metal-gpu --lib -- forward::metal::` → 6 passed, 0 failed: `validate_fused_kernel_shape_rejects_head_dim_other_than_128`, `msl_template_assembles_and_compiles`, `fused_attention_fails_closed_on_nan_q_lane`, `fused_attention_fails_closed_on_inf_q_lane`, `flash_attention_rms_norm_uses_shared_reduction_helper`, `rms_norm_matches_pre_854_oracle_on_finite_input`.
- Mutation sensitivity: with the new Rust check deleted (test kept, everything else identical), `validate_fused_kernel_shape_rejects_head_dim_other_than_128` fails at the `unwrap_err()` on the 64-wide config (`test result: FAILED. 0 passed; 1 failed`); with the check restored (`git apply -R` of the same patch, `git diff HEAD` empty) the test passes.
- `cargo fmt -p lattice-inference -- --check` clean.
- Sibling sweep for the same assumption elsewhere: `decode_reference.metal` loops over `head_dim` generically (no lane mapping); `qwen35.metal` pins `HEAD_DIM = 256` with a shader early-return and the Rust side already errors on `head_dim != METAL_FLASH_HEAD_DIM`; `rms_reduce.metal` and the GEMM kernels carry no head-dimension assumption. `fused_attention` was the only kernel with an unguarded lane-to-float4 mapping.

## bench-compare disposition

Structural waiver: no declared bench target reaches the changed code, and no build input changed.

- Population searched at this head: all 25 `[[bench]]` targets declared in `crates/inference/Cargo.toml` and all 5 in `crates/embed/Cargo.toml` (`git show "$REF:crates/inference/Cargo.toml" | grep -c '^\[\[bench\]\]'`, same for embed).
- The only production caller of `validate_fused_kernel_shape` is `MetalForwardPass::new`, whose only production callers are the two construction sites inside `QwenModel` (`crates/inference/src/model/qwen.rs`). `git grep -l QwenModel` over `crates/inference/benches/*.rs` and `crates/embed/benches/*.rs` returns 0 files (control: `pub struct QwenModel` matches 1 file under `crates/inference/src`). The five model-loading inference benches load `Qwen35Model`, which has its own head-dim pin and does not construct `MetalForwardPass`.
- The whole edited Rust module is `#[cfg(all(target_os = "macos", feature = "metal-gpu"))] mod inner`, and the shader string is only compiled inside it; the default-feature bench build compiles none of the diff.
- Build inputs identical between base and head: `git diff <base> <head> -- Cargo.toml Cargo.lock crates/inference/Cargo.toml crates/inference/benches` is empty; no feature, profile, build-script, or bench-target definition changed.
- `crates/inference/examples/bench_metal.rs` does construct `MetalForwardPass` directly, but it is an example binary, not a `[[bench]]` target, and `bench-compare` never runs it.

Residual risk: this is an unmeasured change, not a measured-safe one. The new check is one integer compare at construction time, off every per-token path, so the mechanism cannot move steady-state throughput; the shader edit is a `static_assert`, which emits nothing.
